### PR TITLE
update install via macports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Join our google group [https://groups.google.com/forum/#!forum/mintpy](https://g
 
 ### 5. Citing this work ###
 
-Yunjun, Z., H. Fattahi, F. Amelung (2019), Small baseline InSAR time series analysis: Unwrapping error correction and noise reduction, _Computers & Geosciences_, _133_, 104331 , doi:[10.1016/j.cageo.2019.104331](https://doi.org/10.1016/j.cageo.2019.104331), [ArXiv](https://eartharxiv.org/9sz6m/).
+Yunjun, Z., H. Fattahi, F. Amelung (2019), Small baseline InSAR time series analysis: Unwrapping error correction and noise reduction, _Computers & Geosciences_, _133_, 104331, doi:[10.1016/j.cageo.2019.104331](https://doi.org/10.1016/j.cageo.2019.104331), [ArXiv](https://eartharxiv.org/9sz6m/).
 
 In addition to the above, we recommend that you cite the original publications that describe the algorithms used in your specific analysis.
 

--- a/docs/api/doc_generation.md
+++ b/docs/api/doc_generation.md
@@ -2,7 +2,7 @@ We use [Doxygen](http://www.doxygen.nl/) to generate the API documentation autom
 
 + Install Doxygen following [link](http://www.doxygen.nl/download.html) if you have not already doen so.
 
-+ Run doxygen command with `MintPy/docs/Doxyfile` to generate the API documentation in html and latex format (to `$MINTPY_HOME/../MINTPY_docs` by default).
++ Run doxygen command with `MintPy/docs/Doxyfile` to generate the API documentation in html and latex format (to `$MINTPY_HOME/docs/api_docs` by default).
 
 ```bash
 cd $MINTPY_HOME/docs/api

--- a/docs/google_earth.md
+++ b/docs/google_earth.md
@@ -22,9 +22,9 @@ MintPy use [pyKML](https://pythonhosted.org/pykml/) to generate KMZ (Keyhole Mar
 
 ### Notes for developers ###
 
-save_kmz_timeseries.py takes the 3D HDF5 file and outputs a KMZ file at multiple levels of details (LODs). It subsets of the data into regionalized boxes, writes the required KML files, references the appropriate auxiliary resources, and zips all of the files together into a KMZ file. 
+save_kmz_timeseries.py takes the 3D HDF5 file and outputs a KMZ file at multiple levels of details (LODs). It divides the data matrix into regionalized boxes, writes the required KML files, references the appropriate auxiliary resources, and zips all of the files together into a KMZ file. 
 
-The script also embeds a javascript using [dygraphs](http://dygraphs.com) for interactive plot of the time-series deformation at each latitude, longitude point included in the original dataset. This allows for the user to select any of the onscreen placemarks and view a timeseries chart displaying the timeseries data from that unique geographic coordinate. The Placemarks are colored onscreen based on their deformation velocity, as computed from a velocity data file.
+The script also embeds a javascript using [dygraphs](http://dygraphs.com) for interactive plot of the time-series deformation at each point. This allows the user to select any placemark onscreen to display the time-series data in an interactive chart. The Placemarks are colored based on the velocity.
 
 #### KML and KMZ Performance ####
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,15 +124,13 @@ Run the following in your terminal in _bash_:
 sudo port install $(cat $MINTPY_HOME/docs/ports.txt)
 
 # install dependencies not available on macports: pykml, pykdtree, pyresample, cdsapi, pyhdf
-sudo /opt/local/bin/pip install git+https://github.com/tylere/pykml.git
-sudo /opt/local/bin/pip install git+https://github.com/storpipfugl/pykdtree.git
-sudo /opt/local/bin/pip install git+https://github.com/pytroll/pyresample.git
-sudo /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
-sudo /opt/local/bin/pip install git+https://github.com/fhs/pyhdf.git
-
-# install the basemap-dev version [remove after basemap-v1.2 release]
 # run "sudo port uninstall py36-matplotlib-basemap" if basemap was installed with port
-sudo /opt/local/bin/pip install git+https://github.com/matplotlib/basemap.git#egg=mpl_toolkits
+sudo -H /opt/local/bin/pip install git+https://github.com/tylere/pykml.git
+sudo -H /opt/local/bin/pip install git+https://github.com/storpipfugl/pykdtree.git
+sudo -H /opt/local/bin/pip install git+https://github.com/pytroll/pyresample.git
+sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
+sudo -H /opt/local/bin/pip install git+https://github.com/fhs/pyhdf.git
+sudo -H /opt/local/bin/pip install https://github.com/matplotlib/basemap/archive/v1.2.1rel.tar.gz
 ```
 
 ### Notes on [PyAPS](https://github.com/yunjunz/pyaps3) ###

--- a/docs/ports.txt
+++ b/docs/ports.txt
@@ -1,3 +1,4 @@
+gcc5
 gcc7
 cmake
 gmake
@@ -27,7 +28,7 @@ tiff
 openmotif
 subversion
 python27
-python36
+python37
 fftw +gcc7
 fftw-single +gcc7
 fftw-3 +gcc7
@@ -47,13 +48,13 @@ sfcgal
 bzr 
 git 
 rsync
-hdf4 
-hdf5 
+hdf5 +gcc7
 hdfeos 
 hdfeos5
 h5utils
-netcdf
+netcdf +gcc7
 netcdf-cxx
+netcdf-fortran
 ecCodes +gcc7
 postgresql95
 postgresql95-server
@@ -61,35 +62,30 @@ proj
 cairo
 scons
 pandoc
-opencv +gdal +python36
+opencv +python37
 gimp2
 ImageMagick
 samba3
 swig
 swig-python
-gdal +expat +geos +hdf4 +hdf5 +netcdf +openjpeg +postgresql95 +sqlite3 +grib
-py36-cython
-py36-mpi4py +gcc7 +openmpi
-py36-numpy +gcc7 +openblas
-py36-scipy +gcc7 +openblas
-py36-matplotlib +cairo +tkinter +webagg
-py36-pandas
-py36-sympy
-py36-yaml
-py36-simplejson
-py36-h5py
-py36-cartopy
-py36-shapely
-py36-fiona
-py36-networkx
-py36-scikit-image
-py36-ipython +notebook +parallel
-py36-dask
-py36-zmq
-py36-bokeh
-py36-dynd
-py36-sphinx
-py36-pip
+gdal +expat +geos +hdf5 +netcdf +openjpeg +postgresql95 +sqlite3
+py37-cython
+py37-mpi4py +gcc7 +openmpi
+py37-numpy +gcc7 +openblas
+py37-scipy +gcc7 +openblas
+py37-matplotlib +cairo +tkinter +webagg
+py37-pandas
+py37-yaml
+py37-h5py
+py37-cartopy
+py37-shapely
+py37-scikit-image
+py37-jupyter
+py37-dask
+py37-bokeh
+py37-sphinx
+py37-pip
+py37-cvxopt +accelerate +dsdp +fftw +glpk +gsl
 gmt5
 kealib
 pandoc
@@ -98,7 +94,7 @@ postgis2 +gui +postgresql95 +raster +sfcgal +topology
 wdiff
 cwdiff
 ndiff
-atlas +gcc7
+atlas +gcc5
 metis +gcc7
 parmetis +gcc7 +openmpi
 vecLibFort
@@ -108,4 +104,3 @@ superlu_dist +gcc7 +openmpi
 hypre +gcc7 +openmpi
 c2html
 sowing
-py36-cvxopt +accelerate +dsdp +fftw +glpk +gsl

--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -59,7 +59,7 @@ def search_gps(SNWE, start_date=None, end_date=None, site_list_file=None, print_
     t_end = np.array([dt(*time.strptime(i, "%Y-%m-%d")[0:5]) for i in txt_data[:, 8].astype(str)])
 
     # limit on space
-    idx = ((site_lats >= SNWE[0]) * (site_lats <= SNWE[1]) * 
+    idx = ((site_lats >= SNWE[0]) * (site_lats <= SNWE[1]) *
            (site_lons >= SNWE[2]) * (site_lons <= SNWE[3]))
 
     # limit on time
@@ -86,7 +86,7 @@ def get_baseline_change(dates1, pos_x1, pos_y1, pos_z1,
     for i in range(len(dates)):
         idx1 = np.where(dates1 == dates[i])[0][0]
         idx2 = np.where(dates2 == dates[i])[0][0]
-        basei = ((pos_x1[idx1] - pos_x2[idx2]) ** 2 
+        basei = ((pos_x1[idx1] - pos_x2[idx2]) ** 2
                + (pos_y1[idx1] - pos_y2[idx2]) ** 2
                + (pos_z1[idx1] - pos_z2[idx2]) ** 2) ** 0.5
         bases[i] = basei
@@ -113,8 +113,8 @@ def get_pos_years(gps_dir, site):
     years = [os.path.basename(i).split('.')[1] for i in fnames]
     years = ptime.yy2yyyy(years)
     return years
-    
-def read_GSI_F3(gps_dir, site, start_date=None, end_date=None):        
+
+def read_GSI_F3(gps_dir, site, start_date=None, end_date=None):
     year0 = int(start_date[0:4])
     year1 = int(end_date[0:4])
     num_year = year1 - year0 + 1

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -44,8 +44,8 @@ def create_parser():
     parser.add_argument('--test-pyaps', dest='test_pyaps', action='store_true',
                         help='Include testing of PyAPS.')
 
-    parser.add_argument('--dir', dest='test_dir', default='~/insarlab/test',
-                        help='test directory. Default: ~/insarlab/test')
+    parser.add_argument('--dir', dest='test_dir', default='~/data/test',
+                        help='test directory. Default: ~/data/test')
 
     parser.add_argument('--nofresh', dest='fresh_start', action='store_false',
                         help='Use exsiting files WITHOUT starting from the scratch.')


### PR DESCRIPTION
**Description of proposed changes**

docs/ports.txt:
1. switch to +gcc7 except for atlas, which supports gcc5 only
2. switch default python from 3.6 to 3.7
3. remove hdf4

docs/installation.md:
1. use released archive of basemap from GitHub, faster and smaller than git clone
2. use 'sudo -H' to solve the directory ownership issue.

typo fixes

Update default test directory in test_smallbaselineApp.py

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
