### PR TITLE
update MODIFICATION_TIME for all ifgramDatasetnames in modify_network step

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -1075,12 +1075,12 @@ class ifgramStack:
             print('update HDF5 dataset "/dropIfgram".')
             f['dropIfgram'][:] = np.array([i not in date12List_to_drop 
                                            for i in date12ListAll], dtype=np.bool_)
-            # update MODIFICATION_TIME for unwrapPhase datasets
-            f['unwrapPhase'].attrs['MODIFICATION_TIME'] = str(time.time())
-            dsName = 'unwrapPhase_bridging'
-            if dsName in f.keys():
-                time.sleep(1)   #to distinguish the modification time of input files
-                f[dsName].attrs['MODIFICATION_TIME'] = str(time.time())
+            # update MODIFICATION_TIME for all datasets in ifgramDatasetNames
+            for dsName in ifgramDatasetNames:
+                if dsName in f.keys():
+                    f[dsName].attrs['MODIFICATION_TIME'] = str(time.time())
+                    time.sleep(1)   #to distinguish the modification time of input files
+
 ################################# ifgramStack class end ################################
 
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -1078,6 +1078,7 @@ class ifgramStack:
             # update MODIFICATION_TIME for all datasets in ifgramDatasetNames
             for dsName in ifgramDatasetNames:
                 if dsName in f.keys():
+                    print('update MODIFICATION_TIME in HDF5 dataset "/{}"'.format(dsName))
                     f[dsName].attrs['MODIFICATION_TIME'] = str(time.time())
                     time.sleep(1)   #to distinguish the modification time of input files
 


### PR DESCRIPTION
**Description of proposed changes**

This PR update the MODIFICATION_TIME metadata value for all datasets defined in objects.stack.ifgramDatasetNames while calling ifgramStack.update_drop_ifgram() function from modify_network.py in the modify_network step.

**Reminders**

- [x] Fix #197
- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

