### PR TITLE
prep_aria: add more metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/license-GPL-yellow.svg)](https://github.com/insarlab/MintPy/blob/master/LICENSE)
 [![Forum](https://img.shields.io/badge/forum-Google%20Group-orange.svg)](https://groups.google.com/forum/#!forum/mintpy)
 
-The Miami INsar Time-series software in PYthon (MintPy) is an open-source package for Interferometric Synthetic Aperture Radar time series analysis. It reads the stack of interferograms (coregistered and unwrapped) in [ISCE](https://github.com/isce-framework/isce2), [SNAP](http://step.esa.int/), Gamma or ROI_PAC format, and produces three dimensional (2D in space and 1D in time) ground surface displacement. It includes a routine time series analysis (`smallbaselineApp.py`) and some independent toolbox.
+The Miami INsar Time-series software in PYthon (MintPy) is an open-source package for Interferometric Synthetic Aperture Radar time series analysis. It reads the stack of interferograms (coregistered and unwrapped) in [ISCE](https://github.com/isce-framework/isce2), [ARIA](https://github.com/aria-tools/ARIA-tools), [SNAP](http://step.esa.int/), Gamma or ROI_PAC format, and produces three dimensional (2D in space and 1D in time) ground surface displacement. It includes a routine time series analysis (`smallbaselineApp.py`) and some independent toolbox.
 
 This package was called PySAR before version 1.1.1. For version 1.1.2 and onward, we use MintPy instead.
 

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -30,8 +30,8 @@ mintpy.load.waterMaskFile  = auto  #[path2water_mask_file], optional
 mintpy.load.bperpFile      = auto  #[path2bperp_file], optional
 ##---------subset (optional):
 ## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
-mintpy.subset.yx     = auto    #[1800:2000,700:800 / no], auto for no
-mintpy.subset.lalo   = auto    #[31.5:32.5,130.5:131.0 / no], auto for no
+mintpy.subset.yx   = auto    #[1800:2000,700:800 / no], auto for no
+mintpy.subset.lalo = auto    #[31.5:32.5,130.5:131.0 / no], auto for no
 
 
 ## 2 Modify Network (optional)
@@ -106,13 +106,15 @@ mintpy.networkInversion.minRedundancy   = auto #[1-inf], auto for 1.0, min num_i
 mintpy.networkInversion.waterMaskFile   = auto #[filename / no], auto for waterMask.h5 or no [if no waterMask.h5 found]
 mintpy.networkInversion.minNormVelocity = auto #[yes / no], auto for yes, min-norm deformation velocity or phase
 mintpy.networkInversion.residualNorm    = auto #[L2 ], auto for L2, norm minimization solution
+
 ## Parallel processing with Dask for HPC
-mintpy.networkInversion.parallel        = auto #[yes / no], auto for no, parallel processing using dask
-mintpy.networkInversion.numWorker       = auto #[int > 0], auto for 40, number of works for dask cluster to use
-mintpy.networkInversion.walltime        = auto #[HH:MM], auto for 00:40, walltime for dask workers
+mintpy.networkInversion.parallel  = auto #[yes / no], auto for no, parallel processing using dask
+mintpy.networkInversion.numWorker = auto #[int > 0], auto for 40, number of works for dask cluster to use
+mintpy.networkInversion.walltime  = auto #[HH:MM], auto for 00:40, walltime for dask workers
+
 ## Temporal coherence is calculated and used to generate final mask (Pepe & Lanari, 2006, IEEE-TGRS)
-mintpy.networkInversion.minTempCoh      = auto #[0.0-1.0], auto for 0.7, min temporal coherence for mask
-mintpy.networkInversion.minNumPixel     = auto #[int > 0], auto for 100, min number of pixels in mask above
+mintpy.networkInversion.minTempCoh  = auto #[0.0-1.0], auto for 0.7, min temporal coherence for mask
+mintpy.networkInversion.minNumPixel = auto #[int > 0], auto for 100, min number of pixels in mask above
 
 
 ########## Local Oscillator Drift (LOD) Correction (for Envisat only)
@@ -129,7 +131,7 @@ mintpy.networkInversion.minNumPixel     = auto #[int > 0], auto for 100, min num
 ##      MERRA - MERRA-2 from NASA Goddard
 ##      NARR  - NARR from NOAA [recommended for study areas in North America]
 ##      ERA5  - ERA-5 from ECMWF [experimental; for advanced users only; need to install pyaps3]
-mintpy.troposphericDelay.method         = auto  #[pyaps / height_correlation / no], auto for pyaps
+mintpy.troposphericDelay.method = auto  #[pyaps / height_correlation / no], auto for pyaps
 
 ## Notes for pyaps: 
 ## a. GAM data latency: with the most recent SAR data, there will be GAM data missing, the correction
@@ -138,8 +140,8 @@ mintpy.troposphericDelay.method         = auto  #[pyaps / height_correlation / n
 ## directory, then MintPy applications will download the GAM files into the indicated directory. Also MintPy
 ## application will look for the GAM files in the directory before downloading a new one to prevent downloading
 ## multiple copies if you work with different dataset that cover the same date/time.
-mintpy.troposphericDelay.weatherModel   = auto  #[ECMWF / MERRA / NARR], auto for ECMWF, for pyaps method
-mintpy.troposphericDelay.weatherDir     = auto  #[path2directory], auto for WEATHER_DIR or "./"
+mintpy.troposphericDelay.weatherModel = auto  #[ECMWF / MERRA / NARR], auto for ECMWF, for pyaps method
+mintpy.troposphericDelay.weatherDir   = auto  #[path2directory], auto for WEATHER_DIR or "./"
 
 ## Notes for height_correlation:
 ## Extra multilooking is applied to estimate the empirical phase/elevation ratio ONLY.
@@ -168,12 +170,12 @@ mintpy.deramp.maskFile = auto  #[filename / no], auto for maskTempCoh.h5, mask f
 ## pixelwiseGeometry - Use pixel-wise geometry info, such as incidence angle and slant range distance for error estimation
 ##    yes - use pixel-wise geometry when they are available [slow; used by default]
 ##    no  - use mean geometry [fast]
-mintpy.topographicResidual                    = auto  #[yes / no], auto for yes
-mintpy.topographicResidual.polyOrder          = auto  #[1-inf], auto for 2, poly order of temporal deformation model
-mintpy.topographicResidual.phaseVelocity      = auto  #[yes / no], auto for no - phase, use phase velocity for error estimation
-mintpy.topographicResidual.stepFuncDate       = auto  #[20080529,20100611 / no], auto for no, date of step jump
-mintpy.topographicResidual.excludeDate        = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
-mintpy.topographicResidual.pixelwiseGeometry  = auto  #[yes / no], auto for yes, use pixel-wise geometry info
+mintpy.topographicResidual                   = auto  #[yes / no], auto for yes
+mintpy.topographicResidual.polyOrder         = auto  #[1-inf], auto for 2, poly order of temporal deformation model
+mintpy.topographicResidual.phaseVelocity     = auto  #[yes / no], auto for no - phase, use phase velocity for error estimation
+mintpy.topographicResidual.stepFuncDate      = auto  #[20080529,20100611 / no], auto for no, date of step jump
+mintpy.topographicResidual.excludeDate       = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
+mintpy.topographicResidual.pixelwiseGeometry = auto  #[yes / no], auto for yes, use pixel-wise geometry info
 
 
 ########## 9. Residual Phase for Noise Evaluation
@@ -189,7 +191,7 @@ mintpy.residualRMS.cutoff   = auto  #[0.0-inf], auto for 3
 ## 2) Select Reference Date
 ## reference all time-series to one date in time
 ## no     - do not change the default reference date (1st date)
-mintpy.reference.date  = auto   #[reference_date.txt / 20090214 / no], auto for reference_date.txt
+mintpy.reference.date = auto   #[reference_date.txt / 20090214 / no], auto for reference_date.txt
 
 
 ########## 10. Velocity Estimation

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -372,7 +372,7 @@ def coherence2phase_variance_ds(coherence, L=32, epsilon=1e-3, print_msg=False):
     lineStr = '    number of looks L={}'.format(L)
     if L > 80:
         L = 80
-        lineStr += ', use L=80 to avoid dividing by 0 in calculation with Negligible effect'
+        lineStr += ', use L=80 to avoid dividing by 0 in calculation with negligible effect'
     if print_msg:
         print(lineStr)
 

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -94,7 +94,7 @@ class ifgramStackDict:
         Attributes         Dictionary for metadata
         /date              2D array of string  in size of (m, 2   ) in YYYYMMDD format for master and slave date
         /bperp             1D array of float32 in size of (m,     ) in meter.
-        /dropIfgram        1D array of bool    in size of (m,     ).
+        /dropIfgram        1D array of bool    in size of (m,     ) True by default for keeping interferogram.
         /unwrapPhase       3D array of float32 in size of (m, l, w) in radian.
         /coherence         3D array of float32 in size of (m, l, w).
         /connectComponent  3D array of int8    in size of (m, l, w).           (optional)

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
+
+
 import os
-import gdal
-import h5py
+import time
 import argparse
+try:
+    import gdal
+except ImportError:
+    raise ImportError('gdal>=3.0 is required.')
+import h5py
 import numpy as np
+#from skimage.transform import resize
 from mintpy.utils import ptime
-from skimage.transform import resize
 
 
+####################################################################################
 EXAMPLE = """example:
-  prep_aria.py -w mintpy_SanFran -s stack/ -i incidenceAngle/20150605_20150512.vrt -d SRTM_3arcsec.dem
+  prep_aria.py -w mintpy -s stack/ -i incidenceAngle/20150605_20150512.vrt -d SRTM_3arcsec.dem
 """
 
 def create_parser():
@@ -17,67 +24,90 @@ def create_parser():
     parser = argparse.ArgumentParser(description='Prepare ARIA processed products for MintPy.',
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=EXAMPLE)
-    parser.add_argument('-w', '--work-dir', dest='workDir', type=str, default="./",
-                        help='The working directory for MintPy.'
-                        )
-    parser.add_argument('-s', '--stack-dir', dest='stackDir', type=str, required=True,
-                        help='The directory which contains stack VRT files.'
-                        )
-    parser.add_argument('-u', '--unwrap-stack-name', dest='unwStack', type=str,
+    parser.add_argument('-w','--work-dir', dest='workDir', type=str, default="./",
+                        help='The working directory for MintPy.')
+    parser.add_argument('-s','--stack-dir', dest='stackDir', type=str, required=True,
+                        help='The directory which contains stack VRT files.')
+    parser.add_argument('-u','--unwrap-stack-name', dest='unwStack', type=str,
                         default="unwrapStack.vrt",
                         help='Name of the stack VRT file of unwrapped data.\n'+
-                              ' default: unwrapStack.vrt')
-    parser.add_argument('-c', '--coherence-stack-name', dest='cohStack', type=str,
+                             'default: unwrapStack.vrt')
+    parser.add_argument('-c','--coherence-stack-name', dest='cohStack', type=str,
                         default="cohStack.vrt",
                         help='Name of the stack VRT file of coherence data.\n'+
-                              'default: cohStack.vrt')
-    parser.add_argument('-l', '--conn-comp-name', dest='connCompStack', type=str,
+                             'default: cohStack.vrt')
+    parser.add_argument('-l','--conn-comp-name', dest='connCompStack', type=str,
                         default="connCompStack.vrt",
                         help='Name of the stack VRT file of connected component data.\n' +
-                              'default: connCompStack.vrt')
-    parser.add_argument('-i', '--incidence-angle', dest='incidenceAngle', type=str,
-                        required=True,
+                             'default: connCompStack.vrt')
+    parser.add_argument('-i','--incidence-angle', dest='incAngle', type=str, required=True,
                         help='Name of the incidence angle file')
-    parser.add_argument('-d', '--dem', dest='dem', type=str,
-                        required=True,
+    parser.add_argument('-d','--dem', dest='dem', type=str, required=True,
                         help='Name of the DEM file')
 
     return parser
 
+
 def cmd_line_parse(iargs = None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
-
+    inps.stackDir = os.path.abspath(inps.stackDir)
     return inps
 
+
+####################################################################################
 def extract_metadata(stack):
 
+    print('extract metadata from {}'.format(stack))
     ds = gdal.Open(stack, gdal.GA_ReadOnly)
+    metaUnw = ds.GetRasterBand(1).GetMetadata("unwrappedPhase")
 
+    # copy over all metadata from unwrappedPhase
     meta = {}
+    for key, value in metaUnw.items():
+        if key not in ["Dates", "perpendicularBaseline"]:
+            meta[key] = value
+
+    meta["ANTENNA_SIDE"] = -1
     meta["PROCESSOR"] = "isce"
     meta["FILE_LENGTH"] = ds.RasterYSize
     meta["LENGTH"] = ds.RasterYSize
-    meta["ORBIT_DIRECTION"] = "DESCENDING"
+    meta["ORBIT_DIRECTION"] = "DESCENDING"    #check with ARIA-tools team
     meta["PLATFORM"] = "Sen"
-    meta["STARTING_RANGE"] = float(ds.GetRasterBand(1).GetMetadata("unwrappedPhase")['startRange'])
-    meta["WAVELENGTH"] = float(ds.GetRasterBand(1).GetMetadata("unwrappedPhase")['Wavelength (m)'])
+    meta["WAVELENGTH"] = float(meta["Wavelength (m)"])
     meta["WIDTH"] = ds.RasterXSize
     meta["NUMBER_OF_PAIRS"] = ds.RasterCount
 
-    # ARIA standard products currently don't number of range and
+    az_angle = float(meta["azimuthAngle"])
+    head_angle = -1 * (270 + az_angle)
+    head_angle -= np.round(head_angle / 360.) * 360.
+    meta['HEADING'] = head_angle
+
+    # ARIA standard products currently don't have number of range and
     # azimuth looks. They are however fixed to the following values
-    meta['ALOOKS'] = 7
-    meta['RLOOKS'] = 19
+    meta["ALOOKS"] = 7
+    meta["RLOOKS"] = 19
+    meta["RANGE_PIXEL_SIZE"] = float(meta["slantRangeSpacing"]) * meta["RLOOKS"]
+    meta["STARTING_RANGE"] = float(meta["startRange"])
 
     # geo transformation
     geoTrans = ds.GetGeoTransform()
-    meta["X_FIRST"] =   geoTrans[0]
-    meta["Y_FIRST"] =   geoTrans[3]
-    meta["X_STEP"]  =   geoTrans[1]
-    meta["Y_STEP"]  =   geoTrans[5]
-    meta["X_UNIT"]  =   "degrees"
-    meta["Y_UNIT"]  =   "degrees"
+    lon0 = geoTrans[0]
+    lat0 = geoTrans[3]
+    lon_step = geoTrans[1]
+    lat_step = geoTrans[5]
+    lon1 = lon0 + lon_step * meta["WIDTH"]
+    lat1 = lat0 + lat_step * meta["LENGTH"]
+    meta["X_FIRST"] = lon0
+    meta["Y_FIRST"] = lat0
+    meta["X_STEP"] = lon_step
+    meta["Y_STEP"] = lat_step
+    meta["X_UNIT"] = "degrees"
+    meta["Y_UNIT"] = "degrees"
+
+    utc = meta["UTCTime (HH:MM:SS.ss)"]
+    utc = time.strptime(utc, "%H:%M:%S.%f")
+    meta["CENTER_LINE_UTC"] = utc.tm_hour*3600.0 + utc.tm_min*60.0 + utc.tm_sec
 
     # following values probably won't be used anywhere for the geocoded data
     # earth radius
@@ -85,101 +115,163 @@ def extract_metadata(stack):
     # nominal altitude of Sentinel1 orbit
     meta["HEIGHT"] = 693000.0
 
-    ds = None
+    meta["LON_REF1"] = lon0
+    meta["LON_REF2"] = lon1
+    meta["LON_REF3"] = lon0
+    meta["LON_REF4"] = lon1
 
+    meta["LAT_REF1"] = lat0
+    meta["LAT_REF2"] = lat0
+    meta["LAT_REF3"] = lat1
+    meta["LAT_REF4"] = lat1
+
+    ds = None
     return meta
 
-def layout_hdf5(filename, dsNameDict, metadata):
 
+def layout_hdf5(filename, dsNameDict, metadata):
+    print('-'*50)
+    print('create HDF5 file {} with w mode'.format(filename))
     h5 = h5py.File(filename, "w")
 
     for key in dsNameDict.keys():
-        print("creating dataset for {0}".format(key))
+        print("creat dataset: {}".format(key))
         h5.create_dataset(key, shape=dsNameDict[key][1], dtype=dsNameDict[key][0])
 
     for key in metadata.keys():
         h5.attrs[key] = metadata[key]
 
     h5.close()
+    print('close HDF5 file {}'.format(filename))
 
     return
 
 
-def add_unwrapped_phase(h5File, unwStack, cohStack, connCompStack):
+def write_ifgram_stack(h5File, unwStack, cohStack, connCompStack):
 
+    print('-'*50)
+    print('opening {}, {}, {} with gdal ...'.format(os.path.basename(unwStack),
+                                                    os.path.basename(unwStack),
+                                                    os.path.basename(unwStack)))
     dsUnw = gdal.Open(unwStack, gdal.GA_ReadOnly)
     dsCoh = gdal.Open(cohStack, gdal.GA_ReadOnly)
     dsComp = gdal.Open(connCompStack, gdal.GA_ReadOnly)
 
     nPairs = dsUnw.RasterCount
 
+    # sort the order of interferograms based on date1_date2 with date1 < date2
+    d12BandDict = {}
+    for ii in range(nPairs):
+        bnd = dsUnw.GetRasterBand(ii+1)
+        d12 = bnd.GetMetadata("unwrappedPhase")["Dates"]
+        d12 = sorted(d12.split("_"))
+        d12 = '{}_{}'.format(d12[0], d12[1])
+        d12BandDict[d12] = ii+1
+    d12List = sorted(d12BandDict.keys())
+
+    print('writing data to HDF5 file {} with a mode ...'.format(h5File))
     h5 = h5py.File(h5File, "a")
 
     prog_bar = ptime.progressBar(maxValue=nPairs)
     for ii in range(nPairs):
-        bnd = dsUnw.GetRasterBand(ii+1)
+        d12 = d12List[ii]
+        bndIdx = d12BandDict[d12]
+
+        h5["date"][ii,0] = d12.split("_")[0].encode("utf-8")
+        h5["date"][ii,1] = d12.split("_")[1].encode("utf-8")
+
+        bnd = dsUnw.GetRasterBand(bndIdx)
         h5["unwrapPhase"][ii,:,:] = -1.0*bnd.ReadAsArray()
 
-        d12 = bnd.GetMetadata("unwrappedPhase")["Dates"]
-        h5["date"][ii,0] = d12.split("_")[1].encode("utf-8")
-        h5["date"][ii,1] = d12.split("_")[0].encode("utf-8")
+        bperp = float(bnd.GetMetadata("unwrappedPhase")["perpendicularBaseline"])
+        h5["bperp"][ii] = -1.0*bperp
 
-        bnd = dsCoh.GetRasterBand(ii+1)
+        bnd = dsCoh.GetRasterBand(bndIdx)
         h5["coherence"][ii,:,:] = bnd.ReadAsArray()
 
-        bnd = dsComp.GetRasterBand(ii+1)
+        bnd = dsComp.GetRasterBand(bndIdx)
         raster = bnd.ReadAsArray()
         raster[raster<0]=0   # assign pixel with no-data [-1] to zero
         h5["connectComponent"][ii,:,:] = raster
 
-        bperp = float(dsUnw.GetRasterBand(ii+1).GetMetadata("unwrappedPhase")["perpendicularBaseline"])
-        h5["bperp"][ii] = -1.0*bperp
-
         h5["dropIfgram"][ii] = True
-        prog_bar.update(ii+1, suffix='{}_{}'.format(d12.split("_")[1], d12.split("_")[0]))
+        prog_bar.update(ii+1, suffix='{}'.format(d12))
 
     prog_bar.close()
     h5.close()
+    print('finished writing to HD5 file: {}'.format(h5File))
     dsUnw = None
     dsCoh = None
     dsComp = None
-
     return
 
-def add_geometry(h5File, incAngleFile,demFile):
 
+def write_geometry(h5File, incAngleFile, demFile=None):
+    print('-'*50)
+    print('writing data to HDF5 file {} with a mode ...'.format(h5File))
     h5 = h5py.File(h5File, 'a')
-
-    startRange = h5.attrs['STARTING_RANGE']
 
     ds = gdal.Open(incAngleFile, gdal.GA_ReadOnly)
     data = ds.ReadAsArray()
+    data[data == ds.GetRasterBand(1).GetNoDataValue()] = np.nan
     h5['incidenceAngle'][:,:] = data
-    data[data!=0] = startRange
-    h5['slantRangeDistance'][:,:] = data
+
+    h5['slantRangeDistance'][:,:] = float(h5.attrs['STARTING_RANGE'])
 
     ds = gdal.Open(demFile, gdal.GA_ReadOnly)
-    data = ds.ReadAsArray()
-    noData = ds.GetRasterBand(1).GetNoDataValue()
-    data[data==noData]=0
-    outShape = (int(h5.attrs['LENGTH']),int(h5.attrs['WIDTH']))
-    demData = resize(data,outShape,order=1, mode='constant', anti_aliasing=True, preserve_range=True)
-    h5['height'][:,:] = demData
+    data = np.array(ds.ReadAsArray(), dtype=np.float32)
+    data[data == ds.GetRasterBand(1).GetNoDataValue()] = np.nan
+    #outShape = (int(h5.attrs['LENGTH']),int(h5.attrs['WIDTH']))
+    #data = resize(data, outShape, order=1, mode='constant', anti_aliasing=True, preserve_range=True)
+    h5['height'][:,:] = data
 
+    h5.close()
+    print('finished writing to HD5 file: {}'.format(h5File))
+    return h5File
+
+
+####################################################################################
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
 
-    inps.stackDir = os.path.abspath(inps.stackDir)
     cohStack = os.path.join(inps.stackDir, inps.cohStack)
     unwStack = os.path.join(inps.stackDir, inps.unwStack)
     connCompStack = os.path.join(inps.stackDir, inps.connCompStack)
+    for vrtFile in [cohStack, unwStack, connCompStack]:
+        if not os.path.isfile(vrtFile):
+            raise FileNotFoundError(vrtFile)
 
+    # prepare mintpy working directory
+    inps.workDir = os.path.abspath(inps.workDir)
+    if not os.path.exists(inps.workDir):
+        os.makedirs(inps.workDir)
+
+    inputDir = os.path.join(inps.workDir , "inputs")
+    if not os.path.exists(inputDir):
+        os.makedirs(inputDir)
+
+    # prepare metadata
     metadata = extract_metadata(unwStack)
 
     length = metadata["LENGTH"]
     width = metadata["WIDTH"]
     numPairs = metadata["NUMBER_OF_PAIRS"]
 
+    # write geometryGeo
+    #dsNameDict = {"azimuthAngle": (np.float32, (length, width)),
+    #              "height": (np.float32, (length, width)),
+    #              "incidenceAngle": (np.float32, (length, width)),
+    #              "shadowMask": (np.bool, (length, width)),
+    #              "slantRangeDistance": (np.float32, (length, width))}
+    dsNameDict = {"height": (np.float32, (length, width)),
+                  "incidenceAngle": (np.float32, (length, width)),
+                  "slantRangeDistance": (np.float32, (length, width))}
+
+    geom_file = os.path.join(inputDir, "geometryGeo.h5")
+    layout_hdf5(geom_file, dsNameDict, metadata)
+    write_geometry(geom_file, incAngleFile=inps.incAngle, demFile=inps.dem)
+
+    # write ifgramStack
     dsNameDict = {"bperp": (np.float32, (numPairs,)),
                   "coherence": (np.float32, (numPairs, length, width)),
                   "connectComponent": (np.byte, (numPairs, length, width)),
@@ -187,30 +279,12 @@ def main(iargs=None):
                   "dropIfgram": (np.bool, (numPairs,)),
                   "unwrapPhase": (np.float32, (numPairs, length, width))}
 
-    workDir = os.path.abspath(inps.workDir)
-    if not os.path.exists(workDir):
-        os.makedirs(workDir)
+    ifgram_file = os.path.join(inputDir, "ifgramStack.h5")
+    layout_hdf5(ifgram_file, dsNameDict, metadata)
+    write_ifgram_stack(ifgram_file, unwStack, cohStack, connCompStack)
+    return ifgram_file, geom_file
 
-    inputDir = os.path.join(workDir , "inputs")
-    if not os.path.exists(inputDir):
-        os.makedirs(inputDir)
 
-    h5Filename = os.path.join(inputDir, "ifgramStack.h5")
-
-    layout_hdf5(h5Filename, dsNameDict, metadata)
-
-    add_unwrapped_phase(h5Filename, unwStack, cohStack, connCompStack)
-
-    # setting up geometry:
-    dsNameDict = {"azimuthAngle": (np.float32, (length, width)),
-                  "height": (np.float32, (length, width)),
-                  "incidenceAngle": (np.float32, (length, width)),
-                  "shadowMask": (np.bool, (length, width)),
-                  "slantRangeDistance": (np.float32, (length, width))}
-
-    h5Filename = os.path.join(inputDir, "geometryGeo.h5")
-    layout_hdf5(h5Filename, dsNameDict, metadata)
-    add_geometry(h5Filename, inps.incidenceAngle, inps.dem)
-
+####################################################################################
 if __name__=="__main__":
     main()

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -151,8 +151,8 @@ def write_ifgram_stack(h5File, unwStack, cohStack, connCompStack):
 
     print('-'*50)
     print('opening {}, {}, {} with gdal ...'.format(os.path.basename(unwStack),
-                                                    os.path.basename(unwStack),
-                                                    os.path.basename(unwStack)))
+                                                    os.path.basename(cohStack),
+                                                    os.path.basename(connCompStack)))
     dsUnw = gdal.Open(unwStack, gdal.GA_ReadOnly)
     dsCoh = gdal.Open(cohStack, gdal.GA_ReadOnly)
     dsComp = gdal.Open(connCompStack, gdal.GA_ReadOnly)

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -10,8 +10,6 @@ import os
 import sys
 import time
 from datetime import datetime as dt, timedelta
-
-import h5py
 import numpy as np
 
 
@@ -126,47 +124,6 @@ def yymmdd_date12(date12_list):
     s_dates = yymmdd([i.replace('-', '_').split('_')[1] for i in date12_list])
     date12_list = ['{}-{}'.format(m, s) for m, s in zip(m_dates, s_dates)]
     return date12_list
-
-
-#################################################################
-def ifgram_date_list(ifgramFile, fmt='YYYYMMDD'):
-    """Read Date List from Interferogram file
-        for timeseries file, use h5file['timeseries'].keys() directly
-    Inputs:
-        ifgramFile - string, name/path of interferograms file
-        fmt        - string, output date format, choices=['YYYYMMDD','YYMMDD']
-    Output:
-        date_list  - list of string, date included in ifgramFile in YYYYMMDD or YYMMDD format
-    """
-    if not ifgramFile:
-        return []
-
-    h5 = h5py.File(ifgramFile, 'r')
-    k = list(h5.keys())
-    if 'interferograms' in k: k = 'interferograms'
-    elif 'coherence' in k: k = 'coherence'
-    elif 'wrapped' in k: k = 'wrapped'
-    else: k = k[0]
-    if k not in  ['interferograms','coherence','wrapped']:
-        raise ValueError('Only interferograms / coherence / wrapped are supported. Input is '+str(k))
-
-    # Get date_list in YYMMDD format
-    date_list = []
-    ifgram_list = sorted(h5[k].keys())
-    for ifgram in ifgram_list:
-        date12 = h5[k][ifgram].attrs['DATE12']
-        try:
-            date12 = date12.decode('utf-8')
-        except:
-            pass
-        date_list.append(date12.split('_')[0])
-        date_list.append(date12.split('_')[1])
-    h5.close()
-    date_list = sorted(list(set(date_list)))
-
-    if fmt == 'YYYYMMDD':
-        date_list = yyyymmdd(date_list)
-    return date_list
 
 
 #################################################################


### PR DESCRIPTION
prep_aria:

+ comment out skimage.transform.resize() because the updated ariaTSsteup.py produces the same size DEM file as the interferogram stack, this eliminates the need of installing scikit-image module while running prep_aria.py within the `ARIA-tools` python environment.

+ copy over all metadata from unwrappedPhase for the sake of completeness, except for Dates and bperp

+ add metadata extraction for:
   - ANTENNA_SIDE
   - HEADING
   - RANGE_PIXEL_SIZE
   - LON/LAT_REF1/2/3/4
   - CENTER_LINE_UTC

+ write all ifgrams in the sorted order of date1_date2 with date1 < date2

+ comment out geometry dataset azimuthAngle and shadowMask for now since both of them are not required by mintpy. Together with waterMask, they can be added afterward when the products are available from ARIA-tools.

+ more print out message for file IO

utils/ptime: remove obsolete ifgram_date_list() to that ptime.py can be independent from h5py module

add ARIA format link to README.md

Update indentation in smallbaselineApp.cfg