### PR TITLE
fixed network.py for only one interferogram

### DIFF
--- a/mintpy/utils/network.py
+++ b/mintpy/utils/network.py
@@ -177,7 +177,11 @@ def get_date12_list(fname, dropIfgram=False):
         txtContent = np.loadtxt(fname, dtype=bytes).astype(str)
         if len(txtContent.shape) == 1:
             txtContent = txtContent.reshape(-1, 1)
-        date12_list = [i for i in txtContent[:, 0]]
+            date12_list = txtContent[0]
+        else:
+            date12_list = [i for i in txtContent[:, 0]]    # for one interferogram
+#        date12_list = [i for i in txtContent[:, 0]]
+
     date12_list = sorted(date12_list)
     return date12_list
 


### PR DESCRIPTION
Fix small thing to generate only one interferogram pair for co-seismic DInSAR processing with just two SAR images.