### PR TITLE
tropo_pyaps3: save abs delay for more generic usage

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -376,6 +376,12 @@ class timeseries:
         metadata = dict(metadata)
         metadata['FILE_TYPE'] = self.name
 
+        # directory
+        outDir = os.path.dirname(os.path.abspath(outFile))
+        if not os.path.isdir(outDir):
+            os.makedirs(outDir)
+            print('create directory: {}'.format(outDir))
+
         # 3D dataset - timeseries
         print('create timeseries HDF5 file: {} with w mode'.format(outFile))
         f = h5py.File(outFile, 'w')

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -124,7 +124,14 @@ def cmd_line_parse(iargs=None):
     inps = parser.parse_args(args=iargs)
 
     ## print model info
-    print('weather model: {}'.format(inps.tropo_model))
+    msg = 'weather model: {}'.format(inps.tropo_model)
+    if inps.delay_type == 'dry':
+        msg += ' - dry (hydrostatic) delay'
+    elif inps.delay_type == 'wet':
+        msg += ' - wet delay'
+    else:
+        msg += ' - dry (hydrostatic) and wet delay'
+    print(msg)
 
     ## weather_dir
     # expand path for ~ and environmental variables in the path
@@ -138,8 +145,9 @@ def cmd_line_parse(iargs=None):
 
     ## ignore invalid filename inputs
     for key in ['timeseries_file', 'geom_file']:
-        if vars(inps)[key] and not os.path.isfile(vars(inps)[key]):
-            vars(inps)[key] = None
+        fname = vars(inps)[key]
+        if fname and not os.path.isfile(fname):
+            raise FileExistsError('input file not exist: {}'.format(fname))
 
     ## required options (for date/time): --file OR --date-list, --hour
     if (not inps.timeseries_file 


### PR DESCRIPTION
**Description of proposed changes**

Save the absolute tropospheric delay calculated from PyAPS, with NO reference in time and NO reference in space, for more generic usage, such as offset displacement.

Update diff.py to handle two input files with different reference in time and space.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.