### PR TITLE
Read list of dates in textfile for mintpy.network.referenceFile

### DIFF
--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -312,7 +312,7 @@ def get_date12_to_drop(inps):
 
     # reference file
     if inps.referenceFile:
-        date12_to_keep = ifgramStack(inps.referenceFile).get_date12_list(dropIfgram=True)
+        date12_to_keep = pnet.get_date12_list(inps.referenceFile, dropIfgram=True)
         print('--------------------------------------------------')
         print('use reference pairs info from file: {}'.format(inps.referenceFile))
         print('number of interferograms in reference: {}'.format(len(date12_to_keep)))

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -837,37 +837,14 @@ class ifgramStack:
 
     # Functions considering dropIfgram value
     def get_date12_list(self, dropIfgram=True):
-        try:
-            with h5py.File(self.file, 'r') as f:
-                dates = f['date'][:]
-                if dropIfgram:
-                    dates = dates[f['dropIfgram'][:], :]
-            mDates = np.array([i.decode('utf8') for i in dates[:, 0]])
-            sDates = np.array([i.decode('utf8') for i in dates[:, 1]])
-        except:
-            mDates, sDates = self.get_date12_txt()
-
+        with h5py.File(self.file, 'r') as f:
+            dates = f['date'][:]
+            if dropIfgram:
+                dates = dates[f['dropIfgram'][:], :]
+        mDates = np.array([i.decode('utf8') for i in dates[:, 0]])
+        sDates = np.array([i.decode('utf8') for i in dates[:, 1]])
         date12List = ['{}_{}'.format(i, j) for i, j in zip(mDates, sDates)]
         return date12List
-
-    def get_date12_txt(self):
-        """ 
-        Extract dates from a textfile, where each line contains ref and sec
-        Order of dates doesn't matter; separation string shouldn't matter
-        """
-        import re
-        mDates = []; sDates = []
-        with open(self.file, 'r') as f:
-            for i, line in enumerate(f):
-                if line.startswith('#'): continue # skip commented lines
-                dt  = re.search('(20\d+)\D*(20\d+)', line)
-                ref = dt.group(1)
-                sec = dt.group(2)
-                if int(sec) < int(ref): ref, sec = sec, ref
-                
-                mDates.append(ref)
-                sDates.append(sec)
-        return np.array(mDates), np.array(sDates)
 
     def get_drop_date12_list(self):
         with h5py.File(self.file, 'r') as f:

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -837,14 +837,37 @@ class ifgramStack:
 
     # Functions considering dropIfgram value
     def get_date12_list(self, dropIfgram=True):
-        with h5py.File(self.file, 'r') as f:
-            dates = f['date'][:]
-            if dropIfgram:
-                dates = dates[f['dropIfgram'][:], :]
-        mDates = np.array([i.decode('utf8') for i in dates[:, 0]])
-        sDates = np.array([i.decode('utf8') for i in dates[:, 1]])
+        try:
+            with h5py.File(self.file, 'r') as f:
+                dates = f['date'][:]
+                if dropIfgram:
+                    dates = dates[f['dropIfgram'][:], :]
+            mDates = np.array([i.decode('utf8') for i in dates[:, 0]])
+            sDates = np.array([i.decode('utf8') for i in dates[:, 1]])
+        except:
+            mDates, sDates = self.get_date12_txt()
+
         date12List = ['{}_{}'.format(i, j) for i, j in zip(mDates, sDates)]
         return date12List
+
+    def get_date12_txt(self):
+        """ 
+        Extract dates from a textfile, where each line contains ref and sec
+        Order of dates doesn't matter; separation string shouldn't matter
+        """
+        import re
+        mDates = []; sDates = []
+        with open(self.file, 'r') as f:
+            for i, line in enumerate(f):
+                if line.startswith('#'): continue # skip commented lines
+                dt  = re.search('(20\d+)\D*(20\d+)', line)
+                ref = dt.group(1)
+                sec = dt.group(2)
+                if int(sec) < int(ref): ref, sec = sec, ref
+                
+                mDates.append(ref)
+                sDates.append(sec)
+        return np.array(mDates), np.array(sDates)
 
     def get_drop_date12_list(self):
         with h5py.File(self.file, 'r') as f:

--- a/mintpy/utils/network.py
+++ b/mintpy/utils/network.py
@@ -153,7 +153,7 @@ def date12_list2index(date12_list, date_list=[]):
 def get_date12_list(fname, dropIfgram=False):
     """Read date12 info from input file: Pairs.list or multi-group hdf5 file
     Parameters: fname       - string, path/name of input multi-group hdf5 file or text file
-                dropIfgram  - bool, check the "DROP_IFGRAM" attribute or not for multi-group hdf5 file
+                dropIfgram  - bool, check the "dropIfgram" dataset in ifgramStack hdf5 file
     Returns:    date12_list - list of string in YYYYMMDD_YYYYMMDD format
     Example:
         date12List = get_date12_list('ifgramStack.h5')

--- a/mintpy/utils/network.py
+++ b/mintpy/utils/network.py
@@ -174,7 +174,7 @@ def get_date12_list(fname, dropIfgram=False):
         txtContent = np.loadtxt(fname, dtype=bytes).astype(str)
         if len(txtContent.shape) == 1:
             txtContent = txtContent.reshape(-1, 1)
-            date12_list = txtContent[0]
+            date12_list = txtContent.flatten().tolist()
         else:
             date12_list = [i for i in txtContent[:, 0]]    # for one interferogram
 #        date12_list = [i for i in txtContent[:, 0]]

--- a/mintpy/utils/network.py
+++ b/mintpy/utils/network.py
@@ -151,12 +151,10 @@ def date12_list2index(date12_list, date_list=[]):
 
 
 def get_date12_list(fname, dropIfgram=False):
-    """Read Date12 info from input file: Pairs.list or multi-group hdf5 file
-    Inputs:
-        fname       - string, path/name of input multi-group hdf5 file or text file
-        dropIfgram  - bool, check the "DROP_IFGRAM" attribute or not for multi-group hdf5 file
-    Output:
-        date12_list - list of string in YYMMDD-YYMMDD format
+    """Read date12 info from input file: Pairs.list or multi-group hdf5 file
+    Parameters: fname       - string, path/name of input multi-group hdf5 file or text file
+                dropIfgram  - bool, check the "DROP_IFGRAM" attribute or not for multi-group hdf5 file
+    Returns:    date12_list - list of string in YYYYMMDD_YYYYMMDD format
     Example:
         date12List = get_date12_list('ifgramStack.h5')
         date12List = get_date12_list('ifgramStack.h5', dropIfgram=True)
@@ -171,15 +169,13 @@ def get_date12_list(fname, dropIfgram=False):
         else:
             return None
     else:
-        txtContent = np.loadtxt(fname, dtype=bytes).astype(str)
-        if len(txtContent.shape) == 1:
-            txtContent = txtContent.reshape(-1, 1)
-            date12_list = txtContent.flatten().tolist()
-        else:
-            date12_list = [i for i in txtContent[:, 0]]    # for one interferogram
-#        date12_list = [i for i in txtContent[:, 0]]
+        date12_list = np.loadtxt(fname, dtype=bytes, usecols=0).astype(str).tolist()
+        # for txt file with only one interferogram
+        if isinstance(date12_list, str):
+            date12_list = [date12_list]
 
     date12_list = sorted(date12_list)
+    date12_list = ptime.yyyymmdd_date12(date12_list)
     return date12_list
 
 


### PR DESCRIPTION
It seems to me that MintPy should be able to read a text file of interferograms to include in the network (e.g. `mintpy.network.referenceFile = date12_list.txt`).
However, the function call seems to only read hdf5 files.
I wrote up a quick workaround:

The call to read the `mintpy.network.referenceFile` is wrapped in a try/except; it will proceed as usual if given a path to hdf5 file. 

otherwise, it calls the function I wrote `get_date12_txt`, which reads the file as text and searches each line for two dates (ref, secondary) of form YYYYmmdd. The regex i used should handle any separator (and any number of them) between the two dates. The order of the two dates per line does not matter.

Please let me know if this functionality already exists somewhere else, or what additional steps I can take to get this code in the way you would like. Thanks!
