### PR TITLE
bugfix for --scalebar-pad in view.py

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -65,6 +65,10 @@ mintpy.network.referenceFile   = auto  #[date12_list.txt / ifgramStack.h5 / no],
 ########## 3. reference_point
 ## Reference all interferograms to one common point in space
 ## auto - randomly select a pixel with coherence > minCoherence
+## recommend to manually specify using prior knowledge of the study area, with the following guideline:
+## 1) located in a coherence area
+## 2) not affected by strong atmospheric turbulence, i.e. ionospheric streaks
+## 3) close to and with similar elevation as the AOI to minimize the impact of spatially correlated atmospheric delay
 mintpy.reference.yx            = auto   #[257,151 / auto]
 mintpy.reference.lalo          = auto   #[31.8,130.8 / auto]
 mintpy.reference.maskFile      = auto   #[filename / no], auto for maskConnComp.h5

--- a/mintpy/objects/resample.py
+++ b/mintpy/objects/resample.py
@@ -26,8 +26,14 @@ class resample:
        (https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html)
 
     Example:
+        # prepare resample object
         res_obj = resample(lookupFile='./inputs/geometryGeo.h5', dataFile='velocity.h5')
         res_obj = resample(lookupFile='./inputs/geometryRadar.h5', dataFile='temporalCoherence.h5')
+        res_obj.open()
+
+        # run geocoding
+        rdr_data = readfile.read('temporalCoherence.h5')[0]
+        geo_data = res_obj.run_resample(src_data=rdr_data, interp_method='nearest', fill_value=np.nan)
     """
 
     def __init__(self, lookupFile, dataFile, SNWE=None, laloStep=None, processor=None):

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -36,7 +36,7 @@ EXAMPLE = """example:
   tropo_pyaps3.py -f timeseries.h5 -g inputs/geometryRadar.h5
 
   # download reanalysys dataset, calculate tropospheric delays
-  tropo_pyaps3.py -d date.list         --hour 12 -m ERA5  -g inputs/geometryRadar.h5
+  tropo_pyaps3.py -d date.list         --hour 12 -m ERA5  -g inputs/geometryGeo.h5
   tropo_pyaps3.py -d 20151002 20151003 --hour 12 -m MERRA -g inputs/geometryRadar.h5
 
   # download reanalysys dataset
@@ -308,7 +308,7 @@ def get_grib_filenames(date_list, hour, model, grib_dir, snwe=None):
 
 
 def ceil2multiple(x, step=10):
-    """Return the closest number in multiple of step in the larger direction"""
+    """Given a number x, find the smallest number in multiple of step >= x."""
     assert isinstance(x, (int, np.int16, np.int32, np.int64)), 'input number is not int: {}'.format(type(x))
     if x % step == 0:
         return x
@@ -316,7 +316,7 @@ def ceil2multiple(x, step=10):
 
 
 def floor2multiple(x, step=10):
-    """Return the closest number in multiple of step in the lesser direction"""
+    """Given a number x, find the largest number in multiple of step <= x."""
     assert isinstance(x, (int, np.int16, np.int32, np.int64)), 'input number is not int: {}'.format(type(x))
     return x - x % step
 
@@ -331,7 +331,7 @@ def get_snwe(meta, min_buffer=2, step=10):
     W = np.floor(min(lon0, lon1) - min_buffer).astype(int)
     E = np.ceil( max(lon0, lon1) + min_buffer).astype(int)
 
-    # SNWE in multiple of 5
+    # SNWE in multiple of 10
     if step > 1:
         S = floor2multiple(S, step=step)
         W = floor2multiple(W, step=step)

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -271,21 +271,21 @@ def enu2los(e, n, u, inc_angle=34., head_angle=-168.):
 
     inc_angle *= np.pi/180.
     head_angle *= np.pi/180.
-    v_los = (-1 * e * np.cos(head_angle) * np.sin(inc_angle)
-             + n * np.sin(head_angle) * np.sin(inc_angle)
+    v_los = (  e * np.sin(inc_angle) * np.cos(head_angle)  * -1
+             + n * np.sin(inc_angle) * np.sin(head_angle) 
              + u * np.cos(inc_angle))
     return v_los
 
 def four_corners(atr):
     """Return 4 corners lat/lon"""
-    width = int(atr['WIDTH'])
+    width  = int(atr['WIDTH'])
     length = int(atr['LENGTH'])
     lon_step = float(atr['X_STEP'])
     lat_step = float(atr['Y_STEP'])
-    west = float(atr['X_FIRST'])
+    west  = float(atr['X_FIRST'])
     north = float(atr['Y_FIRST'])
-    south = north + lat_step*length
-    east = west + lon_step*width
+    south = north + lat_step * length
+    east  = west  + lon_step * width
     return west, east, south, north
 
 
@@ -626,6 +626,13 @@ def round_to_1(x):
     """Return the most significant digit of input number"""
     digit = int(np.floor(np.log10(abs(x))))
     return round(x, -1*digit)
+
+
+def highest_power_of_2(x):
+    """Given a number x, find the highest power of 2 that <= x"""
+    res = np.power(2, np.floor(np.log2(x)))
+    res = np.int16(res)
+    return res
 
 
 def most_common(L, k=1):

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -62,7 +62,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                 msg += '\nRe-run dem_error.py to generate it.'
                 raise Exception(msg)
             else:
-                print('removing a {} ramp from file: {}'.format(ramp_type, timeseries_resid_file))
+                #print('removing a {} ramp from file: {}'.format(ramp_type, timeseries_resid_file))
                 deramped_file = run_deramp(timeseries_resid_file,
                                            ramp_type=ramp_type,
                                            mask_file=mask_file,
@@ -112,7 +112,7 @@ def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                 msg += '\nRe-run dem_error.py to generate it.'
                 raise Exception(msg)
             else:
-                print('removing a {} ramp from file: {}'.format(ramp_type, timeseries_resid_file))
+                #print('remove {} ramp from file: {}'.format(ramp_type, timeseries_resid_file))
                 deramped_file = run_deramp(timeseries_resid_file,
                                            ramp_type=ramp_type,
                                            mask_file=mask_file,

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -12,6 +12,11 @@ import time
 import argparse
 import subprocess
 
+CMAP_DICT = {
+    'FernandinaSenDT128' : 'jet',
+    'WellsEnvD2T399'     : 'jet_r',
+    'KujuAlosAT422F650'  : 'jet_r',
+}
 
 URL_LIST = [
     'https://zenodo.org/record/3635245/files/FernandinaSenDT128.tar.xz',
@@ -121,6 +126,13 @@ def test_dataset(dset_name, test_dir, fresh_start=True, test_pyaps=False):
     status = subprocess.Popen(cmd, shell=True).wait()
     if status is not 0:
         raise RuntimeError('Test failed for example dataset {}'.format(dset_name))
+
+    # custom plot of velocity map
+    if dset_name in CMAP_DICT.keys():
+        cmd = 'view.py geo/geo_velocity.h5 velocity --nodisplay -o pic/geo_velocity.png --noverbose '
+        cmd += ' -c {}'.format(CMAP_DICT[dset_name])
+        print(cmd)
+        subprocess.Popen(cmd, shell=True).wait()
 
     # open final velocity map
     cmd = 'open pic/geo_velocity.png'


### PR DESCRIPTION
**Description of proposed changes**

view:
+ fix broken option for --scalebar-pad introduced while replacing basemap with cartopy (#263)
+ use eval() to replace PROJECTION_NAME2OBJ to specify the map projection from cartopy for more generic supports with more projections.
+ update prep_slice() to use cartopy too

utils/utils0: add highest_power_of_2() to find the highest power of 2 that is <= the input number

more comments in:
+ objects/resample.py
+ tropo_pyaps3.py
+ defaults/smallbaselineApp.cfg with guidelines on reference point

test/test_smallbaselineApp: add custom colormap for final velocit pop out

**Reminders**

- [ ] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.