### PR TITLE
ignore ZERO value for coherence in ifgramStack.spatial_average()

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -818,6 +818,9 @@ class ifgramStack:
                 data = dset[i, box[1]:box[3], box[0]:box[2]]
                 if maskFile:
                     data[mask == 0] = np.nan
+                # ignore ZERO value for coherence
+                if datasetName == 'coherence':
+                    data[data == 0] = np.nan
                 dmean[i] = np.nanmean(data)
                 sys.stdout.write('\rreading interferogram {}/{} ...'.format(i+1, numIfgram))
                 sys.stdout.flush()

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -101,7 +101,7 @@ def create_parser():
     step = parser.add_argument_group('steps processing (start/end/dostep)', STEP_HELP)
     step.add_argument('--start', dest='startStep', metavar='STEP', default=STEP_LIST[0],
                       help='start processing at the named step, default: {}'.format(STEP_LIST[0]))
-    step.add_argument('--end', dest='endStep', metavar='STEP',  default=STEP_LIST[-1],
+    step.add_argument('--end','--stop', dest='endStep', metavar='STEP',  default=STEP_LIST[-1],
                       help='end processing at the named step, default: {}'.format(STEP_LIST[-1]))
     step.add_argument('--dostep', dest='doStep', metavar='STEP',
                       help='run processing at the named step only')


### PR DESCRIPTION
**Description of proposed changes**

+ ignore ZERO value in ifgramStack.spatial_average() if input dataset is coherence so that pixels with zero value won't be taken into account while calculating the average spatial coherence of the ifgramStack file.

+ add `--stop` as an alternative for the `--end` option in smallbaselineApp.py

**Reminders**

- [x] Fix #195
- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.