### PR TITLE
fix bug of data type while reading isce .conncomp

### DIFF
--- a/mintpy/objects/conncomp.py
+++ b/mintpy/objects/conncomp.py
@@ -27,7 +27,7 @@ class connectComponent:
         unw_file = 'filt_fine.unw'
         # prepare connectComponent object
         atr = readfile.read_attribute(unw_file)
-        conncomp = readfile.read_attribute(unw_file+'.conncomp')[0]
+        conncomp = readfile.read(unw_file+'.conncomp')[0]
         cc = connectComponent(conncomp=conncomp, metadata=atr)
         cc.label()
         cc.find_mst_bridge()

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -555,7 +555,7 @@ Attributes         Dictionary for metadata
 /dropIfgram        1D array of bool    in size of (m,     ) with 0/False for drop and 1/True for keep
 /unwrapPhase       3D array of float32 in size of (m, l, w) in radian.
 /coherence         3D array of float32 in size of (m, l, w).
-/connectComponent  3D array of bool    in size of (m, l, w).           (optional)
+/connectComponent  3D array of int8    in size of (m, l, w).           (optional)
 /wrapPhase         3D array of float32 in size of (m, l, w) in radian. (optional)
 /rangeOffset       3D array of float32 in size of (m, l, w).           (optional)
 /azimuthOffset     3D array of float32 in size of (m, l, w).           (optional)

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -97,7 +97,7 @@ class ifgramStackDict:
         /dropIfgram        1D array of bool    in size of (m,     ).
         /unwrapPhase       3D array of float32 in size of (m, l, w) in radian.
         /coherence         3D array of float32 in size of (m, l, w).
-        /connectComponent  3D array of bool    in size of (m, l, w).           (optional)
+        /connectComponent  3D array of int8    in size of (m, l, w).           (optional)
         /wrapPhase         3D array of float32 in size of (m, l, w) in radian. (optional)
         /iono              3D array of float32 in size of (m, l, w) in radian. (optional)
         /rangeOffset       3D array of float32 in size of (m, l, w).           (optional)
@@ -127,7 +127,7 @@ class ifgramStackDict:
             dsShape = (self.numIfgram, self.length, self.width)
             dsDataType = dataType
             if dsName in ['connectComponent']:
-                dsDataType = np.bool_
+                dsDataType = np.byte
             print(('create dataset /{d:<{w}} of {t:<25} in size of {s}'
                    ' with compression = {c}').format(d=dsName,
                                                      w=maxDigit,

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -295,7 +295,7 @@ def read_binary_file(fname, datasetName=None, box=None):
     if processor in ['isce']:
         # default short name for data type from ISCE
         dataTypeDict = {
-            'byte': 'bool_',
+            'byte': 'int8',
             'float': 'float32',
             'double': 'float64',
             'cfloat': 'complex64',


### PR DESCRIPTION
utils/readfile: fix bug while converting byte data type for ISCE file

objects/stackDict: change default connectComponent data type from bool to byte (int8) while loading from binary files

update comments accordingly