### PR TITLE
ARIA standard products

### DIFF
--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+import os
+import gdal
+import h5py
+import argparse
+import numpy as np
+from mintpy.utils import ptime
+
+EXAMPLE = """ example:
+
+prep_aria.py -w mintpy_SanFran -s stack/stack/ -i stack/incidenceAngle/20150605_20150512.vrt -b stack/bPerpendicular/ 
+
+"""
+
+def create_parser():
+    """Command line parser."""
+    parser = argparse.ArgumentParser(description='Prepare ARIA processed products for MintPy.',
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     epilog=EXAMPLE)
+    parser.add_argument('-w', '--work-dir', dest='workDir', type=str, default="./",
+                        help='The working directory for MintPy.'
+                        )
+    parser.add_argument('-s', '--stack-dir', dest='stackDir', type=str, required=True,
+                        help='The directory which contains stack VRT files.'
+                        )
+    parser.add_argument('-u', '--unwrap-stack-name', dest='unwStack', type=str,
+                        default="unwrapStack.vrt",
+                        help='Name of the stack VRT file of unwrapped data.\n'+
+                              ' default: unwrapStack.vrt')
+    parser.add_argument('-c', '--coherence-stack-name', dest='cohStack', type=str,
+                        default="cohStack.vrt",
+                        help='Name of the stack VRT file of coherence data.\n'+
+                              'default: cohStack.vrt') 
+    parser.add_argument('-l', '--conn-comp-name', dest='connCompStack', type=str,
+                        default="connCompStack.vrt",
+                        help='Name of the stack VRT file of connected component data.\n' +
+                              'default: connCompStack.vrt')
+    parser.add_argument('-b', '--bperp-dir', dest='bperpDir', type=str,
+                        required=True,
+                        help='Name of the directory where perpendicular baselines are stored.\n'+
+                              'default: bPerpendicular')
+    parser.add_argument('-i', '--incidence-angle', dest='incidenceAngle', type=str,
+                        required=True,
+                        help='Name of the incidence angle file')
+    return parser
+
+def cmd_line_parse(iargs = None):
+    parser = create_parser()
+    inps = parser.parse_args(args=iargs)
+
+    return inps
+
+def extract_metadata(stack):
+
+    ds = gdal.Open(stack, gdal.GA_ReadOnly)
+    
+    length = ds.RasterYSize
+    wodth = ds.RasterXSize
+    
+
+    meta = {}
+    meta["PROCESSOR"] = "isce" 
+    meta["EARTH_RADIUS"] = 6337286.638938101
+    meta["FILE_LENGTH"] = ds.RasterYSize
+    meta["HEIGHT"] = 850000
+    meta["LENGTH"] = ds.RasterYSize
+    meta["ORBIT_DIRECTION"] = "DESCENDING"
+    meta["PLATFORM"] = "Sen"
+    meta["STARTING_RANGE"] = 800026.44
+    meta["WAVELENGTH"] = float(ds.GetRasterBand(1).GetMetadata("unwrappedPhase")['Wavelength (m)']) 
+    meta["WIDTH"] = ds.RasterXSize
+    meta["NUMBER_OF_PAIRS"] = ds.RasterCount
+
+    # the stack vrt doesn't have the GeoTransform setup. 
+    # A temporary hack to acess the GeoTransform info
+    fileList = ds.GetFileList()
+    ds_temp = gdal.Open(fileList[1], gdal.GA_ReadOnly)
+    geoTrans = ds_temp.GetGeoTransform()
+
+    meta["X_FIRST"] =   geoTrans[0]
+    meta["Y_FIRST"] =   geoTrans[3]
+    meta["X_STEP"]  =   geoTrans[1]
+    meta["Y_STEP"]  =   geoTrans[5]
+    meta["X_UNIT"]  =   "degrees"
+    meta["Y_UNIT"]  =   "degrees"
+
+    ds_temp = None
+    ds = None
+
+    return meta
+
+def layout_hdf5(filename, dsNameDict, metadata):
+
+    h5 = h5py.File(filename, "w")
+
+    for key in dsNameDict.keys():
+        print("creating dataset for {0}".format(key))
+        ds = h5.create_dataset(key, shape=dsNameDict[key][1], dtype=dsNameDict[key][0])
+
+    for key in metadata.keys():
+        h5.attrs[key] = metadata[key]
+
+    h5.close()
+
+
+def add_unwrapped_phase(h5File, unwStack, cohStack, connCompStack, bPerpDir):
+    
+    dsUnw = gdal.Open(unwStack, gdal.GA_ReadOnly)
+    dsCoh = gdal.Open(cohStack, gdal.GA_ReadOnly)
+    dsComp = gdal.Open(connCompStack, gdal.GA_ReadOnly)
+
+    nPairs = dsUnw.RasterCount
+
+    h5 = h5py.File(h5File, "a")
+    
+    prog_bar = ptime.progressBar(maxValue=nPairs)
+    for ii in range(nPairs):
+        bnd = dsUnw.GetRasterBand(ii+1)
+        h5["unwrapPhase"][ii,:,:] = bnd.ReadAsArray()
+
+        d12 = bnd.GetMetadata("unwrappedPhase")["Dates"]       
+        h5["date"][ii,0] = d12.split("_")[1].encode("utf-8")
+        h5["date"][ii,1] = d12.split("_")[0].encode("utf-8")
+
+        bnd = dsCoh.GetRasterBand(ii+1)
+        h5["coherence"][ii,:,:] = bnd.ReadAsArray()
+        
+        bnd = dsComp.GetRasterBand(ii+1)
+        h5["connectComponent"][ii,:,:] = bnd.ReadAsArray()
+   
+        baselineName = os.path.join(bPerpDir, d12 + ".vrt")
+        bperp = extractBaseline(baselineName)
+        h5["bperp"][ii] = -1.0*bperp
+
+        h5["dropIfgram"][ii] = True
+        prog_bar.update(ii+1, suffix='{}_{}'.format(d12.split("_")[1], d12.split("_")[0]))
+
+    prog_bar.close()
+    h5.close()        
+    dsUnw = None
+    dsCoh = None
+    dsComp = None
+
+    return
+    
+def add_geometry(h5File, incAngleFile):
+    
+    h5 = h5py.File(h5File, 'a')
+
+    startRange = h5.attrs['STARTING_RANGE']
+
+    ds = gdal.Open(incAngleFile, gdal.GA_ReadOnly)
+    data = ds.ReadAsArray()
+    h5['incidenceAngle'][:,:] = data
+    data[data!=0] = startRange
+    h5['slantRangeDistance'][:,:] = data
+
+
+def extractBaseline(baselineName):
+    ds = gdal.Open(baselineName)
+    # return [min, max, mean, std]
+    stat  = ds.GetRasterBand(1).GetStatistics(True, True)
+    bperp = stat[2]
+    ds = None
+    
+    return bperp
+
+def main(iargs=None):
+    inps = cmd_line_parse(iargs)
+
+    inps.stackDir = os.path.abspath(inps.stackDir)  
+    cohStack = os.path.join(inps.stackDir, inps.cohStack)
+    unwStack = os.path.join(inps.stackDir, inps.unwStack)
+    connCompStack = os.path.join(inps.stackDir, inps.connCompStack) 
+    bPerpDir = inps.bperpDir
+    
+    metadata = extract_metadata(unwStack)
+
+    length = metadata["LENGTH"]
+    width = metadata["WIDTH"]
+    numPairs = metadata["NUMBER_OF_PAIRS"]
+
+    dsNameDict = {"bperp": (np.float32, (numPairs,)),
+                  "coherence": (np.float32, (numPairs, length, width)),
+                  "connectComponent": (np.byte, (numPairs, length, width)),
+                  "date": (np.dtype('S8'), (numPairs, 2)),
+                  "dropIfgram": (np.bool, (numPairs,)),
+                  "unwrapPhase": (np.float32, (numPairs, length, width))}
+
+    workDir = os.path.abspath(inps.workDir)
+    if not os.path.exists(workDir):
+        os.makedirs(workDir)
+
+    inputDir = os.path.join(workDir , "inputs")
+    if not os.path.exists(inputDir):
+        os.makedirs(inputDir)
+
+    h5Filename = os.path.join(inputDir, "ifgramStack.h5")
+
+    layout_hdf5(h5Filename, dsNameDict, metadata)
+
+    add_unwrapped_phase(h5Filename, unwStack, cohStack, connCompStack, bPerpDir)
+
+    # setting up geometry:
+    dsNameDict = {"azimuthAngle": (np.float32, (length, width)),
+                  "height": (np.float32, (length, width)),
+                  "incidenceAngle": (np.float32, (length, width)),
+                  "shadowMask": (np.bool, (length, width)),
+                  "slantRangeDistance": (np.float32, (length, width))}
+
+    h5Filename = os.path.join(inputDir, "geometryGeo.h5")
+    layout_hdf5(h5Filename, dsNameDict, metadata)
+    add_geometry(h5Filename, inps.incidenceAngle)
+
+if __name__=="__main__":
+    main()
+

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -60,23 +60,22 @@ def extract_metadata(stack):
 
     meta = {}
     meta["PROCESSOR"] = "isce" 
-    meta["EARTH_RADIUS"] = 6337286.638938101
     meta["FILE_LENGTH"] = ds.RasterYSize
-    meta["HEIGHT"] = 850000
     meta["LENGTH"] = ds.RasterYSize
     meta["ORBIT_DIRECTION"] = "DESCENDING"
     meta["PLATFORM"] = "Sen"
-    meta["STARTING_RANGE"] = 800026.44
+    meta["STARTING_RANGE"] = float(ds.GetRasterBand(1).GetMetadata("unwrappedPhase")['startRange'][1:-1])
     meta["WAVELENGTH"] = float(ds.GetRasterBand(1).GetMetadata("unwrappedPhase")['Wavelength (m)']) 
     meta["WIDTH"] = ds.RasterXSize
     meta["NUMBER_OF_PAIRS"] = ds.RasterCount
 
-    # the stack vrt doesn't have the GeoTransform setup. 
-    # A temporary hack to acess the GeoTransform info
-    fileList = ds.GetFileList()
-    ds_temp = gdal.Open(fileList[1], gdal.GA_ReadOnly)
-    geoTrans = ds_temp.GetGeoTransform()
+    # ARIA standard products currently don't number of range and 
+    # azimuth looks. They are however fixed to the following values
+    meta['ALOOKS'] = 7
+    meta['RLOOKS'] = 19
 
+    # geo transformation 
+    geoTrans = ds.GetGeoTransform()
     meta["X_FIRST"] =   geoTrans[0]
     meta["Y_FIRST"] =   geoTrans[3]
     meta["X_STEP"]  =   geoTrans[1]
@@ -84,7 +83,12 @@ def extract_metadata(stack):
     meta["X_UNIT"]  =   "degrees"
     meta["Y_UNIT"]  =   "degrees"
 
-    ds_temp = None
+    # following values probably won't be used anywhere for the geocoded data
+    # earth radius
+    meta["EARTH_RADIUS"] = 6337286.638938101
+    # nominal altitude of Sentinel1 orbit
+    meta["HEIGHT"] = 693000.0
+
     ds = None
 
     return meta

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -54,10 +54,6 @@ def extract_metadata(stack):
 
     ds = gdal.Open(stack, gdal.GA_ReadOnly)
     
-    length = ds.RasterYSize
-    wodth = ds.RasterXSize
-    
-
     meta = {}
     meta["PROCESSOR"] = "isce" 
     meta["FILE_LENGTH"] = ds.RasterYSize
@@ -99,12 +95,14 @@ def layout_hdf5(filename, dsNameDict, metadata):
 
     for key in dsNameDict.keys():
         print("creating dataset for {0}".format(key))
-        ds = h5.create_dataset(key, shape=dsNameDict[key][1], dtype=dsNameDict[key][0])
+        h5.create_dataset(key, shape=dsNameDict[key][1], dtype=dsNameDict[key][0])
 
     for key in metadata.keys():
         h5.attrs[key] = metadata[key]
 
     h5.close()
+
+    return 
 
 
 def add_unwrapped_phase(h5File, unwStack, cohStack, connCompStack, bPerpDir):

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -80,7 +80,6 @@ def check_loaded_dataset(work_dir='./', print_msg=True):
     # could be different than geometry file in case of roipac and gamma
     flist = [os.path.join(work_dir, 'inputs/geometry*.h5')]
     lookup_file = get_lookup_file(flist, abspath=True, print_msg=print_msg)
-    print("lookup_file: ", lookup_file)
     if 'X_FIRST' not in atr.keys():
         if lookup_file is not None:
             obj = geometry(lookup_file)
@@ -100,7 +99,6 @@ def check_loaded_dataset(work_dir='./', print_msg=True):
                     load_complete = False
                     raise Exception('required dataset "{}" is missing in file {}'.format(dname, lookup_file))
         else:
-            print("no lookup file")
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), './inputs/geometry*.h5')
     else:
         print("Input data seems to be geocoded. Lookup file not needed.")

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -80,25 +80,30 @@ def check_loaded_dataset(work_dir='./', print_msg=True):
     # could be different than geometry file in case of roipac and gamma
     flist = [os.path.join(work_dir, 'inputs/geometry*.h5')]
     lookup_file = get_lookup_file(flist, abspath=True, print_msg=print_msg)
-    if lookup_file is not None:
-        obj = geometry(lookup_file)
-        obj.open(print_msg=False)
+    print("lookup_file: ", lookup_file)
+    if 'X_FIRST' not in atr.keys():
+        if lookup_file is not None:
+            obj = geometry(lookup_file)
+            obj.open(print_msg=False)
 
-        if atr['PROCESSOR'] in ['isce', 'doris']:
-            dnames = [geometryDatasetNames[1],
-                      geometryDatasetNames[2]]
-        elif atr['PROCESSOR'] in ['gamma', 'roipac']:
-            dnames = [geometryDatasetNames[3],
+            if atr['PROCESSOR'] in ['isce', 'doris']:
+                dnames = [geometryDatasetNames[1],
+                         geometryDatasetNames[2]]
+            elif atr['PROCESSOR'] in ['gamma', 'roipac']:
+                dnames = [geometryDatasetNames[3],
                       geometryDatasetNames[4]]
-        else:
-            raise AttributeError('InSAR processor: {}'.format(atr['PROCESSOR']))
+            else:
+                raise AttributeError('InSAR processor: {}'.format(atr['PROCESSOR']))
 
-        for dname in dnames:
-            if dname not in obj.datasetNames:
-                load_complete = False
-                raise Exception('required dataset "{}" is missing in file {}'.format(dname, lookup_file))
+            for dname in dnames:
+                if dname not in obj.datasetNames:
+                    load_complete = False
+                    raise Exception('required dataset "{}" is missing in file {}'.format(dname, lookup_file))
+        else:
+            print("no lookup file")
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), './inputs/geometry*.h5')
     else:
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), './inputs/geometry*.h5')
+        print("Input data seems to be geocoded. Lookup file not needed.")
 
     # print message
     if print_msg:


### PR DESCRIPTION
This PR adds a stand-alone script "prep_aria.py" which creates interferogram and geometry HDF5 files from ARIA standard products. prep_aria.py is not integrated to load_data.py in mintpy. One needs to first run ARIA-tools (will be available soon) to create required files which perp_aria.py works with. 
A minor bug is also fixed in which checking lookup files is skipped for geocoded data. 