### PR TITLE
bug fix for unwrap_erro_bridging if num_label > 10

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/license-GPL-yellow.svg)](https://github.com/insarlab/MintPy/blob/master/LICENSE)
 [![Forum](https://img.shields.io/badge/forum-Google%20Group-orange.svg)](https://groups.google.com/forum/#!forum/mintpy)
 
-The Miami INsar Time-series software in PYthon (MintPy) is an open-source package for Interferometric Synthetic Aperture Radar time series analysis. It reads the stack of interferograms (coregistered and unwrapped) in [ISCE](https://github.com/isce-framework/isce2), [ARIA](https://github.com/aria-tools/ARIA-tools), [SNAP](http://step.esa.int/), Gamma or ROI_PAC format, and produces three dimensional (2D in space and 1D in time) ground surface displacement. It includes a routine time series analysis (`smallbaselineApp.py`) and some independent toolbox.
+The Miami INsar Time-series software in PYthon (MintPy) is an open-source package for Interferometric Synthetic Aperture Radar time series analysis. It reads the stack of interferograms (coregistered and unwrapped) in [ISCE](https://github.com/isce-framework/isce2), GAMMA, [ARIA](https://github.com/aria-tools/ARIA-tools), [SNAP](http://step.esa.int/) or ROI_PAC format, and produces three dimensional (2D in space and 1D in time) ground surface displacement. It includes a routine time series analysis (`smallbaselineApp.py`) and some independent toolbox.
 
 This package was called PySAR before version 1.1.1. For version 1.1.2 and onward, we use MintPy instead.
 
@@ -88,4 +88,5 @@ Join our google group [https://groups.google.com/forum/#!forum/mintpy](https://g
 * Alfredo Terreco
 * David Grossman
 * Yunmeng Cao
+* Andre Theron
 * [_other community members_](https://github.com/insarlab/MintPy/graphs/contributors)

--- a/docs/examples/input_files/FernandinaSenDT128.txt
+++ b/docs/examples/input_files/FernandinaSenDT128.txt
@@ -33,7 +33,7 @@ mintpy.load.shadowMaskFile   = ../merged/geom_master/shadowMask.rdr
 mintpy.load.waterMaskFile    = None
 
 mintpy.reference.lalo        = -0.30,-91.43
-mintpy.troposphericDelay.weatherModel    = ERA5
+mintpy.troposphericDelay.weatherModel    = ECMWF
 mintpy.topographicResidual.stepFuncDate  = 20170910,20180613  #eruption dates
 mintpy.deramp                = linear
 

--- a/docs/examples/input_files/KujuAlosAT422F650.txt
+++ b/docs/examples/input_files/KujuAlosAT422F650.txt
@@ -18,8 +18,9 @@ mintpy.load.shadowMaskFile = None                                  #[path2shadow
 mintpy.load.waterMaskFile  = None                                  #[path2water_mask_file]
 
 ##————————————————————————————— PROCESSING Options ——-----————————————————————##
-mintpy.reference.lalo      = 33.0655, 131.2076
-mintpy.deramp              = linear
+mintpy.reference.lalo                   = 33.0655, 131.2076
+mintpy.troposphericDelay.weatherModel   = ECMWF
+mintpy.deramp                           = linear
 
 ##————————————————————————————— HDF-EOS5 Attributes -—————————————————————————##
 beam_mode           = SM

--- a/docs/examples/input_files/WellsEnvD2T399.txt
+++ b/docs/examples/input_files/WellsEnvD2T399.txt
@@ -19,6 +19,7 @@ mintpy.reference.lalo      = 41.03, -114.70
 mintpy.network.coherenceBased     = yes       #[yes / no], auto for yes, exclude interferograms with coherence < minCoherence
 mintpy.network.keepMinSpanTree    = no
 mintpy.network.excludeDate        = 20071231, 20080204, 20080310
+mintpy.troposphericDelay.weatherModel   = ECMWF
 mintpy.topographicResidual.stepFuncDate = 20080221
 
 ##------------------------  HDF-EOS5 --------------------------------##

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -45,6 +45,7 @@ mintpy.network.minCoherence    = auto  #[0.0-1.0], auto for 0.7
 mintpy.network.maskFile        = auto  #[file name, no], auto for waterMask.h5 or no [if no waterMask.h5 found]
 mintpy.network.aoiYX           = auto  #[y0:y1,x0:x1 / no], auto for no, area of interest for coherence calculation
 mintpy.network.aoiLALO         = auto  #[lat0:lat1,lon0:lon1 / no], auto for no - use the whole area
+
 ## 2) Network modification based on temporal/perpendicular baselines, date etc.
 mintpy.network.tempBaseMax     = auto  #[1-inf, no], auto for no, maximum temporal baseline in days
 mintpy.network.perpBaseMax     = auto  #[1-inf, no], auto for no, maximum perpendicular spatial baseline in meter

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -239,6 +239,10 @@ def read_data(inps):
         elif dname == 'wrapPhase':
             atr['FILE_TYPE'] = '.int'
             atr['UNIT'] = 'radian'
+        elif dname == 'connectComponent':
+            atr['FILE_TYPE'] = '.conncomp'
+            atr['UNIT'] = '1'
+            atr['DATA_TYPE'] = 'byte'
         else:
             raise ValueError('unrecognized dataset type: {}'.format(inps.dset))
 

--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -149,8 +149,10 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None)
             write_real_float32(data_list[0], out_file)
         elif meta['DATA_TYPE'].lower() in ['int16', 'short']:
             write_real_int16(data_list[0], out_file)
-        elif meta['DATA_TYPE'].lower() in ['byte','bool']:
+        elif meta['DATA_TYPE'].lower() in ['byte']:
             write_byte(data_list[0], out_file)
+        elif meta['DATA_TYPE'].lower() in ['bool']:
+            write_bool(data_list[0], out_file)
         else:
             print('Un-supported file type: '+ext)
             return 0
@@ -327,6 +329,12 @@ def write_complex_int16(data, out_file):
 
 
 def write_byte(data, out_file):
+    data = np.array(data, dtype=np.byte)
+    data.tofile(out_file)
+    return out_file
+
+
+def write_bool(data, out_file):
     data = np.array(data, dtype=np.bool_)
     data.tofile(out_file)
     return out_file


### PR DESCRIPTION
objects/conncomp.py:
+ fix bug of connection identification confusion when there are more than 10 reliable connected components in the dataset.

+ more comments on get_all_bridges() and find_mst_bridge()

save_roipac.py: support ouptut connectComponent from ifgramStack.h5 file

utils/readfile: more generic reading for binary data files by assigning some data structure info before checking InSAR processor

utils/writefile: bug fixed for writing byte and bool type of data file

specify ECMWF (ERAI) as the tropo dataset for test example. They should be changed to ERA5 in the future.