### PR TITLE
Updated read_template2inps to read cluster parameter from template file

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -119,6 +119,7 @@ mintpy.networkInversion.minRedundancy   = auto #[1-inf], auto for 1.0, min num_i
 
 ## Parallel processing with Dask for HPC
 mintpy.networkInversion.parallel    = auto #[yes / no], auto for no, parallel processing using dask
+mintpy.networkInversion.cluster	    = auto #[SLURM / PBS / LSF], auto for SLURM, cluster type for dask
 mintpy.networkInversion.numWorker   = auto #[int > 0], auto for 40, number of works for dask cluster to use
 mintpy.networkInversion.walltime    = auto #[HH:MM], auto for 00:40, walltime for dask workers
 

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -55,6 +55,7 @@ mintpy.networkInversion.minNumPixel      = 100
 mintpy.networkInversion.shadowMask       = yes
 
 mintpy.networkInversion.parallel         = no
+mintpy.networkInversion.cluster		 = SLURM
 mintpy.networkInversion.numWorker        = 40
 mintpy.networkInversion.walltime         = 00:40
 

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -206,11 +206,10 @@ def read_template2inps(template_file, inps):
     iDict = vars(inps)
     template = readfile.read_template(template_file)
     template = ut.check_template_auto_value(template)
-
     keyList = [i for i in list(iDict.keys()) if key_prefix+i in template.keys()]
     for key in keyList:
         value = template[key_prefix+key]
-        if key in ['maskDataset', 'minNormVelocity', 'parallel']:
+        if key in ['maskDataset', 'minNormVelocity', 'parallel', 'cluster']:
             iDict[key] = value
         elif value:
             if key in ['numWorker']:


### PR DESCRIPTION
**Description of proposed changes**
Ensured that the value of 'cluster' could be read from a template file. This makes it easy to switch out the type of cluster object the code should use by simply setting a template option rather than having to pass a value at runtime.


**Reminders**

- [x] Pass Codacy code review (green)
- [ ] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.

