### PR TITLE
add template option for not applying shadow mask for mask of reliable pixels

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -117,6 +117,7 @@ mintpy.networkInversion.walltime    = auto #[HH:MM], auto for 00:40, walltime fo
 ## Temporal coherence is calculated and used to generate final mask (Pepe & Lanari, 2006, IEEE-TGRS)
 mintpy.networkInversion.minTempCoh  = auto #[0.0-1.0], auto for 0.7, min temporal coherence for mask
 mintpy.networkInversion.minNumPixel = auto #[int > 0], auto for 100, min number of pixels in mask above
+mintpy.networkInversion.shadowMask  = auto #[yes / no], auto for yes [if shadowMask is in geometry file] or no.
 
 
 ########## Local Oscillator Drift (LOD) Correction (for Envisat only)

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -52,6 +52,7 @@ mintpy.networkInversion.residualNorm     = L2
 
 mintpy.networkInversion.minTempCoh       = 0.7
 mintpy.networkInversion.minNumPixel      = 100
+mintpy.networkInversion.shadowMask       = yes
 
 mintpy.networkInversion.parallel         = no
 mintpy.networkInversion.numWorker        = 40

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -649,7 +649,7 @@ def main(iargs=None):
         geomRadarObj.write2hdf5(outputFile=inps.outfile[1],
                                 access_mode='w',
                                 box=box,
-                                compression='gzip',
+                                compression='lzf',
                                 extra_metadata=extraDict)
 
     if geomGeoObj and update_object(inps.outfile[2], geomGeoObj, boxGeo, updateMode=updateMode):
@@ -657,7 +657,7 @@ def main(iargs=None):
         geomGeoObj.write2hdf5(outputFile=inps.outfile[2],
                               access_mode='w',
                               box=boxGeo,
-                              compression='gzip')
+                              compression='lzf')
 
     return inps.outfile
 

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -410,7 +410,7 @@ class geometryDict:
         #self.metadata['PROCESSOR'] = self.processor
         return self.metadata
 
-    def write2hdf5(self, outputFile='geometryRadar.h5', access_mode='w', box=None, compression='gzip', extra_metadata=None):
+    def write2hdf5(self, outputFile='geometryRadar.h5', access_mode='w', box=None, compression='lzf', extra_metadata=None):
         '''
         /                        Root level
         Attributes               Dictionary for metadata. 'X/Y_FIRST/STEP' attribute for geocoded.

--- a/mintpy/process_isce_stack.py
+++ b/mintpy/process_isce_stack.py
@@ -3,6 +3,7 @@
 
 
 import os
+import glob
 import argparse
 import subprocess
 import configparser

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -549,8 +549,10 @@ class TimeSeriesAnalysis:
         tcoh_min = self.template['mintpy.networkInversion.minTempCoh']
 
         scp_args = '{} -m {} -o {}'.format(tcoh_file, tcoh_min, mask_file)
+
         # exclude pixels in shadow if shadowMask dataset is available
-        if 'shadowMask' in readfile.get_dataset_list(geom_file):
+        apply_shadow_mask = self.template['mintpy.networkInversion.shadowMask']
+        if apply_shadow_mask is True and 'shadowMask' in readfile.get_dataset_list(geom_file):
             scp_args += ' --base {} --base-dataset shadowMask --base-value 1'.format(geom_file)
         print('generate_mask.py', scp_args)
 


### PR DESCRIPTION
**Description of proposed changes**

+ Add `mintpy.networkInversion.shadowMask` to be able to not use shadowMask in geometry file while generating maskTempCoh.h5 [use it by defalt].

+ switch the HDF5 compression for geometry file from gzip to lzf by default.

+ fix bug of missing glob module in `process_isce_stack.py`.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
