### PR TITLE
adjust cmy to green in center

### DIFF
--- a/docs/resources/colormaps/README.md
+++ b/docs/resources/colormaps/README.md
@@ -1,18 +1,29 @@
 ## Custom colormaps
 
-MintPy support all colormaps from [Matplotlib](https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html) and custom colormap files in **.cpt** (color palette tables) format. To add your own colormap, drop the corresponding .cpt file in `$MINTPY/docs/resources/colormaps`.
+MintPy support the following colormaps:
 
-To use `vik` colormap in view.py for example:
++ [Matplotlib colormaps](https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html)
++ Custom colormaps: `cmy` and `dismph`
++ Custom colormaps in **.cpt** (color palette tables) format. To add your own colormap, drop the corresponding .cpt file in `$MINTPY/docs/resources/colormaps`.
 
-```bash
-view.py velocity.h5 -c vik
-```
-
-The default colormap for phase/displacement data is `cmy`:
+We recommend to use cyclic colormap `cmy` for wrapped phase/displacement measurement.
 
 <p align="left">
-  <img width="280" src="https://yunjunzhang.files.wordpress.com/2020/01/cmap_cmy.png">
+  <img width="280" src="https://yunjunzhang.files.wordpress.com/2020/01/cmap_cmy-1.png">
 </p>
+
+To use colormap `cmy` in view.py:
+
+```bash
+view.py velocity.h5 -c cmy
+```
+
+To use colormap `cmy` in python:
+
+```python
+from mintpy.colors import ColormapExt
+cmap = ColormapExt('cmy').colromap
+```
 
 ### Colormaps from [GMT](http://www.soest.hawaii.edu/gmt/) ###
 

--- a/mintpy/objects/colors.py
+++ b/mintpy/objects/colors.py
@@ -229,6 +229,9 @@ class ColormapExt(ScalarMappable):
             rgbs[255,0] = 0
             rgbs[255,1] = 255
             rgbs[255,2] = 255
+            
+            rgbs = np.roll(rgbs, int(256/2-214), axis=0)  #shift green to the center
+            rgbs = np.flipud(rgbs)   #flip up-down so that orange is in the later half (positive)
 
             # color list --> colormap object
             colormap = LinearSegmentedColormap.from_list('cmy', rgbs/255., N=cmap_lut)

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -96,6 +96,7 @@ datasetUnitDict = {'unwrapPhase'        :'radian',
                    'ramp'               :'m',
                    'displacement'       :'m',
 
+                   'temporalCoherence'  :'1',
                    'velocity'           :'m/year',
                    'acceleration'       :'m/year^2',
                    'mask'               :'1',

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -15,6 +15,9 @@ from mintpy.objects import ifgramStack
 from mintpy.utils import (readfile,
                           utils as ut,
                           plot as pp)
+# suppress UserWarning from matplotlib
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")
 
 
 ###########################  Sub Function  #############################

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -399,6 +399,8 @@ def plot_slice(ax, data, metadata, inps=None):
     if not inps:
         inps = cmd_line_parse([''])
         inps = update_inps_with_file_metadata(inps, metadata)
+    if isinstance(inps.colormap, str):
+        inps.colormap = pp.ColormapExt(inps.colormap).colormap
 
     # read DEM 
     if inps.dem_file:


### PR DESCRIPTION
**Description of proposed changes**

+ adjust cmy colormap to be green in the center and orange for positive value by default.

+ update colormap file url

+ bugs fix

+ suppress matplotlib user warning in plot_network.py

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.