### PR TITLE
bug fix for multilook with AZIMUTH_PIXEL_SIZE

### DIFF
--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -121,8 +121,10 @@ def multilook_attribute(atr_dict, lks_y, lks_x, print_msg=True):
     atr['YMIN'] = '0'
     atr['XMAX'] = str(width_mli-1)
     atr['YMAX'] = str(length_mli-1)
+    atr['RLOOKS'] = str(int(atr.get('RLOOKS', '1')) * lks_x)
+    atr['ALOOKS'] = str(int(atr.get('ALOOKS', '1')) * lks_y)
     if print_msg:
-        print('update LENGTH, WIDTH, YMIN, YMAX, XMIN, XMAX')
+        print('update LENGTH, WIDTH, Y/XMIN/MAX, A/RLOOKS')
 
     if 'Y_STEP' in atr.keys():
         atr['Y_STEP'] = str(lks_y * float(atr['Y_STEP']))
@@ -130,17 +132,15 @@ def multilook_attribute(atr_dict, lks_y, lks_x, print_msg=True):
         if print_msg:
             print('update Y/X_STEP')
 
-    if 'RANGE_PIXEL_SIZE' in atr.keys():
+    if 'AZIMUTH_PIXEL_SIZE' in atr.keys():
         atr['AZIMUTH_PIXEL_SIZE'] = str(lks_y * float(atr['AZIMUTH_PIXEL_SIZE']))
+        if print_msg:
+            print('update AZIMUTH_PIXEL_SIZE')
+
+    if 'RANGE_PIXEL_SIZE' in atr.keys():
         atr['RANGE_PIXEL_SIZE'] = str(lks_x * float(atr['RANGE_PIXEL_SIZE']))
         if print_msg:
-            print('update AZIMUTH/RANGE_PIXEL_SIZE')
-
-    if 'Y_FIRST' not in atr.keys() and 'ALOOKS' in atr.keys():
-        atr['RLOOKS'] = str(int(atr['RLOOKS']) * lks_x)
-        atr['ALOOKS'] = str(int(atr['ALOOKS']) * lks_y)
-        if print_msg:
-            print('update R/ALOOKS')
+            print('update RANGE_PIXEL_SIZE')
 
     if 'REF_Y' in atr.keys():
         atr['REF_Y'] = str(int(int(atr['REF_Y']) / lks_y))

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -31,9 +31,9 @@ def create_parser():
 
     parser.add_argument('file', nargs='+', help='File(s) to multilook')
     parser.add_argument('-r','--range','-x', dest='lks_x', type=int,
-                        help='number of multilooking in azimuth/y direction')
-    parser.add_argument('-a','--azimuth','-y', dest='lks_y', type=int,
                         help='number of multilooking in range  /x direction')
+    parser.add_argument('-a','--azimuth','-y', dest='lks_y', type=int,
+                        help='number of multilooking in azimuth/y direction')
     parser.add_argument('-o', '--outfile',
                         help='Output file name. Disabled when more than 1 input files')
     parser.add_argument('--no-parallel', dest='parallel', action='store_false', default=True,

--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -43,6 +43,7 @@ def create_parser():
 
 
 def cmd_line_parse(iargs=None):
+    print('{} {}'.format(os.path.basename(__file__), ' '.join(iargs)))
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
     inps.file = os.path.abspath(inps.file)
@@ -196,4 +197,4 @@ def main(iargs=None):
 
 ##########################################################################
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -190,6 +190,7 @@ def touch(fname_list, times=None):
 def get_lat_lon(meta, box=None):
     """extract lat/lon info of all grids into 2D matrix.
     For meta dict in geo-coordinates only.
+    Returned lat/lon are corresponds to the pixel center
     Parameters: meta : dict, including LENGTH, WIDTH and Y/X_FIRST/STEP
                 box  : 4-tuple of int for (x0, y0, x1, y1)
     Returns:    lats : 2D np.array for latitude  in size of (length, width)
@@ -204,8 +205,8 @@ def get_lat_lon(meta, box=None):
     # generate 2D matrix for lat/lon
     lat_step = float(meta['Y_STEP'])
     lon_step = float(meta['X_STEP'])
-    lat0 = float(meta['Y_FIRST']) + lat_step * box[1]
-    lon0 = float(meta['X_FIRST']) + lon_step * box[0]
+    lat0 = float(meta['Y_FIRST']) + lat_step * (box[1] + 0.5)
+    lon0 = float(meta['X_FIRST']) + lon_step * (box[0] + 0.5)
     lat1 = lat0 + lat_step * lat_num
     lon1 = lon0 + lon_step * lon_num
     lats, lons = np.mgrid[lat0:lat1:lat_num*1j,


### PR DESCRIPTION
**Description of proposed changes**
multilook:
+ check AZIMUTH_PXIEL_SIZE specifically, as it is not currently available from ARIA products yet #216.
+ use A/RLOOKS always with default value of 1 if not exists.

utils/utils0.get_lat_lon(): return the lat/lon of the pixel center instead of the upper left corner previously.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
