### PR TITLE
Cluster

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -42,9 +42,8 @@ EXAMPLE = """example:
   ifgram_inversion.py  inputs/ifgramStack.h5 -w coh
 
   # parallel processing for HPC
-  # support LSF job scheduler, PBS should also work out of the box after changing module import
   ifgram_inversion.py  inputs/ifgramStack.h5 -w var --parallel
-  ifgram_inversion.py  inputs/ifgramStack.h5 -w var --parallel --parallel-workers-num 25
+  ifgram_inversion.py  inputs/ifgramStack.h5 -w var --parallel --num-worker 25
 """
 
 TEMPLATE = """
@@ -155,12 +154,13 @@ def create_parser():
     par = parser.add_argument_group('parallel', 'parallel processing configuration for Dask')
     par.add_argument('--parallel', dest='parallel', action='store_true',
                      help='Enable parallel processing for the pixelwise weighted inversion.')
-    par.add_argument('--parallel-type', '--cluster', '--cluster-type', dest='cluster', type=str, default='SLURM',
-                     choices={'LSF', 'PBS', 'SLURM'}, help='The type of HPC cluster you are running on.')
-    par.add_argument('--parallel-workers-num','--par-workers-num','--parallel-num', dest='numWorker', type=int,
-                     default=40, help='Specify the number of workers the Dask cluster should use. Default: 40')
-    par.add_argument('--parallel-walltime','--par-walltime','--parallel-walltime', dest='walltime', type=str,
-                     default='00:40', help='Specify the walltime for each dask worker. Default: 00:40')
+    par.add_argument('--cluster', '--cluster-type', dest='cluster', type=str,
+                     default='SLURM', choices={'LSF', 'PBS', 'SLURM'},
+                     help='Type of HPC cluster you are running on (default: %(default)s).')
+    par.add_argument('--num-worker', dest='numWorker', type=int, default=40,
+                     help='Number of workers the Dask cluster should use (default: %(default)s).')
+    par.add_argument('--walltime', dest='walltime', type=str, default='00:40',
+                     help='Walltime for each dask worker (default: %(default)s).')
 
     return parser
 

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -155,6 +155,8 @@ def create_parser():
     par = parser.add_argument_group('parallel', 'parallel processing configuration for Dask')
     par.add_argument('--parallel', dest='parallel', action='store_true',
                      help='Enable parallel processing for the pixelwise weighted inversion.')
+    par.add_argument('--parallel-type', '--cluster', '--cluster-type', dest='cluster', type=str, default='SLURM',
+                     choices={'LSF', 'PBS', 'SLURM'}, help='The type of HPC cluster you are running on.')
     par.add_argument('--parallel-workers-num','--par-workers-num','--parallel-num', dest='numWorker', type=int,
                      default=40, help='Specify the number of workers the Dask cluster should use. Default: 40')
     par.add_argument('--parallel-walltime','--par-walltime','--parallel-walltime', dest='walltime', type=str,
@@ -1051,34 +1053,28 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
     else:
         try:
             from dask.distributed import Client, as_completed
-            # dask_jobqueue is needed for HPC.
-            # PBSCluster (similar to LSFCluster) should also work out of the box
-            from dask_jobqueue import LSFCluster
+            from mintpy.objects.cluster import Cluster
         except ImportError:
             raise ImportError('Cannot import dask.distributed or dask_jobqueue!')
 
         ts = np.zeros((num_date, length, width), np.float32)
-        python_executable_location = sys.executable
 
         # Look at the ~/.config/dask/dask_mintpy.yaml file for Changing the Dask configuration defaults
-        #cluster = LSFCluster(config_name='default', walltime=inps.walltime, python=python_executable_location)
-        cluster = LSFCluster(walltime=inps.walltime, python=python_executable_location)
-        #cluster = LSFCluster(config_name='ifgram_inversion',
-        #                     python=python_executable_location)
 
         # This line submits NUM_WORKERS jobs to Pegasus to start a bunch of workers
         # In tests on Pegasus `general` queue in Jan 2019, no more than 40 workers could RUN
         # at once (other user's jobs gained higher priority in the general at that point)
         NUM_WORKERS = inps.numWorker
         # FA: the following command starts the jobs
-        cluster.scale(NUM_WORKERS)
-        print("JOB COMMAND CALLED FROM PYTHON:", cluster.job_script())
+        c = Cluster(type=inps.cluster, walltime=inps.walltime)
+        c.cluster.scale(NUM_WORKERS)
+        print("JOB COMMAND CALLED FROM PYTHON:", c.cluster.job_script())
         with open('dask_command_run_from_python.txt', 'w') as f:
-              f.write(cluster.job_script() + '\n')
+              f.write(c.cluster.job_script() + '\n')
 
         # This line needs to be in a function or in a `if __name__ == "__main__":` block. If it is in no function
         # or "main" block, each worker will try to create its own client (which is bad) when loading the module
-        client = Client(cluster)
+        client = Client(c.cluster)
 
         all_boxes = []
         for box in box_list:
@@ -1126,7 +1122,7 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
             num_inv_ifg[subbox[1]:subbox[3], subbox[0]:subbox[2]] = ifg_numi
 
         # Shut down Dask workers gracefully
-        cluster.close()
+        c.cluster.close()
         client.close()
 
         ut.move_dask_stdout_stderr_files()

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -1,0 +1,18 @@
+from dask_jobqueue import LSFCluster, PBSCluster, SLURMCluster
+
+
+class Cluster:
+
+    def __init__(self, type, **kwargs):
+
+        self.cluster = None
+
+        print("Using cluster type: {}".format(type))
+
+        if type == 'LSF':
+            self.cluster = LSFCluster(**kwargs)
+        elif type == 'PBS':
+            self.cluster = PBSCluster(**kwargs)
+        elif type == 'SLURM':
+            self.cluster = SLURMCluster(**kwargs)
+

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -1,18 +1,15 @@
 from dask_jobqueue import LSFCluster, PBSCluster, SLURMCluster
 
 
-class Cluster:
+def get_cluster(type, **kwargs):
+    print("Using cluster type: {}".format(type))
 
-    def __init__(self, type, **kwargs):
+    if type == 'LSF':
+        cluster = LSFCluster(**kwargs)
+    elif type == 'PBS':
+        cluster = PBSCluster(**kwargs)
+    elif type == 'SLURM':
+        cluster = SLURMCluster(**kwargs)
 
-        self.cluster = None
-
-        print("Using cluster type: {}".format(type))
-
-        if type == 'LSF':
-            self.cluster = LSFCluster(**kwargs)
-        elif type == 'PBS':
-            self.cluster = PBSCluster(**kwargs)
-        elif type == 'SLURM':
-            self.cluster = SLURMCluster(**kwargs)
+    return cluster
 


### PR DESCRIPTION
The current version of MintPy uses only the `LSFCluster` object from `dask-jobqueue` to do parallel computation in `ingram_inversion.py`. Obviously, not all users are running on an HPC cluster that uses LSF, so we need to support other common cluster types (namely PBS and SLURM as those are the two other popular ones).

I created a generalized `Cluster` object (`mintpy.objects.cluster`) that acts as a wrapper around the standard Dask cluster objects, but additionally takes a type parameters that allows for it to switch between different cluster styles based on user input. All remaining dask options are still available and are passed to the appropriate cluster object through `**kwargs`.


**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.