### PR TITLE
bug fix for correct data in unwrapping corrections

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -192,7 +192,8 @@ def cmd_line_parse(iargs=None):
         stack_obj = ifgramStack(inps.ifgramStackFile)
         stack_obj.open(print_msg=False)
         if inps.obsDatasetName not in stack_obj.datasetNames:
-            raise ValueError('input dataset name not found in file: {}'.format(inps.ifgramStackFile))
+            msg = 'input dataset name "{}" not found in file: {}'.format(inps.obsDatasetName, inps.ifgramStackFile)
+            raise ValueError(msg)
 
     # --skip-ref option
     if 'offset' in inps.obsDatasetName.lower():

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -157,6 +157,8 @@ def cmd_line_parse(iargs=None):
 
     if inps.templateFile:
         inps = read_template2inps(inps.templateFile, inps)
+        template = readfile.read_template(inps.templateFile)
+        template = ut.check_template_auto_value(template)
 
     if inps.waterMaskFile and not os.path.isfile(inps.waterMaskFile):
         inps.waterMaskFile = None
@@ -175,11 +177,20 @@ def cmd_line_parse(iargs=None):
     if not inps.obsDatasetName:
         stack_obj = ifgramStack(inps.ifgramStackFile)
         stack_obj.open(print_msg=False)
-        inps.obsDatasetName = [i for i in ['unwrapPhase_bridging_phaseClosure',
+        obsMap = {False: '', 'bridging' : '_bridging', 'phase_closure': '_phaseClosure', 
+                                    'bridging+phase_closure' : '_bridging_phaseClosure'}
+
+        try:
+            unw_method = template['mintpy.unwrapError.method']
+            inps.obsDatasetName = 'unwrapPhase' + obsMap[unw_method]
+            
+        except:
+            inps.obsDatasetName = [i for i in ['unwrapPhase_bridging_phaseClosure',
                                            'unwrapPhase_bridging',
                                            'unwrapPhase_phaseClosure',
                                            'unwrapPhase']
                                if i in stack_obj.datasetNames][0]
+            pass
 
     # --skip-ref option
     if 'offset' in inps.obsDatasetName.lower():

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -125,7 +125,7 @@ def create_parser():
     par.add_argument('--parallel', dest='parallel', action='store_true',
                      help='Enable parallel processing for the pixelwise weighted inversion.')
     par.add_argument('--cluster', '--cluster-type', dest='cluster', type=str,
-                     default='SLURM', choices={'LSF', 'PBS', 'SLURM'},
+                     default='slurm', choices={'lsf', 'pbs', 'slurm'},
                      help='Type of HPC cluster you are running on (default: %(default)s).')
     par.add_argument('--config', '--config-name', dest='config', type=str, default='no', 
                      help='Configuration name to use in dask.yaml (default: %(default)s).')
@@ -182,12 +182,11 @@ def cmd_line_parse(iargs=None):
                           'phase_closure'          : '_phaseClosure',
                           'bridging+phase_closure' : '_bridging_phaseClosure'}
         key = 'mintpy.unwrapError.method'
-        if key in template.keys():
-            unw_err_method = template[key].replace(' ','')
-            if unw_err_method:
-                inps.obsDatasetName += obs_suffix_map[unw_err_method]
-                print('phase unwrapping error correction {} is turn ON'.format(unw_err_method))
-        print('use dataset "{}" by default.'.format(inps.obsDatasetName))
+        if key in template.keys() and template[key]:
+            unw_err_method = template[key].lower().replace(' ','')   # fix potential typo
+            inps.obsDatasetName += obs_suffix_map[unw_err_method]
+            print('phase unwrapping error correction "{}" is turned ON'.format(unw_err_method))
+        print('use dataset "{}" by default'.format(inps.obsDatasetName))
 
         # check if input observation dataset exists.
         stack_obj = ifgramStack(inps.ifgramStackFile)


### PR DESCRIPTION
prior to fix, mintpy would default to using corrected dataset in timeseries.h5
if unwrapping corrections were turned off after running them, this would not be reflected
this obtains the name of the dataset from the input file

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.