### PR TITLE
plot_network: fix bug in colormap

### DIFF
--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -59,8 +59,6 @@ def create_parser():
                         help='Template file with input options:\n'+TEMPLATE+'\n')
     parser.add_argument('--reset', action='store_true',
                         help='restore all interferograms in the file, by marking all dropIfgram=True')
-    parser.add_argument('--plot', action='store_true',
-                        help='plot and save the result to image files.')
     parser.add_argument('--noaux', dest='update_aux', action='store_false',
                         help='Do not update auxilary files, e.g.\n' +
                              'maskConnComp.h5 or avgSpatialCoh.h5 from ifgramStack.h5')
@@ -473,21 +471,7 @@ def main(iargs=None):
 
     if inps.date12_to_drop is not None:
         ifgramStack(inps.file).update_drop_ifgram(date12List_to_drop=inps.date12_to_drop)
-        #print('--------------------------------------------------')
-        #ut.nonzero_mask(inps.file)
-        #print('--------------------------------------------------')
-        #ut.temporal_average(inps.file, datasetName='coherence', updateMode=True)
-        # Touch spatial average txt file of coherence if it's existed
         ut.touch(os.path.splitext(os.path.basename(inps.file))[0]+'_coherence_spatialAvg.txt')
-
-        # Plot result
-        if inps.plot:
-            print('\nplot modified network and save to file.')
-            plotCmd = 'plot_network.py {} --nodisplay'.format(inps.file)
-            if inps.template_file:
-                plotCmd += ' --template {}'.format(inps.template_file)
-            print(plotCmd)
-            os.system(plotCmd)
         print('Done.')
     return
 

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -50,9 +50,9 @@ def create_parser():
 def cmd_line_parse(iargs = None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
-    if not inps.ifgramDir and not inps.geometryDir:
+    if all(not i for i in [inps.ifgramDir, inps.geometryDir, inps.metaFile]):
         parser.print_usage()
-        raise SystemExit('error: at least one of the following arguments are required: -i, -g')
+        raise SystemExit('error: at least one of the following arguments are required: -i, -g, -m')
     return inps
 
 


### PR DESCRIPTION
plot_network:
+ add --cmap-vlist option to replace the -m, -M and --threshold options.
+ more robust default color jump

utils/plot.plot_network(): use ColormapExt() for the truncate_* colormap directly.

modify_network: remove --plot for more simple main()