### PR TITLE
 connectComponent: byte to int16

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ## Running as Docker container
 
-[Docker](https://docs.docker.com/get-started/) allows you to run MintPy in a dedicated container (essentially an efficient virtual machine). [Here](https://docs.docker.com/install/) is the instruction to install docker.
+Thanks to Andre Theron for putting together an [MintPy container on DockerHub](https://hub.docker.com/r/andretheronsa/mintpy). [Docker](https://docs.docker.com/get-started/) allows you to run MintPy in a dedicated container (essentially an efficient virtual machine). [Here](https://docs.docker.com/install/) is the instruction to install docker.
 
 To pull the MintPy container from Dockerhub to your local machine: 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,15 +66,15 @@ git push -f
 
 If the pull request discussion results in changes, commit new changes to `my_user_name/my_new_feature_branch`, they will show up in the pull request in `insarlab` automatically.
 
-## Testing ##
+## Test, before push back to `insarlab/master` ##
 
-It's a good idea to test any changes or bugs you have fixed. We realize that we don't have a complete testing system in place yet, except for an overall testing script `test_smallbaselineApp.py`, run
+It's a good idea to test any changes or bugs you have fixed, in the feature branch before pushing back to `insarlab/master` branch. We realize that we don't have a complete testing system in place yet, except for an overall testing script `test_smallbaselineApp.py`, run
 
 ```
 ${MINTPY_HOME}/test/test_smallbaselineApp.py
 ```
 
-to see the testing result, it takes about 26 mins to finish.
+to see the testing result, it takes about 10 mins to finish.
 
 
 ## Things you should NOT do ##

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,4 +89,4 @@ Join our google group [https://groups.google.com/forum/#!forum/mintpy](https://g
 * David Grossman
 * Yunmeng Cao
 * Andre Theron
-* [_other community members_](https://github.com/insarlab/MintPy/graphs/contributors)
+* [Other community members.](https://github.com/insarlab/MintPy/graphs/contributors) [[Contribute](./CONTRIBUTING.md)]

--- a/mintpy/objects/conncomp.py
+++ b/mintpy/objects/conncomp.py
@@ -7,16 +7,17 @@
 #   from mintpy.objects.conncomp import connectComponent
 
 
+try:
+    from skimage import measure, segmentation as seg, morphology as morph
+except ImportError:
+    raise ImportError('Could not import skimage!')
+
 import os
 import time
 import itertools
 import numpy as np
 from scipy.sparse import csgraph as csg
 from scipy.spatial import cKDTree
-try:
-    from skimage import measure, segmentation as seg, morphology as morph
-except ImportError:
-    raise ImportError('Could not import skimage!')
 from .ramp import deramp
 
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -555,7 +555,7 @@ Attributes         Dictionary for metadata
 /dropIfgram        1D array of bool    in size of (m,     ) with 0/False for drop and 1/True for keep
 /unwrapPhase       3D array of float32 in size of (m, l, w) in radian.
 /coherence         3D array of float32 in size of (m, l, w).
-/connectComponent  3D array of int8    in size of (m, l, w).           (optional)
+/connectComponent  3D array of int16   in size of (m, l, w).           (optional)
 /wrapPhase         3D array of float32 in size of (m, l, w) in radian. (optional)
 /rangeOffset       3D array of float32 in size of (m, l, w).           (optional)
 /azimuthOffset     3D array of float32 in size of (m, l, w).           (optional)

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -97,7 +97,7 @@ class ifgramStackDict:
         /dropIfgram        1D array of bool    in size of (m,     ) True by default for keeping interferogram.
         /unwrapPhase       3D array of float32 in size of (m, l, w) in radian.
         /coherence         3D array of float32 in size of (m, l, w).
-        /connectComponent  3D array of int8    in size of (m, l, w).           (optional)
+        /connectComponent  3D array of int16   in size of (m, l, w).           (optional)
         /wrapPhase         3D array of float32 in size of (m, l, w) in radian. (optional)
         /iono              3D array of float32 in size of (m, l, w) in radian. (optional)
         /rangeOffset       3D array of float32 in size of (m, l, w).           (optional)
@@ -126,8 +126,11 @@ class ifgramStackDict:
         for dsName in self.dsNames:
             dsShape = (self.numIfgram, self.length, self.width)
             dsDataType = dataType
+            dsCompression = compression
             if dsName in ['connectComponent']:
-                dsDataType = np.byte
+                dsDataType = np.int16
+                dsCompression = 'lzf'
+
             print(('create dataset /{d:<{w}} of {t:<25} in size of {s}'
                    ' with compression = {c}').format(d=dsName,
                                                      w=maxDigit,

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -136,13 +136,13 @@ class ifgramStackDict:
                                                      w=maxDigit,
                                                      t=str(dsDataType),
                                                      s=dsShape,
-                                                     c=str(compression)))
+                                                     c=dsCompression))
             ds = f.create_dataset(dsName,
                                   shape=dsShape,
                                   maxshape=(None, dsShape[1], dsShape[2]),
                                   dtype=dsDataType,
                                   chunks=True,
-                                  compression=compression)
+                                  compression=dsCompression)
 
             prog_bar = ptime.progressBar(maxValue=self.numIfgram)
             for i in range(self.numIfgram):

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -729,7 +729,7 @@ def auto_row_col_num(subplot_num, data_shape, fig_size, fig_num=1):
 
 
 def check_colormap_input(metadata, cmap_name=None, datasetName=None, cmap_lut=256, print_msg=True):
-    gray_dataset_key_words = ['coherence', 'temporal_coherence', 'connectComponent',
+    gray_dataset_key_words = ['coherence', 'temporal_coherence',
                               '.cor', '.mli', '.slc', '.amp', '.ramp']
     if not cmap_name:
         if any(i in gray_dataset_key_words for i in [metadata['FILE_TYPE'],

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -303,7 +303,7 @@ def update_inps_with_file_metadata(inps, metadata):
     # Min / Max - Display
     if not inps.vlim:
         if (any(i in inps.key.lower() for i in ['coherence', '.cor'])
-                or (inps.key == 'ifgramStack' and inps.dset[0].split('-')[0] in ['coherence', 'connectComponent'])
+                or (inps.key == 'ifgramStack' and inps.dset[0].split('-')[0] in ['coherence'])
                 or inps.dset[0] == 'cmask'):
             inps.vlim = [0.0, 1.0]
         elif inps.key in ['.int'] or inps.wrap:


### PR DESCRIPTION
prep_aria.py and objects/stackDict.py:

+ change the data type of connectComponent dataset from BYTE to INT16 to support up to 32767 reliable regions/connected components for single interferograms.

+ turn ON compression of "lzf" while writing connectComponent to HDF5 file to save disk space

prep_aria.py:
+ add FILE_TYPE metadata
+ add MODIFICATION_TIME metadata to 3D datasets
+ turn ON chunks while writing HDF5 to speedup file IO
+ turn ON maxshape for 3D datasets to support updatable ifgramStack.h5: feature not used anyway yet; just to be consistent with mintpy.

update default plot settings for connectComponent dataset in view.py and  plot.py