### PR TITLE
bugs fix in plot_network.py

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 [![Latest version](https://img.shields.io/badge/latest%20version-v1.2-yellowgreen.svg)](https://github.com/insarlab/MintPy/releases)
 [![License](https://img.shields.io/badge/license-GPLv3-yellow.svg)](https://github.com/insarlab/MintPy/blob/master/LICENSE)
 [![Forum](https://img.shields.io/badge/forum-Google%20Group-orange.svg)](https://groups.google.com/forum/#!forum/mintpy)
-[![Citation](https://img.shields.io/badge/DOI-10.1016%2Fj.cageo.2019.104331-blue)](https://doi.org/10.1016/j.cageo.2019.104331)
+[![Citation](https://img.shields.io/badge/doi-10.1016%2Fj.cageo.2019.104331-blue)](https://doi.org/10.1016/j.cageo.2019.104331)
 
 ## MintPy ##
 

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -123,9 +123,9 @@ def create_parser():
                         'fim - Fisher Information Matrix as weight' +
                         'coh - spatial coherence\n' +
                         'no  - no/uniform weight')
-    parser.add_argument('--min-norm-velocity', dest='minNormVelocity', action='store_true',
-                        help=('Enable inversion with minimum-norm deformation velocity,'
-                              ' instead of minimum-norm deformation phase'))
+    parser.add_argument('--min-norm-phase', dest='minNormVelocity', action='store_false',
+                        help=('Enable inversion with minimum-norm deformation phase,'
+                              ' instead of the default minimum-norm deformation velocity.'))
     parser.add_argument('--norm', dest='residualNorm', default='L2', choices=['L1', 'L2'],
                         help='Inverse method used to residual optimization, L1 or L2 norm minimization. Default: L2')
 

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -132,13 +132,18 @@ def cmd_line_parse(iargs=None):
         # use template value
         key = 'mintpy.network.minCoherence'
         if key in inps.template.keys():
-            inps.cmap_vlist[1] = float(inps.template[key])
+            inps.cmap_vlist[1] = max(0.01, float(inps.template[key]))
         # calculate from dropped interferograms, if there is any
         elif len(inps.date12List_drop) > 0:
             idx_drop = [inps.date12List.index(i) for i in inps.date12List_drop]
             coh_drop = [inps.cohList[i] for i in idx_drop]
             inps.cmap_vlist[1] = max(coh_drop)
             print('max coherence of excluded interferograms: {}'.format(max(coh_drop)))
+        # update default cmap_vlist[0] value if the manually input cmap_vlist[1] is too small
+        if inps.cmap_vlist[1] <= inps.cmap_vlist[0]:
+            inps.cmap_vlist[0] = min(0, inps.cmap_vlist[1])
+    # in case the manually input list is not in order
+    inps.cmap_vlist = sorted(inps.cmap_vlist)
     inps.colormap = pp.ColormapExt(inps.cmap_name, vlist=inps.cmap_vlist).colormap
     return inps
 


### PR DESCRIPTION
**Description of proposed changes**

plot_network: fix bug when the input coherence cut value is smaller than the default 0.2 for start.

ifgram_inversion.py: turn off the minNormVelocity, to be consistent with smallbaselineApp_auto.cfg file.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
