### PR TITLE
remove Dask version constraint for installation?

### DIFF
--- a/docs/conda.txt
+++ b/docs/conda.txt
@@ -2,8 +2,8 @@ python>=3.6
 cartopy
 cdsapi
 cvxopt
-dask>=1.0,<2.0
-dask-jobqueue>=0.3,<1.0
+dask
+dask-jobqueue
 ecCodes
 h5py
 lxml

--- a/docs/conda.txt
+++ b/docs/conda.txt
@@ -2,8 +2,8 @@ python>=3.6
 cartopy
 cdsapi
 cvxopt
-dask
-dask-jobqueue
+dask>=1.0
+dask-jobqueue>=0.3
 ecCodes
 h5py
 lxml


### PR DESCRIPTION
Removed version dependencies for dask and dask-jobqueue. Thorough testing on both Pegasus and Stampede have shown that the version dependencies are unnecessary and may cause issues.


**Reminders**

- [ ] Pass Codacy code review (green)
- [ ] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`