### PR TITLE
unw_err_phase_closure: import mpl with Agg backend

### DIFF
--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -11,6 +11,7 @@ import argparse
 import time
 import h5py
 import numpy as np
+import matplotlib; matplotlib.use("Agg")  # Force matplotlib to not use any Xwindows backend.
 import matplotlib.pyplot as plt
 try:
     from cvxopt import matrix


### PR DESCRIPTION
**Description of proposed changes**

Force matplotlib to use Agg backend without requiring Xwindows display, because unwrap_error_phase_closure.py does not need an interactive display.

**Reminders**

- [x] Fix #223 
- [ ] Pass Codacy code review (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.