### PR TITLE
smallbaselineApp: add mintpy.topographicResidual.pixelwiseGeometry

### DIFF
--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -67,16 +67,25 @@ def add_file(fnames, out_file=None):
             out_file += '_plus_' + os.path.splitext(os.path.basename(fnames[i]))[0]
         out_file += ext
 
-    atr = readfile.read_attribute(fnames[0])
-    dsNames = readfile.get_dataset_list(fnames[0])
     dsDict = {}
+    dsNames = readfile.get_dataset_list(fnames[0])
     for dsName in dsNames:
+        # ignore dsName if input file has single dataset
+        if len(dsNames) == 1:
+            dsName2read = None
+        else:
+            dsName2read = dsName
+
         print('adding {} ...'.format(dsName))
-        data = readfile.read(fnames[0], datasetName=dsName)[0]
+        data = readfile.read(fnames[0], datasetName=dsName2read)[0]
         for i in range(1, len(fnames)):
-            d = readfile.read(fnames[i], datasetName=dsName)[0]
+            d = readfile.read(fnames[i], datasetName=dsName2read)[0]
             data = add_matrix(data, d)
         dsDict[dsName] = data
+
+    # output
+    atr = readfile.read_attribute(fnames[0])
+    print('use metadata from the 1st file: {}'.format(fnames[0]))
     writefile.write(dsDict, out_file=out_file, metadata=atr, ref_file=fnames[0])
     return out_file
 

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -159,14 +159,20 @@ mintpy.deramp.maskFile = auto  #[filename / no], auto for maskTempCoh.h5, mask f
 
 ########## 8. Topographic Residual (DEM Error) Correction (optional and recommended)
 ## reference: Fattahi and Amelung, 2013, IEEE-TGRS
-## Specify stepFuncDate option if you know there are sudden displacement jump in your area,
-## i.e. volcanic eruption, or earthquake, and check timeseriesStepModel.h5 afterward for their estimation.
-mintpy.topographicResidual               = auto  #[yes / no], auto for yes
-mintpy.topographicResidual.polyOrder     = auto  #[1-inf], auto for 2, poly order of temporal deformation model
-mintpy.topographicResidual.phaseVelocity = auto  #[yes / no], auto for no - phase, use phase velocity for error estimation
-mintpy.topographicResidual.stepFuncDate  = auto  #[20080529,20100611 / no], auto for no, date of step jump
-mintpy.topographicResidual.excludeDate   = auto  #[20070321 / txtFile / no], auto for exclude_date.txt,
-                                                # dates exlcuded for error estimation
+## Notes on options:
+## stepFuncDate      - Specify stepFuncDate option if you know there are sudden displacement jump in your area,
+##    i.e. volcanic eruption, or earthquake, and check timeseriesStepModel.h5 afterward for their estimation.
+## excludeDate       - Dates excluded for error estimation only
+## pixelwiseGeometry - Use pixel-wise geometry info, such as incidence angle and slant range distance for error estimation
+##    yes - use pixel-wise geometry when they are available [slow; used by default]
+##    no  - use mean geometry [fast]
+mintpy.topographicResidual                    = auto  #[yes / no], auto for yes
+mintpy.topographicResidual.polyOrder          = auto  #[1-inf], auto for 2, poly order of temporal deformation model
+mintpy.topographicResidual.phaseVelocity      = auto  #[yes / no], auto for no - phase, use phase velocity for error estimation
+mintpy.topographicResidual.stepFuncDate       = auto  #[20080529,20100611 / no], auto for no, date of step jump
+mintpy.topographicResidual.excludeDate        = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
+mintpy.topographicResidual.pixelwiseGeometry  = auto  #[yes / no], auto for yes, use pixel-wise geometry info
+
 
 ########## 9. Residual Phase for Noise Evaluation
 ## 1) Residual Phase Root Mean Square

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -19,11 +19,12 @@ mintpy.network.aoiLALO           = no
 mintpy.network.tempBaseMax       = no
 mintpy.network.perpBaseMax       = no
 mintpy.network.connNumMax        = no
-mintpy.network.referenceFile     = no
-mintpy.network.excludeDate       = no
-mintpy.network.excludeIfgIndex   = no
 mintpy.network.startDate         = no
 mintpy.network.endDate           = no
+mintpy.network.excludeDate       = no
+mintpy.network.excludeIfgIndex   = no
+mintpy.network.referenceFile     = no
+
 
 ########## Reference in Space
 mintpy.reference.yx              = no
@@ -48,8 +49,10 @@ mintpy.networkInversion.minRedundancy    = 1.0
 mintpy.networkInversion.waterMaskFile    = waterMask.h5
 mintpy.networkInversion.minNormVelocity  = yes
 mintpy.networkInversion.residualNorm     = L2
+
 mintpy.networkInversion.minTempCoh       = 0.7
 mintpy.networkInversion.minNumPixel      = 100
+
 mintpy.networkInversion.parallel         = no
 mintpy.networkInversion.numWorker        = 40
 mintpy.networkInversion.walltime         = 00:40
@@ -69,12 +72,12 @@ mintpy.deramp.maskFile   = maskTempCoh.h5
 
 
 ########## Topographic (DEM) Residual Correction
-mintpy.topographicResidual               = yes
-mintpy.topographicResidual.polyOrder     = 2
-mintpy.topographicResidual.phaseVelocity = no
-mintpy.topographicResidual.stepFuncDate  = no
-mintpy.topographicResidual.excludeDate   = exclude_date.txt
-
+mintpy.topographicResidual                    = yes
+mintpy.topographicResidual.polyOrder          = 2
+mintpy.topographicResidual.phaseVelocity      = no
+mintpy.topographicResidual.stepFuncDate       = no
+mintpy.topographicResidual.excludeDate        = exclude_date.txt
+mintpy.topographicResidual.pixelwiseGeometry  = yes
 
 ########## Phase Residual for Noise Evaluation
 ## Phase Residual Root Mean Square

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -18,34 +18,46 @@ from mintpy.objects import timeseries, geometry
 
 # key configuration parameter name
 key_prefix = 'mintpy.topographicResidual.'
-configKeys = ['polyOrder',
-              'phaseVelocity',
-              'stepFuncDate',
-              'excludeDate']
+configKeys = [
+    'polyOrder',
+    'phaseVelocity',
+    'stepFuncDate',
+    'excludeDate',
+]
 
 
 ############################################################################
 TEMPLATE = """
 ## reference: Fattahi and Amelung, 2013, IEEE-TGRS
-## Specify stepFuncDate option if you know there are sudden displacement jump in your area,
-## i.e. volcanic eruption, or earthquake, and check timeseriesStepModel.h5 afterward for their estimation.
-mintpy.topographicResidual               = auto  #[yes / no], auto for yes
-mintpy.topographicResidual.polyOrder     = auto  #[1-inf], auto for 2, poly order of temporal deformation model
-mintpy.topographicResidual.phaseVelocity = auto  #[yes / no], auto for no - phase, use phase velocity for error estimation
-mintpy.topographicResidual.stepFuncDate  = auto  #[20080529,20100611 / no], auto for no, date of step jump
-mintpy.topographicResidual.excludeDate   = auto  #[20070321 / txtFile / no], auto for exclude_date.txt,
-                                                # date exlcuded for error estimation
+## Notes on options:
+## stepFuncDate      - Specify stepFuncDate option if you know there are sudden displacement jump in your area,
+##    i.e. volcanic eruption, or earthquake, and check timeseriesStepModel.h5 afterward for their estimation.
+## excludeDate       - Dates excluded for error estimation only
+## pixelwiseGeometry - Use pixel-wise geometry info, such as incidence angle and slant range distance for error estimation
+##    yes - use pixel-wise geometry when they are available [slow; used by default]
+##    no  - use mean geometry [fast]
+mintpy.topographicResidual                    = auto  #[yes / no], auto for yes
+mintpy.topographicResidual.polyOrder          = auto  #[1-inf], auto for 2, poly order of temporal deformation model
+mintpy.topographicResidual.phaseVelocity      = auto  #[yes / no], auto for no - phase, use phase velocity for error estimation
+mintpy.topographicResidual.stepFuncDate       = auto  #[20080529,20100611 / no], auto for no, date of step jump
+mintpy.topographicResidual.excludeDate        = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
+mintpy.topographicResidual.pixelwiseGeometry  = auto  #[yes / no], auto for yes, use pixel-wise geometry info
 """
 
 EXAMPLE = """example:
-  # correct DEM error with pixel-wise geometry parameters
-  dem_error.py  timeseries_ECMWF.h5 -g inputs/geometryRadar.h5 -t smallbaselineApp.cfg
+  # correct DEM error with pixel-wise geometry parameters [slow]
+  dem_error.py  timeseries_ECMWF_ramp.h5 -g inputs/geometryRadar.h5 -t smallbaselineApp.cfg
 
-  # correct DEM error with mean geometry parameters
-  dem_error.py  timeseries_ECMWF_ramp.h5
+  # correct DEM error with mean geometry parameters [fast]
+  dem_error.py  timeseries_ECMWF_ramp.h5 -t smallbaselineApp.cfg
 
   # get time-series of estimated deformation model
   diff.py timeseries_ECMWF_ramp_demErr.h5 timeseriesResidual.h5 -o timeseriesDefModel.h5
+
+  # get updated/corrected DEM
+  save_roipac.py inputs/geometryGeo.h5 -o dem.h5   #for dataset in geo coordinates
+  mask.py demErr.h5 -m maskTempCoh.h5 -o demErr_msk.h5
+  add.py demErr_msk.h5 dem.h5 -o demNew.h5
 """
 
 REFERENCE = """reference:

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -247,6 +247,11 @@ def read_data(inps):
         if not inps.outfile:
             inps.outfile = '{}{}'.format(os.path.splitext(inps.file)[0], atr['FILE_TYPE'])
 
+    # get rid of starting . if output as hdf5 file
+    if inps.outfile.endswith('.h5'):
+        if atr['FILE_TYPE'].startswith('.'):
+            atr['FILE_TYPE'] = atr['FILE_TYPE'][1:]
+
     atr['PROCESSOR'] = 'roipac'
     return data, atr, inps.outfile
 

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -69,7 +69,7 @@ EXAMPLE = """example:
 """
 
 REFERENCE = """reference:
-  Yunjun, Z., H. Fattahi, F. Amelung (2019), InSAR time series analysis: error
+  Yunjun, Z., H. Fattahi, F. Amelung (2019), Small baseline InSAR time series analysis: unwrapping error
   correction and noise reduction (under review).
 """
 
@@ -759,10 +759,9 @@ class TimeSeriesAnalysis:
         in_file = fnames['input']
         out_file = fnames['output']
         if in_file != out_file:
-            scp_args = '{f} -g {g} -t {t} -o {o} --update '.format(f=in_file,
-                                                                   g=geom_file,
-                                                                   t=self.templateFile,
-                                                                   o=out_file)
+            scp_args = '{f} -t {t} -o {o} --update'.format(f=in_file, t=self.templateFile, o=out_file)
+            if self.template['mintpy.topographicResidual.pixelwiseGeometry']:
+                scp_args += ' -g {}'.format(geom_file)
             print('dem_error.py', scp_args)
             mintpy.dem_error.main(scp_args.split())
         else:


### PR DESCRIPTION
1. add `mintpy.topographicResidual.pixelwiseGeometry` option to speed up the DEM error correction step [turned OFF by defalut]

2. add example in dem_error.py to generate updated/corrected DEM file

3. save_roipac: get rid of the starting "." in the dataset name if output file is HDF5 file.

4. add: ignore dataset name if input file is single dataset, to be able to support input files without different dataset names.