### PR TITLE
Added geos and basemap as conda packages to conda_env.yml

### DIFF
--- a/docs/conda.txt
+++ b/docs/conda.txt
@@ -1,4 +1,5 @@
 python>=3.6
+basemap
 cdsapi
 cvxopt
 dask>=1.0,<2.0

--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -9,6 +9,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.6
+  - basemap
   - cdsapi
   - cvxopt
   - dask>=1.0,<2.0
@@ -28,8 +29,6 @@ dependencies:
   - pyresample
   - scikit-image
   - scipy
-  - geos
-  - basemap
   - pip:
     - git+https://github.com/tylere/pykml.git
 

--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -3,7 +3,7 @@
 # remove environment : conda env remove -n mintpy
 # enter  environment : conda activate mintpy
 # exit   environment : conda deactivate
-name: MintPy
+name: mintpy
 channels:
   - conda-forge
   - defaults

--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -3,7 +3,7 @@
 # remove environment : conda env remove -n mintpy
 # enter  environment : conda activate mintpy
 # exit   environment : conda deactivate
-name: mintpy
+name: MintPy
 channels:
   - conda-forge
   - defaults
@@ -28,6 +28,8 @@ dependencies:
   - pyresample
   - scikit-image
   - scipy
+  - geos
+  - basemap
   - pip:
     - git+https://github.com/tylere/pykml.git
-    - https://github.com/matplotlib/basemap/archive/v1.2.1rel.tar.gz
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,9 +83,7 @@ $PYTHON3DIR/bin/conda config --add channels conda-forge
 $PYTHON3DIR/bin/conda install --yes --file $MINTPY_HOME/docs/conda.txt
 
 # install dependencies not compatiable from conda: basemap, pykml
-# run "conda uninstall basemap" if basemap was installed with conda
 $PYTHON3DIR/bin/pip install git+https://github.com/tylere/pykml.git
-$PYTHON3DIR/bin/pip install https://github.com/matplotlib/basemap/archive/v1.2.1rel.tar.gz
 ```
 
 Or run the following in your terminal to install the dependencies to a new environment _mintpy_:


### PR DESCRIPTION
Modified conda_env.yml file to include geos and basemap modules as conda installations; removed pip install basemap. This is intended to resolve issues with pip finding the proper geos lib files when installing basemap. 
