### PR TITLE
adding block by block writing for timeseries inversion

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -568,8 +568,8 @@ def write2hdf5_file(ifgram_file, metadata, ts, temp_coh, num_inv_ifg=None,
     writefile.write(num_inv_ifg, out_file=out_file, metadata=metadata)
     return
 
-def write2hdf5_auxFiles(ifgram_file, metadata, temp_coh, num_inv_ifg=None,
-                    suffix='', inps=None):
+
+def write2hdf5_auxFiles(metadata, temp_coh, num_inv_ifg=None, suffix='', inps=None):
 
     # File 2 - temporalCoherence.h5
     out_file = '{}{}.h5'.format(suffix, os.path.splitext(inps.outfile[1])[0])
@@ -586,6 +586,7 @@ def write2hdf5_auxFiles(ifgram_file, metadata, temp_coh, num_inv_ifg=None,
     writefile.write(num_inv_ifg, out_file=out_file, metadata=metadata)
 
     return None
+
 
 def split_ifgram_file(ifgram_file, chunk_size=100e6):
     """Split ifgramStack file into several smaller files."""
@@ -1096,8 +1097,6 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
 
     # Loop
     if not inps.parallel:
-        print('-'*50)
-        print('converting phase to range')
         ts_file = '{}.h5'.format(os.path.splitext(inps.outfile[0])[0])
         phase2range = -1*float(stack_obj.metadata['WAVELENGTH'])/(4.*np.pi)
 
@@ -1138,6 +1137,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
             # block = [zStart, zEnd, yStart, yEnd, xStart, xEnd]
             block = [0, num_date, box[1], box[3], box[0], box[2]]
             # convert phase 2 range change
+            print('converting phase to range')
             tsi *= phase2range
             temp_coh[box[1]:box[3], box[0]:box[2]] = temp_cohi
             num_inv_ifg[box[1]:box[3], box[0]:box[2]] = ifg_numi
@@ -1244,7 +1244,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
         # for dask still use the old function to write. This needs also migrate to block-by-block writing
         write2hdf5_file(ifgram_file, metadata, ts, temp_coh, num_inv_ifg, suffix='', inps=inps)
     else:
-        write2hdf5_auxFiles(ifgram_file, metadata, temp_coh, num_inv_ifg, suffix='', inps=inps)
+        write2hdf5_auxFiles(metadata, temp_coh, num_inv_ifg, suffix='', inps=inps)
 
     m, s = divmod(time.time()-start_time, 60)
     print('time used: {:02.0f} mins {:02.1f} secs.\n'.format(m, s))

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -568,6 +568,24 @@ def write2hdf5_file(ifgram_file, metadata, ts, temp_coh, num_inv_ifg=None,
     writefile.write(num_inv_ifg, out_file=out_file, metadata=metadata)
     return
 
+def write2hdf5_auxFiles(ifgram_file, metadata, temp_coh, num_inv_ifg=None,
+                    suffix='', inps=None):
+
+    # File 2 - temporalCoherence.h5
+    out_file = '{}{}.h5'.format(suffix, os.path.splitext(inps.outfile[1])[0])
+    metadata['FILE_TYPE'] = 'temporalCoherence'
+    metadata['UNIT'] = '1'
+    print('-'*50)
+    writefile.write(temp_coh, out_file=out_file, metadata=metadata)
+
+    # File 3 - numInvIfgram.h5
+    out_file = 'numInvIfgram{}.h5'.format(suffix)
+    metadata['FILE_TYPE'] = 'mask'
+    metadata['UNIT'] = '1'
+    print('-'*50)
+    writefile.write(num_inv_ifg, out_file=out_file, metadata=metadata)
+
+    return None
 
 def split_ifgram_file(ifgram_file, chunk_size=100e6):
     """Split ifgramStack file into several smaller files."""
@@ -1059,13 +1077,46 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
     # Initialization of output matrix
     stack_obj = ifgramStack(ifgram_file)
     stack_obj.open(print_msg=False)
-    ts     = np.zeros((num_date, length, width), np.float32)
+    pbase = stack_obj.get_perp_baseline_timeseries(dropIfgram=True)
+    date_list = stack_obj.get_date_list(dropIfgram=True)
+
+    #ts     = np.zeros((num_date, length, width), np.float32)
     #ts_std = np.zeros((num_date, length, width), np.float32)
     temp_coh    = np.zeros((length, width), np.float32)
     num_inv_ifg = np.zeros((length, width), np.int16)
 
+    # metadata
+    metadata = dict(stack_obj.metadata)
+    for key in configKeys:
+        metadata[key_prefix+key] = str(vars(inps)[key])
+
+    metadata['REF_DATE'] = date_list[0]
+    metadata['FILE_TYPE'] = 'timeseries'
+    metadata['UNIT'] = 'm'
+
     # Loop
     if not inps.parallel:
+        print('-'*50)
+        print('converting phase to range')
+        ts_file = '{}.h5'.format(os.path.splitext(inps.outfile[0])[0])
+        phase2range = -1*float(stack_obj.metadata['WAVELENGTH'])/(4.*np.pi)
+
+        # instantiate a timeseries object
+        ts_obj = timeseries(ts_file)
+
+        # A dictionary of the datasets which we like to have in the timeseries
+        dsNameDict = {
+                "date": ((np.dtype('S8'), (num_date,))) ,   
+                "bperp": (np.float32, (num_date,)),
+                "timeseries": (np.float32, (num_date, length, width)),
+            }
+
+        # layout the HDF5 file for the datasets and the metadata
+        ts_obj.layout_hdf5(dsNameDict, metadata)
+
+        # open the created HDF5 and leave it open for block by block writing
+        ts_obj.openH5()
+
         for i in range(num_box):
             box = box_list[i]
             if num_box > 1:
@@ -1083,10 +1134,21 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
                                                 min_redundancy=inps.minRedundancy,
                                                 water_mask_file=inps.waterMaskFile)
 
-            ts[:, box[1]:box[3], box[0]:box[2]] = tsi
-            #ts_std[:, box[1]:box[3], box[0]:box[2]] = ts_stdi
+            # create a list which indicates the 3D block indices
+            # block = [zStart, zEnd, yStart, yEnd, xStart, xEnd]
+            block = [0, num_date, box[1], box[3], box[0], box[2]]
+            # convert phase 2 range change
+            tsi *= phase2range
             temp_coh[box[1]:box[3], box[0]:box[2]] = temp_cohi
             num_inv_ifg[box[1]:box[3], box[0]:box[2]] = ifg_numi
+            # write this block of timeseries to disk
+            ts_obj.write2hdf5_block(tsi, 'timeseries', block)
+
+        date_list_utf8 = [dt.encode('utf-8') for dt in date_list]
+        ts_obj.write2hdf5_block(date_list_utf8, 'date')
+        ts_obj.write2hdf5_block(pbase, 'bperp')
+
+        ts_obj.close()
 
     # Parallel loop
     else:
@@ -1098,6 +1160,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
         except ImportError:
             raise ImportError('Cannot import dask.distributed or dask_jobqueue!')
 
+        ts     = np.zeros((num_date, length, width), np.float32)
         python_executable_location = sys.executable
 
         # Look at the ~/.config/dask/dask_mintpy.yaml file for Changing the Dask configuration defaults
@@ -1177,11 +1240,11 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
     num_inv_ifg[ref_y, ref_x] = num_ifgram
     temp_coh[ref_y, ref_x] = 1.
 
-    # metadata
-    metadata = dict(stack_obj.metadata)
-    for key in configKeys:
-        metadata[key_prefix+key] = str(vars(inps)[key])
-    write2hdf5_file(ifgram_file, metadata, ts, temp_coh, num_inv_ifg, suffix='', inps=inps)
+    if inps.parallel:
+        # for dask still use the old function to write. This needs also migrate to block-by-block writing
+        write2hdf5_file(ifgram_file, metadata, ts, temp_coh, num_inv_ifg, suffix='', inps=inps)
+    else:
+        write2hdf5_auxFiles(ifgram_file, metadata, temp_coh, num_inv_ifg, suffix='', inps=inps)
 
     m, s = divmod(time.time()-start_time, 60)
     print('time used: {:02.0f} mins {:02.1f} secs.\n'.format(m, s))

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -297,11 +297,9 @@ class timeseries:
             self.f[dsname][block[0]:block[1], block[2]:block[3], block[4]:block[5]] = data
 
         elif len(block) == 4:
-            print("writing block : ", block)
             self.f[dsname][block[0]:block[1], block[2]:block[3]] = data
 
         elif len(block) == 2:
-            print("writing block : ", block)
             self.f[dsname][block[0]:block[1]] = data
 
         return None

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -140,6 +140,10 @@ class timeseries:
         self.name = 'timeseries'
         self.file_structure = FILE_STRUCTURE_TIMESERIES
 
+    def openH5(self, mode='a'):
+        print('opening {} in {} mode'.format(self.file, mode))
+        self.f = h5py.File(self.file, mode)
+
     def close(self, print_msg=True):
         try:
             self.f.close()
@@ -147,6 +151,8 @@ class timeseries:
                 print('close timeseries file: {}'.format(os.path.basename(self.file)))
         except:
             pass
+    
+    
 
     def open(self, print_msg=True):
         if print_msg:
@@ -242,6 +248,63 @@ class timeseries:
             data = ds[dateFlag, box[1]:box[3], box[0]:box[2]]
             data = np.squeeze(data)
         return data
+
+    def layout_hdf5(self, dsNameDict, metadata, compression=None):
+        print('-'*50)
+        print('create HDF5 file {} with w mode'.format(self.file))
+        h5 = h5py.File(self.file, "w") 
+
+        for key in dsNameDict.keys():
+            print("create dataset: {d:<25} of {t:<25} in size of {s}".format(
+                d=key,
+                t=str(dsNameDict[key][0]),
+                s=dsNameDict[key][1]))
+
+            h5.create_dataset(key,
+                          shape=dsNameDict[key][1],
+                          dtype=dsNameDict[key][0],
+                          chunks=True,
+                          compression=compression)
+
+        # write attributes
+        metadata = dict(metadata)
+        metadata['FILE_TYPE'] = self.name
+        for key in metadata.keys():
+            h5.attrs[key] = metadata[key]
+
+        print('close HDF5 file {}'.format(self.file))
+        h5.close()
+
+        return None
+
+    def write2hdf5_block(self, data, dsname, block=None):
+        if block is None:
+            if type(data)==list:
+                shape=(len(data),)
+            else:
+                shape = data.shape
+
+            if len(shape) ==1:
+                block = [0, shape[0]]
+            elif len(shape) == 2:
+                block = [0, shape[0], 0, shape[1]]
+            elif len(shape) == 3:
+                zSize , ySize, xSize = data.shape
+                block = [0, zSize, 0, ySize, 0, xSize]
+        
+        if len(block) == 6:
+            print("writing block : ", block)
+            self.f[dsname][block[0]:block[1], block[2]:block[3], block[4]:block[5]] = data
+
+        elif len(block) == 4:
+            print("writing block : ", block)
+            self.f[dsname][block[0]:block[1], block[2]:block[3]] = data
+
+        elif len(block) == 2:
+            print("writing block : ", block)
+            self.f[dsname][block[0]:block[1]] = data
+
+        return None
 
     def write2hdf5(self, data, outFile=None, dates=None, bperp=None, metadata=None, refFile=None, compression=None):
         """

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -292,8 +292,8 @@ class timeseries:
                 zSize , ySize, xSize = data.shape
                 block = [0, zSize, 0, ySize, 0, xSize]
         
+        print("writing dataset /{:<25} block: {}".format(dsname, block))
         if len(block) == 6:
-            print("writing block : ", block)
             self.f[dsname][block[0]:block[1], block[2]:block[3], block[4]:block[5]] = data
 
         elif len(block) == 4:

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -279,7 +279,7 @@ class timeseries:
 
     def write2hdf5_block(self, data, dsname, block=None):
         if block is None:
-            if type(data)==list:
+            if isinstance(data, list):
                 shape=(len(data),)
             else:
                 shape = data.shape


### PR DESCRIPTION
This PR is the first attempt for a block by block writing of the time-series.
1) object/stack.py: 
         - added new methods to separate dataset creation from writing
         - added a list of indices to represent the 3D block in the new write method for timeseries class
         - added a method openH5 which simply opens the HDF5 file when called
2) ifgram_inversion.py:
         now writing each block of timeseries is done right after estimating that block

Note:
      For Dask, the writing has not changed. 
      If we agree that this is the way to go, then we should do similar thing for other files (tempCoh, etc) and for Dask inversion and for few other steps (e.g., DEM error correction, etc).