### PR TITLE
 fix bug of mask from geometry in dem_error.py

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -34,7 +34,7 @@ mintpy.subset.yx   = auto    #[1800:2000,700:800 / no], auto for no
 mintpy.subset.lalo = auto    #[31.5:32.5,130.5:131.0 / no], auto for no
 
 
-## 2 Modify Network (optional)
+## 2 Modify Network
 ## 1) Coherence-based network modification = Threshold + MST, by default
 ## It calculates a average coherence value for each interferogram using spatial coherence and input mask (with AOI)
 ## Then it finds a minimum spanning tree (MST) network with inverse of average coherence as weight (keepMinSpanTree)

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -359,6 +359,7 @@ def correct_dem_error(inps, A_def):
     if num_step > 0:
         step_model = np.zeros((num_step, num_pixel), dtype=np.float32)
 
+    # initiate mask based on time-series
     print('skip pixels with ZERO in ALL acquisitions')
     mask = np.nanmean(ts_data, axis=0) != 0.
     print('skip pixels with NaN  in ANY acquisitions')
@@ -383,9 +384,11 @@ def correct_dem_error(inps, A_def):
         if num_step > 0:
             step_model[:, mask] = step_model_i
     else:
-        # mask
-        print('skip pixels with zero/nan value in geometry: incidenceAngle or slantRangeDistance')
-        mask *= np.multiply(inps.sinIncAngle != 0., inps.rangeDist != 0.)
+        # update mask based on geometry
+        print('skip pixels with ZERO / NaN value in incidenceAngle / slantRangeDistance')
+        for geom_data in [inps.sinIncAngle, inps.rangeDist]:
+            mask *= geom_data != 0.
+            mask *= ~np.isnan(geom_data)
 
         num_pixel2inv = np.sum(mask)
         idx_pixel2inv = np.where(mask)[0]

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -20,14 +20,21 @@ except ImportError:
 
 ####################################################################################
 EXAMPLE = """example:
-  # run ARIA-tools to download and extract inteferograms stack for time-series analysis.
+  # 1. run ARIA-tools to download and extract inteferograms stack for time-series analysis.
   # reference: https://github.com/aria-tools/ARIA-tools
   conda activate ARIA-tools
   ariaDownload.py -b '37.25 38.1 -122.6 -121.75' --track 42
   ariaTSsetup.py -f 'products/*.nc' -b '37.25 38.1 -122.6 -121.75' --mask Download
 
+  # 2. run prep_aria.py to load into HDF5 files
   prep_aria.py -w mintpy -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt 
   prep_aria.py -w mintpy -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt -a azimuthAngle/20150605_20150512.vrt --water-mask mask/watermask.msk
+
+  # 3. run smallbaselineApp.py for time series analysis
+  conda deactivate
+  conda activate mintpy
+  smallbaselineApp.py -g #generate smallbaselineApp.cfg file (modify default auto value)
+  smallbaselineApp.py    #run routine analysis, or smallbaselineApp.py --start modify_network
 """
 
 def create_parser():

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -367,15 +367,6 @@ class TimeSeriesAnalysis:
         # 3) check loading result
         load_complete, stack_file, geom_file = ut.check_loaded_dataset(self.workDir, print_msg=True)[0:3]
 
-        # 3.1) output waterMask.h5
-        water_mask_file = 'waterMask.h5'
-        if 'waterMask' in readfile.get_dataset_list(geom_file):
-            print('generate {} from {} for conveniency'.format(water_mask_file, geom_file))
-            if ut.run_or_skip(out_file=water_mask_file, in_file=geom_file) == 'run':
-                water_mask, atr = readfile.read(geom_file, datasetName='waterMask')
-                atr['FILE_TYPE'] = 'waterMask'
-                writefile.write(water_mask, out_file=water_mask_file, metadata=atr)
-
         # 4) add custom metadata (optional)
         if self.customTemplateFile:
             print('updating {}, {} metadata based on custom template file: {}'.format(
@@ -425,19 +416,28 @@ class TimeSeriesAnalysis:
     def run_network_modification(self, step_name):
         """Modify network of interferograms before the network inversion."""
         # check the existence of ifgramStack.h5
-        stack_file = ut.check_loaded_dataset(self.workDir, print_msg=False)[1]
+        stack_file, geom_file = ut.check_loaded_dataset(self.workDir, print_msg=False)[1:3]
         coh_txt = '{}_coherence_spatialAvg.txt'.format(os.path.splitext(os.path.basename(stack_file))[0])
         try:
             net_fig = [i for i in ['Network.pdf', 'pic/Network.pdf'] if os.path.isfile(i)][0]
         except:
             net_fig = None
 
-        # 1) modify network
+        # 1) output waterMask.h5 to simplify the detection/use of waterMask
+        water_mask_file = 'waterMask.h5'
+        if 'waterMask' in readfile.get_dataset_list(geom_file):
+            print('generate {} from {} for conveniency'.format(water_mask_file, geom_file))
+            if ut.run_or_skip(out_file=water_mask_file, in_file=geom_file) == 'run':
+                water_mask, atr = readfile.read(geom_file, datasetName='waterMask')
+                atr['FILE_TYPE'] = 'waterMask'
+                writefile.write(water_mask, out_file=water_mask_file, metadata=atr)
+
+        # 2) modify network
         scp_args = '{} -t {}'.format(stack_file, self.templateFile)
         print('modify_network.py', scp_args)
         mintpy.modify_network.main(scp_args.split())
 
-        # 2) plot network
+        # 3) plot network
         scp_args = '{} -t {} --nodisplay'.format(stack_file, self.templateFile)
         print('\nplot_network.py', scp_args)
         if ut.run_or_skip(out_file=net_fig,
@@ -445,21 +445,19 @@ class TimeSeriesAnalysis:
                           check_readable=False) == 'run':
             mintpy.plot_network.main(scp_args.split())
 
-        # 3) aux files: maskConnComp and avgSpatialCoh
+        # 4) aux files: maskConnComp and avgSpatialCoh
         self.generate_ifgram_aux_file()
         return
 
 
     def generate_ifgram_aux_file(self):
-        """Generate auxiliary files from ifgramStack file, including:
-        
-        """
+        """Generate auxiliary files from ifgramStack file"""
         stack_file = ut.check_loaded_dataset(self.workDir, print_msg=False)[1]
-        cc_mask_file = 'maskConnComp.h5'
+        mask_file = 'maskConnComp.h5'
         coh_file = 'avgSpatialCoh.h5'
 
         # 1) generate mask file from the common connected components
-        scp_args = '{} --nonzero -o {} --update'.format(stack_file, cc_mask_file)
+        scp_args = '{} --nonzero -o {} --update'.format(stack_file, mask_file)
         print('\ngenerate_mask.py', scp_args)
         mintpy.generate_mask.main(scp_args.split())
 
@@ -478,6 +476,7 @@ class TimeSeriesAnalysis:
         """
         stack_file = ut.check_loaded_dataset(self.workDir, print_msg=False)[1]
         coh_file = 'avgSpatialCoh.h5'
+
         scp_args = '{} -t {} -c {}'.format(stack_file, self.templateFile, coh_file)
         print('reference_point.py', scp_args)
         mintpy.reference_point.main(scp_args.split())

--- a/test/FernandinaSenDT128.txt
+++ b/test/FernandinaSenDT128.txt
@@ -24,4 +24,5 @@ mintpy.troposphericDelay.weatherModel           = ECMWF
 mintpy.topographicResidual.pixelwiseGeometry    = no
 mintpy.topographicResidual.stepFuncDate         = 20170910,20180613  #eruption dates
 mintpy.deramp                                   = linear
+mintpy.save.hdfEos5                             = yes
 

--- a/test/KujuAlosAT422F650.txt
+++ b/test/KujuAlosAT422F650.txt
@@ -23,6 +23,7 @@ mintpy.networkInversion.weightFunc              = no
 mintpy.troposphericDelay.weatherModel           = ECMWF
 mintpy.topographicResidual.pixelwiseGeometry    = no
 mintpy.deramp                                   = linear
+mintpy.save.hdfEos5                             = yes
 
 ##————————————————————————————— HDF-EOS5 Attributes -—————————————————————————##
 beam_mode           = SM

--- a/test/WellsEnvD2T399.txt
+++ b/test/WellsEnvD2T399.txt
@@ -23,6 +23,7 @@ mintpy.networkInversion.weightFunc              = no
 mintpy.troposphericDelay.weatherModel           = ECMWF
 mintpy.topographicResidual.stepFuncDate         = 20080221
 mintpy.topographicResidual.pixelwiseGeometry    = no
+mintpy.save.hdfEos5         = yes
 
 ##------------------------  HDF-EOS5 --------------------------------##
 mission             = Env                 # ERS,ENV,S1,RS1,RS2,CSK,TSX,JERS,ALOS,ALOS2


### PR DESCRIPTION
+ dem_error.py: ignore pixels with NaN value in any of the geometry dataset, which caused the initial error in #172.

+ prep_aria.py: add more notes in example

+ smallbaselineApp.py: move waterMask.h5 generation from step `load_data` to `modify_network`, so that `smallbaselineApp.py --dostep load_data` is equivalent to `load_data.py` and `prep_aria.py`.