### PR TITLE
update conda install for basemap

### DIFF
--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -29,6 +29,5 @@ dependencies:
   - scikit-image
   - scipy
   - pip:
-    - git+https://github.com/matplotlib/basemap.git#egg=mpl_toolkits
     - git+https://github.com/tylere/pykml.git
-
+    - https://github.com/matplotlib/basemap/archive/v1.2.1rel.tar.gz

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,8 +84,8 @@ $PYTHON3DIR/bin/conda install --yes --file $MINTPY_HOME/docs/conda.txt
 
 # install dependencies not compatiable from conda: basemap, pykml
 # run "conda uninstall basemap" if basemap was installed with conda
-$PYTHON3DIR/bin/pip install git+https://github.com/matplotlib/basemap.git#egg=mpl_toolkits
 $PYTHON3DIR/bin/pip install git+https://github.com/tylere/pykml.git
+$PYTHON3DIR/bin/pip install https://github.com/matplotlib/basemap/archive/v1.2.1rel.tar.gz
 ```
 
 Or run the following in your terminal to install the dependencies to a new environment _mintpy_:


### PR DESCRIPTION
**Description of proposed changes**

use the release version instead of git clone for faster install and smaller download, both in command line and conda_env.yml

**Reminders**

- [x] Pass Codacy code review (green)