### PR TITLE
save_gbis: add --ellipsoid2geoid option

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,12 +27,11 @@ docker pull andretheronsa/mintpy:latest
 
 ### 1. Download and setup MintPy ###
 
-To use the package, you need to setup the environment a) by adding _${MINTPY_HOME}_ to your _$PYTHONPATH_ to make mintpy importable in Python and b) by adding _${MINTPY_HOME}/mintpy_ to your _$path_ to make application scripts executable in command line, as shown below.
+To use the package, you need to setup the environment a) by adding _${MINTPY_HOME}_ to your _$PYTHONPATH_ to make mintpy importable in Python and b) by adding _${MINTPY_HOME}/mintpy_ to your _$PATH_ to make application scripts executable in command line, as shown below.
 
 Add to your **_~/.bash_profile_** file for _bash_ user. For _tcsh_ user, check the example [here](https://github.com/yunjunz/macOS_Setup/blob/master/.tcshrc). Source the file for the first time. It will be sourced automatically next time when you login.
 
 ```bash
-############################  Python  ###############################
 if [ -z ${PYTHONPATH+x} ]; then export PYTHONPATH=""; fi
 
 ##--------- MintPy ------------------##

--- a/mintpy/asc_desc2horz_vert.py
+++ b/mintpy/asc_desc2horz_vert.py
@@ -15,7 +15,7 @@ from mintpy.utils import readfile, writefile, utils as ut
 ################################################################################
 REFERENCE = """reference:
   Wright, T. J., B. E. Parsons, and Z. Lu (2004), Toward mapping surface deformation
-    in three dimensions using InSAR, Geophysical Research Letters, 31(1), n/a-n/a, 
+    in three dimensions using InSAR, Geophysical Research Letters, 31(1), n/a-n/a,
     doi:10.1029/2003GL018827.
 """
 
@@ -100,7 +100,7 @@ def get_overlap_lalo(atr1, atr2):
     Inputs:
         atr1/2 - dict, attribute dictionary of two input files in geo coord
     Outputs:
-        W/E/S/N - float, West/East/South/North in deg 
+        W/E/S/N - float, West/East/South/North in deg
     """
     W1, E1, S1, N1 = ut.four_corners(atr1)
     W2, E2, S2, N2 = ut.four_corners(atr2)
@@ -116,7 +116,7 @@ def get_overlap_lalo(atr1, atr2):
 def get_design_matrix(atr1, atr2, az_angle=90):
     """Get the design matrix A to convert asc/desc to hz/up.
     Only asc + desc -> hz + up is implemented for now.
-    
+
     Project displacement from LOS to Horizontal and Vertical components
         math for 3D: cos(theta)*Uz - cos(alpha)*sin(theta)*Ux + sin(alpha)*sin(theta)*Uy = Ulos
         math for 2D: cos(theta)*Uv - sin(alpha-az)*sin(theta)*Uh = Ulos   #Uh_perp = 0.0
@@ -244,7 +244,7 @@ def main(iargs=None):
     else:
         print('writing horizontal component to file: '+inps.outfile[0])
         writefile.write(dH, out_file=inps.outfile[0], metadata=atr)
-    
+
         print('writing   vertical component to file: '+inps.outfile[1])
         writefile.write(dV, out_file=inps.outfile[1], metadata=atr)
 

--- a/mintpy/load_gbis.py
+++ b/mintpy/load_gbis.py
@@ -12,6 +12,10 @@ import numpy as np
 import scipy.io as sio
 import matplotlib.pyplot as plt
 import pyproj
+# suppress UserWarning from matplotlib
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")
+
 from mintpy.utils import writefile
 
 
@@ -35,6 +39,11 @@ def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
     inps.file = os.path.abspath(inps.file)
+
+    # Backend setting
+    if not inps.disp_fig:
+            plt.switch_backend('Agg')
+
     return inps
 
 

--- a/mintpy/mask.py
+++ b/mintpy/mask.py
@@ -222,7 +222,8 @@ def mask_isce_file(in_file, mask_file, out_file=None):
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
 
-    if os.path.isfile(inps.file+'.xml'):
+    ext = os.path.splitext(inps.file)[1]
+    if os.path.isfile(inps.file+'.xml') and ext in ['.unw','.int','.cor','.conncomp']:
         mask_isce_file(inps.file, inps.mask_file, inps.outfile)
     else:
         mask_file(inps.file, inps.mask_file, inps.outfile, inps)

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -13,7 +13,6 @@ import sys
 import argparse
 import datetime as dt
 import numpy as np
-#import matplotlib; matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 # suppress UserWarning from matplotlib


### PR DESCRIPTION
**Description of proposed changes**

+ support converting height from ellipsoid to geoid for modeling with GBIS. This is required if the input DEM data is from ISCE or GSI DEHM data.

+ load/save_gbis: fix warning/backend issue for matplotlib

+ mask: restrict mask_isce_file() to ifgram files only

+ Update installation.md

**Reminders**

- [x] Pass Codacy code review (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.