### PR TITLE
keep single date timeseries as 3D for common IO

### DIFF
--- a/mintpy/mask.py
+++ b/mintpy/mask.py
@@ -119,6 +119,7 @@ def mask_file(fname, mask_file, out_file, inps=None):
     mask = update_mask_with_inps(mask, inps)
 
     # masking input file
+    atr = readfile.read_attribute(fname)
     dsNames = readfile.get_dataset_list(fname)
     maxDigit = max([len(i) for i in dsNames])
     dsDict = {}
@@ -126,6 +127,12 @@ def mask_file(fname, mask_file, out_file, inps=None):
         if dsName not in ['coherence']:
             print('masking {d:<{w}} from {f} ...'.format(d=dsName, w=maxDigit, f=fname))
             data = readfile.read(fname, datasetName=dsName, print_msg=False)[0]
+            
+            # keep timeseries data as 3D matrix when there is only one acquisition
+            # because readfile.read() will squeeze it to 2D
+            if atr['FILE_TYPE'] == 'timeseries' and len(data.shape) == 2:
+                data = np.reshape(data, (1, data.shape[0], data.shape[1]))
+
             data = mask_matrix(data, mask, fill_value=inps.fill_value)
         dsDict[dsName] = data
 

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -186,6 +186,12 @@ def multilook_file(infile, lks_y, lks_x, outfile=None):
         print('multilooking {d:<{w}} from {f} ...'.format(
             d=dsName, w=maxDigit, f=os.path.basename(infile)))
         data = readfile.read(infile, datasetName=dsName, print_msg=False)[0]
+
+        # keep timeseries data as 3D matrix when there is only one acquisition
+        # because readfile.read() will squeeze it to 2D
+        if atr['FILE_TYPE'] == 'timeseries' and len(data.shape) == 2:
+            data = np.reshape(data, (1, data.shape[0], data.shape[1]))
+
         data = multilook_data(data, lks_y, lks_x)
         dsDict[dsName] = data
     atr = multilook_attribute(atr, lks_y, lks_x)

--- a/mintpy/subset.py
+++ b/mintpy/subset.py
@@ -293,11 +293,7 @@ def subset_file(fname, subset_dict_input, out_file=None):
     """
 
     # Input File Info
-    try:
-        atr = readfile.read_attribute(fname)
-    except:
-        return None
-
+    atr = readfile.read_attribute(fname)
     width = int(atr['WIDTH'])
     length = int(atr['LENGTH'])
     k = atr['FILE_TYPE']
@@ -354,6 +350,11 @@ def subset_file(fname, subset_dict_input, out_file=None):
         print('subsetting {d:<{w}} from {f} ...'.format(
             d=dsName, w=maxDigit, f=os.path.basename(fname)))
         data = readfile.read(fname, datasetName=dsName, print_msg=False)[0]
+
+        # keep timeseries data as 3D matrix when there is only one acquisition
+        # because readfile.read() will squeeze it to 2D
+        if atr['FILE_TYPE'] == 'timeseries' and len(data.shape) == 2:
+            data = np.reshape(data, (1, data.shape[0], data.shape[1]))
 
         # subset 2D data
         if len(data.shape) == 2:


### PR DESCRIPTION
**Description of proposed changes**

For timeseries FILE_TYPE dataset, keep the data as 3D matrix when there is only one acuiqisiotn (readfile.read() will squeeze it to 2D by default). To be consistent with the data structure definition and geocode.py

**Reminders**

- [x] Fix #272 
- [x] Pass Codacy code review (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.