### PR TITLE
ifg_inv: convert NaN to zero

### DIFF
--- a/docs/ports.txt
+++ b/docs/ports.txt
@@ -72,7 +72,7 @@ py36-cython
 py36-mpi4py +gcc5 +openmpi
 py36-numpy +gcc5 +openblas
 py36-scipy +gcc5 +openblas
-py36-matplotlib +cairo +tkinter
+py36-matplotlib +cairo +tkinter +webagg
 py36-matplotlib-basemap
 py36-pandas
 py36-sympy

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -698,6 +698,7 @@ def read_unwrap_phase(stack_obj, box, ref_phase, unwDatasetName='unwrapPhase', d
                               box=box,
                               dropIfgram=dropIfgram,
                               print_msg=False).reshape(num_ifgram, -1)
+    pha_data[np.isnan(pha_data)] = 0.
 
     # read ref_phase
     if ref_phase is not None:
@@ -732,6 +733,7 @@ def mask_unwrap_phase(pha_data, stack_obj, box, mask_ds_name=None, mask_threshol
                                   box=box,
                                   dropIfgram=dropIfgram,
                                   print_msg=False).reshape(num_ifgram, -1)
+        msk_data[np.isnan(msk_data)] = 0
         if mask_ds_name == 'coherence':
             msk_data = msk_data >= mask_threshold
             if print_msg:
@@ -752,6 +754,7 @@ def read_coherence(stack_obj, box, dropIfgram=True, print_msg=True):
                               box=box,
                               dropIfgram=dropIfgram,
                               print_msg=False).reshape(num_ifgram, -1)
+    coh_data[np.isnan(coh_data)] = 0.
     return coh_data
 
 

--- a/mintpy/plot_coherence_matrix.py
+++ b/mintpy/plot_coherence_matrix.py
@@ -43,7 +43,8 @@ def create_parser():
     parser.add_argument('--img-file', dest='img_file', default='velocity.h5',
                         help='dataset to show in map to facilitate point selection')
     parser.add_argument('--view-cmd', dest='view_cmd', default='view.py {} --wrap --noverbose ',
-                        help='view.py command to plot the input map file')
+                        help='view.py command to plot the input map file\n'+
+                             'Default: view.py img_file --wrap --noverbose')
 
     parser.add_argument('--save', dest='save_fig',
                         action='store_true', help='save the figure')

--- a/mintpy/timeseries_rms.py
+++ b/mintpy/timeseries_rms.py
@@ -55,7 +55,7 @@ def create_parser():
                         help='M-score used for outlier detection based on standardised residuals\n'+
                              'Recommend range: [3, 4], default is 3.')
     parser.add_argument('--figsize', dest='fig_size', metavar=('WID', 'LEN'),
-                        type=float, nargs=2, default=[4., 3.],
+                        type=float, nargs=2, default=[5., 3.],
                         help='figure size in inches - width and length')
     parser.add_argument('--tick-year-num', dest='tick_year_num',
                         type=int, default=1, help='Year number per major tick')
@@ -142,7 +142,7 @@ def analyze_rms(date_list, rms_list, inps):
 
 def plot_rms_bar(ax, date_list, rms, cutoff=3., font_size=12, 
                  tick_year_num=1, legend_loc='best',
-                 disp_legend=True, disp_side_plot=True, disp_thres_text=True,
+                 disp_legend=True, disp_side_plot=True, disp_thres_text=False,
                  ylabel=r'Residual Phase $\hat \phi_{resid}$ RMS [mm]'):
     """ Bar plot Phase Residual RMS
     Parameters: ax : Axes object
@@ -176,7 +176,8 @@ def plot_rms_bar(ax, date_list, rms, cutoff=3., font_size=12,
 
     # Plot rms_threshold line
     (ax, xmin, xmax) = pp.auto_adjust_xaxis_date(ax, datevector, font_size, every_year=tick_year_num)
-    ax.plot(np.array([xmin, xmax]), np.array([rms_threshold, rms_threshold]), '--k', label='RMS threshold')
+    ax.plot(np.array([xmin, xmax]), np.array([rms_threshold, rms_threshold]), '--k',
+            label='Median Abs Dev * {}'.format(cutoff))
 
     # axis format
     ax = pp.auto_adjust_yaxis(ax, np.append(rms, rms_threshold), font_size, ymin=0.0)

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -257,6 +257,13 @@ def read_init_info(inps):
 
 
 def read_exclude_date(input_ex_date, dateListAll):
+    """
+    Parameters: input_ex_date : list of string in YYYYMMDD or filenames for excluded dates
+                dateListAll   : list of string in YYYYMMDD for all dates
+    Returns:    ex_date_list  : list of string in YYYYMMDD for excluded dates
+                ex_dates      : list of datetime.datetime objects for excluded dates
+                ex_flag       : 1D np.ndarray in size of (num_date), 1/True for kept, 0/False for excluded
+    """
     # default value
     ex_date_list = []
     ex_dates = []
@@ -359,8 +366,10 @@ def read_timeseries_data(inps):
 
 
 def plot_ts_errorbar(ax, dis_ts, inps, ppar):
+    # make a local copy
     dates = np.array(inps.dates)
     d_ts = dis_ts[:]
+
     if inps.ex_date_list:
         # Update displacement time-series
         d_ts = dis_ts[inps.ex_flag == 1]
@@ -385,8 +394,10 @@ def plot_ts_errorbar(ax, dis_ts, inps, ppar):
 
 
 def plot_ts_scatter(ax, dis_ts, inps, ppar):
+    # make a local copy
     dates = np.array(inps.dates)
     d_ts = dis_ts[:]
+
     if inps.ex_date_list:
         # Update displacement time-series
         d_ts = dis_ts[inps.ex_flag == 1]

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -206,7 +206,7 @@ def read_date_list(date_list_in, date_list_all=None):
 
     # exclude date not in date_list_ref
     if date_list_all:
-        date_list_out = list(set(date_list_out).intersection(date_list_all))
+        date_list_out = sorted(list(set(date_list_out).intersection(date_list_all)))
 
     return date_list_out
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -103,7 +103,7 @@ ENVI_BAND_INTERLEAVE = {
 
 ###########################################################################
 ## Slice-based data identification for data reading:
-## 
+##
 ## slice   : np.ndarray in 2D,  with/without '-' in their names
 ##           each slice is unique within a file
 ## dataset : np.ndarray in 2D or 3D, without '-' in their names
@@ -259,7 +259,7 @@ def read_hdf5_file(fname, datasetName=None, box=None):
             if not inputDateList or inputDateList == ['']:
                 slice_flag[:] = True
             else:
-                date_list = [i.split('-')[1] for i in 
+                date_list = [i.split('-')[1] for i in
                              [j for j in slice_list if j.startswith(dsFamily)]]
                 for d in inputDateList:
                     slice_flag[date_list.index(d)] = True
@@ -867,7 +867,7 @@ def read_roipac_rsc(fname, delimiter=' ', standardize=True):
 
 def read_gamma_par(fname, delimiter=':', skiprows=3, standardize=True):
     """Read GAMMA .par/.off file into a python dictionary structure.
-    Parameters: fname : str. 
+    Parameters: fname : str.
                     File path of .par, .off file.
                 delimiter : str, optional
                     String used to separate values.
@@ -1073,18 +1073,18 @@ def read_binary(fname, shape, box=None, data_type='float32', byte_order='l',
         data = np.fromfile(fname,
                            dtype=data_type,
                            count=box[3]*width*num_band).reshape(-1, width*num_band)
-        data = data[box[1]:box[3], 
+        data = data[box[1]:box[3],
                     width*(band-1)+box[0]:width*(band-1)+box[2]]
 
     elif band_interleave == 'BIP':
-        data = np.fromfile(fname, 
+        data = np.fromfile(fname,
                            dtype=data_type,
                            count=box[3]*width*num_band).reshape(-1, width*num_band)
         data = data[box[1]:box[3],
                     np.arange(box[0], box[2])*num_band+band-1]
 
     elif band_interleave == 'BSQ':
-        data = np.fromfile(fname, 
+        data = np.fromfile(fname,
                            dtype=data_type,
                            count=(box[3]+length*(band-1))*width).reshape(-1, width)
         data = data[length*(band-1)+box[1]:length*(band-1)+box[3],
@@ -1118,7 +1118,7 @@ def read_float32(fname, box=None, byte_order='l'):
     RMG format (named after JPL radar pionner Richard M. Goldstein): made
     up of real*4 numbers in two arrays side-by-side. The two arrays often
     show the magnitude of the radar image and the phase, although not always
-    (sometimes the phase is the correlation). The length and width of each 
+    (sometimes the phase is the correlation). The length and width of each
     array are given as lines in the metadata (.rsc) file. Thus the total
     width width of the binary file is (2*width) and length is (length), data
     are stored as:
@@ -1198,7 +1198,7 @@ def read_complex_float32(fname, box=None, byte_order='l', band='phase'):
                 band : str
                     output format, default = phase
                     phase, amplitude, real, imag, complex
-    Returns: data : 2D np.array in complex float32 
+    Returns: data : 2D np.array in complex float32
     Example:
         amp, phase, atr = read_complex_float32('geo_070603-070721_0048_00018.int')
         data, atr       = read_complex_float32('150707.slc', 1)
@@ -1240,7 +1240,7 @@ def read_real_float32(fname, box=None, byte_order='l'):
     """Read real float 32 data matrix, i.e. GAMMA .mli file
     Parameters: fname     : str, path, filename to be read
                 byte_order : str, optional, order of reading byte in the file
-    Returns: data : 2D np.array, data matrix 
+    Returns: data : 2D np.array, data matrix
              atr  : dict, attribute dictionary
     Usage: data, atr = read_real_float32('20070603.mli')
            data, atr = read_real_float32('diff_filt_130118-130129_4rlks.unw')
@@ -1333,7 +1333,7 @@ def read_real_int16(fname, box=None, byte_order='l'):
 
 def read_bool(fname, box=None):
     """Read binary file with flags, 1-byte values with flags set in bits
-    For ROI_PAC .flg, *_snap_connect.byt file.    
+    For ROI_PAC .flg, *_snap_connect.byt file.
     """
     # Read attribute
     if fname.endswith('_snap_connect.byt'):

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -512,8 +512,9 @@ def plot_slice(ax, data, metadata, inps=None):
         # Status bar
         if inps.dem_file:
             coord_dem = ut.coordinate(dem_metadata)
+            dem_len, dem_wid = dem.shape
         def format_coord(x, y):
-            msg = 'lon={:.4f}, lat={:.4f}'.format(x, y)
+            msg = 'E{:.4f}, N{:.4f}'.format(x, y)
             col = coord.lalo2yx(x, coord_type='lon') - inps.pix_box[0]
             row = coord.lalo2yx(y, coord_type='lat') - inps.pix_box[1]
             if 0 <= col < num_col and 0 <= row < num_row:
@@ -525,8 +526,9 @@ def plot_slice(ax, data, metadata, inps=None):
                 if inps.dem_file:
                     dem_col = coord_dem.lalo2yx(x, coord_type='lon') - dem_pix_box[0]
                     dem_row = coord_dem.lalo2yx(y, coord_type='lat') - dem_pix_box[1]
-                    h = dem[dem_row, dem_col]
-                    msg += ', h={:.0f}'.format(h)
+                    if 0 <= dem_col < dem_wid and 0 <= dem_row < dem_len:
+                        h = dem[dem_row, dem_col]
+                        msg += ', h={:.0f}'.format(h)
                 msg += ', x={:.0f}, y={:.0f}'.format(col+inps.pix_box[0],
                                                      row+inps.pix_box[1])
             return msg
@@ -574,10 +576,11 @@ def plot_slice(ax, data, metadata, inps=None):
         ax.set_ylim(extent[2:4])
 
         # Status bar
+        # extent is (-0.5, -0.5, width-0.5, length-0.5)
         def format_coord(x, y):
             msg = 'x={:.1f}, y={:.1f}'.format(x, y)
-            col = np.floor(x - inps.pix_box[0])
-            row = np.floor(y - inps.pix_box[1])
+            col = int(np.rint(x - inps.pix_box[0]))
+            row = int(np.rint(y - inps.pix_box[1]))
             if 0 <= col < num_col and 0 <= row < num_row:
                 v = data[row, col]
                 msg += ', v={:.3f}'.format(v)
@@ -1114,8 +1117,11 @@ def prepare4multi_subplots(inps, metadata):
             vprint('consider reference pixel in y/x: {}'.format(inps.file_ref_yx))
 
     if inps.dsetNum > 10:
-        inps.disp_ref_pixel = False
-        vprint('turn off reference pixel plot for more than 10 datasets to display')
+        inps.ref_marker_size /= 10.
+    elif inps.dsetNum > 100:
+        inps.ref_marker_size /= 20.
+        #inps.disp_ref_pixel = False
+        #vprint('turn off reference pixel plot for more than 10 datasets to display')
 
     # Check dropped interferograms
     inps.dropDatasetList = []

--- a/sh/load_data_aoi.sh
+++ b/sh/load_data_aoi.sh
@@ -53,7 +53,7 @@ subset_opt=" --lat $S $N --lon $W $E"
 
 echo "subset - DEM"
 src_file=$inputs_dir_src"/../../../DEM/gsi10m.dem.wgs84"   #adjust filename for specific dataset
-dst_file=$inputs_dir_dst"/../../gsi10m.dem.wgs84"          #adjust filename for specific dataset
+dst_file=$inputs_dir_dst"/gsi10m.dem.wgs84"                #adjust filename for specific dataset
 echo "subset.py $src_file -o $dst_file $subset_opt"
 subset.py $src_file -o $dst_file $subset_opt
 


### PR DESCRIPTION
ifgram_inversion: convert all NaN values in phase, coherence and mask data to zero, to avoid RuntimeWarning message during math operation. Since zero is ignored in the inversion, it won't has effect on the result.

view:
+ turn ON reference point display by default for multiple subplots
+ fix bug of coordinates in status bar for radar coord, as it starts from -0.5 in the UL corner. This is introduced from last commit.
+ bug fix while showing heigt in coordinates status bar

ptime: sorting in read_date_list(), otherwise, it causes unexpected behavior for --ex option in tsview.py