### PR TITLE
prep_aria: no-data for waterMask, unw, coh and connComp

### DIFF
--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -221,9 +221,14 @@ def write_geometry(h5File, demFile, incAngleFile, azAngleFile=None, waterMaskFil
     # waterMask
     if waterMaskFile is not None:
         ds = gdal.Open(waterMaskFile, gdal.GA_ReadOnly)
+        water_mask = ds.ReadAsArray()
+        water_mask[water_mask == ds.GetRasterBand(1).GetNoDataValue()] = False
+
+        # assign False to invalid pixels based on incAngle data
+        ds = gdal.Open(incAngleFile, gdal.GA_ReadOnly)
         data = ds.ReadAsArray()
-        data[data == ds.GetRasterBand(1).GetNoDataValue()] = False
-        h5['waterMask'][:,:] = data
+        water_mask[data == ds.GetRasterBand(1).GetNoDataValue()] = False
+        h5['waterMask'][:,:] = water_mask
 
     h5.close()
     print('finished writing to HD5 file: {}'.format(h5File))

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -58,8 +58,8 @@ EXAMPLE = """example:
 
   # InSAR v.s. GPS
   # for one subplot only
-  view.py geo_velocity_masked.h5 velocity --show-gps   #show locations of available GPS
-  view.py geo_velocity_masked.h5 velocity --show-gps --gps-comp enu2los --ref-gps GV01
+  view.py geo_velocity_msk.h5 velocity --show-gps   #show locations of available GPS
+  view.py geo_velocity_msk.h5 velocity --show-gps --gps-comp enu2los --ref-gps GV01
   view.py geo_timeseries_ECMWF_demErr_ramp.h5 20180619 --ref-date 20141213 --show-gps --gps-comp enu2los --ref-gps GV01
 
   # Custom colormap


### PR DESCRIPTION
Grab mask of invalid pixels from incidence angle and use it to maskout pixels in water mask too. This benefits:

1) more representative calculation of the average spatial coherence --> improving the performance of coherence-based network modification; 

2) one way of handling the no-data because water mask is used as a basic mask in mintpy.