### PR TITLE
support `aria` processor in smallbaselineApp.py 

### DIFF
--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -190,6 +190,88 @@ mintpy.load.azAngleFile      = $DATA_DIR/KirishimaAlosAT424F620_630/geom_master/
 mintpy.load.shadowMaskFile   = $DATA_DIR/KirishimaAlosAT424F620_630/geom_master/shadowMask.rdr
 ```
 
+### ARIA from ARIA-tools ###
+
+```
+$DATA_DIR/SanFranSenDT42
+├── DEM
+│   ├── SRTM_3arcsec.dem
+│   ├── SRTM_3arcsec.dem.aux.xml
+│   ├── SRTM_3arcsec.dem.vrt
+│   ├── SRTM_3arcsec.hdr
+│   ├── ...
+├── azimuthAngle
+│   ├── 20150605_20150512
+│   ├── 20150605_20150512.aux.xml
+│   ├── 20150605_20150512.hdr
+│   ├── 20150605_20150512.vrt
+├── coherence
+│   ├── 20150605_20150512
+│   ├── 20150605_20150512.aux.xml
+│   ├── 20150605_20150512.hdr
+│   ├── 20150605_20150512.vrt
+│   ├── ...
+├── connectedComponents
+│   ├── 20150605_20150512
+│   ├── 20150605_20150512.aux.xml
+│   ├── 20150605_20150512.hdr
+│   ├── 20150605_20150512.vrt
+│   ├── ...
+├── incidenceAngle
+│   ├── 20150605_20150512
+│   ├── 20150605_20150512.aux.xml
+│   ├── 20150605_20150512.hdr
+│   ├── 20150605_20150512.vrt
+├── lookAngle
+│   ├── 20150605_20150512
+│   ├── 20150605_20150512.aux.xml
+│   ├── 20150605_20150512.hdr
+│   ├── 20150605_20150512.vrt
+├── mask
+│   ├── watermask.hdr
+│   ├── watermask.msk
+│   ├── watermask.msk.aux.xml
+│   ├── watermask.msk.vrt
+│   ├── ...
+├── mintpy
+│   ├── SanFranSenDT42.txt
+│   ├── ...
+├── productBoundingBox
+│   ├── 20150605_20150512.shp
+│   ├── 20150629_20150512.shp
+│   ├── ...
+│   ├── productBoundingBox.shp
+├── products
+│   ├── S1-GUNW-D-R-042-tops-20150605_20150512-140722-39616N_37642N-PP-e396-v2_0_0.nc
+│   ├── S1-GUNW-D-R-042-tops-20150605_20150512-140746-38125N_36150N-PP-24d1-v2_0_0.nc
+│   ├── ...
+├── stack
+│   ├── cohStack.vrt
+│   ├── connCompStack.vrt
+│   ├── unwrapStack.vrt
+├── unwrappedPhase
+│   ├── 20150605_20150512
+│   ├── 20150605_20150512.aux.xml
+│   ├── 20150605_20150512.hdr
+│   ├── 20150605_20150512.vrt
+│   ├── ...
+```
+
+The corresponding template options:
+
+```cfg
+mintpy.load.processor        = aria
+##---------interferogram datasets:
+mintpy.load.unwFile          = $DATA_DIR/SanFranSenDT42/stack/unwrapStack.vrt
+mintpy.load.corFile          = $DATA_DIR/SanFranSenDT42/stack/cohStack.vrt
+mintpy.load.connCompFile     = $DATA_DIR/SanFranSenDT42/stack/connCompStack.vrt
+##---------geometry datasets:
+mintpy.load.demFile          = $DATA_DIR/SanFranSenDT42/DEM/SRTM_3arcsec.dem
+mintpy.load.incAngleFile     = $DATA_DIR/SanFranSenDT42/incidenceAngle/20150605_20150512.vrt
+mintpy.load.azAngleFile      = $DATA_DIR/SanFranSenDT42/azimuthAngle/20150605_20150512.vrt
+mintpy.load.waterMaskFile    = $DATA_DIR/SanFranSenDT42/mask/watermask.msk
+```
+
 ### Gamma ###
 
 ```

--- a/docs/examples/input_files/README.md
+++ b/docs/examples/input_files/README.md
@@ -7,6 +7,9 @@
 #### ISCE/stripmapStack ####
 + [KirishimaAlos2DT23F2970.template](KirishimaAlos2DT23F2970.template)
 
+#### ARIA ####
++ [SanFranSenDT42.txt](SanFranSenDT42.txt)
+
 #### GAMMA ####
 + [GalapagosEnvA2T061.txt](GalapagosEnvA2T061.txt)
 + [WellsEnvD2T399.txt](WellsEnvD2T399.txt)

--- a/docs/examples/input_files/SanFranSenDT42.txt
+++ b/docs/examples/input_files/SanFranSenDT42.txt
@@ -1,0 +1,26 @@
+# vim: set filetype=cfg:
+########## 1. load_data
+## no   - save   0% disk usage, fast [default]
+## lzf  - save ~57% disk usage, relative slow
+## gzip - save ~62% disk usage, very slow [not recommend]
+mintpy.load.processor      = aria  #[isce, aria, snap, gamma, roipac], auto for isce
+mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
+mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
+##---------interferogram datasets:
+mintpy.load.unwFile        = ../stack/unwrapStack.vrt
+mintpy.load.corFile        = ../stack/cohStack.vrt
+mintpy.load.connCompFile   = ../stack/connCompStack.vrt
+##---------geometry datasets:
+mintpy.load.demFile        = ../DEM/SRTM_3arcsec.dem
+mintpy.load.incAngleFile   = ../incidenceAngle/20150605_20150512.vrt
+mintpy.load.azAngleFile    = ../azimuthAngle/20150605_20150512.vrt
+mintpy.load.waterMaskFile  = ../mask/watermask.msk
+
+mintpy.reference.lalo           = 37.70, -122.07
+mintpy.network.coherenceBased   = yes
+mintpy.network.minCoherence     = 0.7
+
+## options to speedup the processing (fast but not the best)
+mintpy.networkInversion.weightFunc              = no
+mintpy.topographicResidual.pixelwiseGeometry    = no
+

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -7,7 +7,7 @@
 ## no   - save   0% disk usage, fast [default]
 ## lzf  - save ~57% disk usage, relative slow
 ## gzip - save ~62% disk usage, very slow [not recommend]
-mintpy.load.processor      = auto  #[isce, snap, gamma, roipac], auto for isce
+mintpy.load.processor      = auto  #[isce, aria, snap, gamma, roipac], auto for isce
 mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
 mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
 ##---------for ISCE only:

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -7,31 +7,31 @@
 ## no   - save   0% disk usage, fast [default]
 ## lzf  - save ~57% disk usage, relative slow
 ## gzip - save ~62% disk usage, very slow [not recommend]
-mintpy.load.processor      = auto  #[isce,snap,gamma,roipac], auto for isce
+mintpy.load.processor      = auto  #[isce, snap, gamma, roipac], auto for isce
 mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
 mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
 ##---------for ISCE only:
-mintpy.load.metaFile       = auto  #[path2metadata_file], i.e.: ./master/IW1.xml, ./masterShelve/data.dat
-mintpy.load.baselineDir    = auto  #[path2baseline_dir], i.e.: ./baselines
+mintpy.load.metaFile       = auto  #[path of common metadata file for the stack], i.e.: ./master/IW1.xml, ./masterShelve/data.dat
+mintpy.load.baselineDir    = auto  #[path of the baseline dir], i.e.: ./baselines
 ##---------interferogram datasets:
-mintpy.load.unwFile        = auto  #[path2unw_file]
-mintpy.load.corFile        = auto  #[path2cor_file]
-mintpy.load.connCompFile   = auto  #[path2conn_file], optional
-mintpy.load.intFile        = auto  #[path2int_file], optional
-mintpy.load.ionoFile       = auto  #[path2iono_file], optional
-##---------offset datasets:
-mintpy.load.azOffFile      = auto  #[path2az_off_file], optional
-mintpy.load.rgOffFile      = auto  #[path2rg_off_file], optional
-mintpy.load.offSnrFile     = auto  #[path2off_SNR_file], optional
+mintpy.load.unwFile        = auto  #[path pattern of unwrapped interferogram files]
+mintpy.load.corFile        = auto  #[path pattern of spatial coherence       files]
+mintpy.load.connCompFile   = auto  #[path pattern of connected components    files], optional
+mintpy.load.intFile        = auto  #[path pattern of wrapped interferogram   files], optional
+mintpy.load.ionoFile       = auto  #[path pattern of ionospheric delay       files], optional
+##---------offset datasets (optional):
+mintpy.load.azOffFile      = auto  #[path pattern of azimuth offset file], optional
+mintpy.load.rgOffFile      = auto  #[path pattern of range   offset file], optional
+mintpy.load.offSnrFile     = auto  #[path pattern of offset signal-to-noise ratio file], optional
 ##---------geometry datasets:
-mintpy.load.demFile        = auto  #[path2hgt_file]
-mintpy.load.lookupYFile    = auto  #[path2lat_file], not required for geocoded data
-mintpy.load.lookupXFile    = auto  #[path2lon_file], not required for geocoded data
-mintpy.load.incAngleFile   = auto  #[path2los_file], optional
-mintpy.load.azAngleFile    = auto  #[path2los_file], optional
-mintpy.load.shadowMaskFile = auto  #[path2shadow_file], optional
-mintpy.load.waterMaskFile  = auto  #[path2water_mask_file], optional
-mintpy.load.bperpFile      = auto  #[path2bperp_file], optional
+mintpy.load.demFile        = auto  #[path of DEM file]
+mintpy.load.lookupYFile    = auto  #[path of latitude /row   /y coordinate file], not required for geocoded data
+mintpy.load.lookupXFile    = auto  #[path of longitude/column/x coordinate file], not required for geocoded data
+mintpy.load.incAngleFile   = auto  #[path of incidence angle file], optional
+mintpy.load.azAngleFile    = auto  #[path of azimuth   angle file], optional
+mintpy.load.shadowMaskFile = auto  #[path of shadow mask file], optional
+mintpy.load.waterMaskFile  = auto  #[path of water  mask file], optional
+mintpy.load.bperpFile      = auto  #[path pattern of 2D perpendicular baseline file], optional
 ##---------subset (optional):
 ## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
 mintpy.subset.yx   = auto    #[1800:2000,700:800 / no], auto for no
@@ -40,7 +40,7 @@ mintpy.subset.lalo = auto    #[31.5:32.5,130.5:131.0 / no], auto for no
 
 ########## 2. modify_network
 ## reference: Yunjun et al. (2019)
-## 1) Coherence-based network modification = threshold + MST, by default
+## 1) Coherence-based network modification = (threshold + MST) by default
 ## It calculates a average coherence value for each interferogram using spatial coherence and input mask (with AOI)
 ## Then it finds a minimum spanning tree (MST) network with inverse of average coherence as weight (keepMinSpanTree)
 ## For all interferograms except for MST's, exclude those with average coherence < minCoherence.
@@ -65,7 +65,7 @@ mintpy.network.referenceFile   = auto  #[date12_list.txt / ifgramStack.h5 / no],
 ########## 3. reference_point
 ## Reference all interferograms to one common point in space
 ## auto - randomly select a pixel with coherence > minCoherence
-## recommend to manually specify using prior knowledge of the study area, with the following guideline:
+## however, manually specify using prior knowledge of the study area is highly recommended, with the following guideline:
 ## 1) located in a coherence area
 ## 2) not affected by strong atmospheric turbulence, i.e. ionospheric streaks
 ## 3) close to and with similar elevation as the AOI to minimize the impact of spatially correlated atmospheric delay
@@ -77,6 +77,7 @@ mintpy.reference.minCoherence  = auto   #[0.0-1.0], auto for 0.85, minimum coher
 
 
 ########## 4. correct_unwrap_error (optional)
+## connected components (mintpy.load.connCompFile) are required for this step.
 ## reference: Yunjun et al. (2019)
 ## supported methods:
 ## a. phase_closure           - suitable for highly redundant network
@@ -94,9 +95,9 @@ mintpy.unwrapError.bridgePtsRadius = auto  #[1-inf], auto for 50, half size of t
 
 
 ########## stack_interferograms
-## reference: Zebker et al. (1997)
 ## A quick assessment of possible groud deformation
 ## using the velocity from interferogram stacking
+## reference: Zebker et al. (1997)
 
 
 ########## 5. invert_network
@@ -128,7 +129,8 @@ mintpy.networkInversion.config      = auto #[slurm / pbs / lsf / no], auto for n
 mintpy.networkInversion.numWorker   = auto #[int > 0], auto for 40, number of works to deploy
 mintpy.networkInversion.walltime    = auto #[HH:MM], auto for 00:40, walltime for each dask worker
 
-## Temporal coherence is calculated and used to generate final mask (Pepe & Lanari, 2006, IEEE-TGRS)
+## Temporal coherence is calculated and used to generate the mask as the reliability measure
+## reference: Pepe & Lanari (2006, IEEE-TGRS)
 mintpy.networkInversion.minTempCoh  = auto #[0.0-1.0], auto for 0.7, min temporal coherence for mask
 mintpy.networkInversion.minNumPixel = auto #[int > 0], auto for 100, min number of pixels in mask above
 mintpy.networkInversion.shadowMask  = auto #[yes / no], auto for yes [if shadowMask is in geometry file] or no.
@@ -145,26 +147,26 @@ mintpy.networkInversion.shadowMask  = auto #[yes / no], auto for yes [if shadowM
 ## correct tropospheric delay using the following methods:
 ## a. height_correlation - correct stratified tropospheric delay (Doin et al., 2009, J Applied Geop)
 ## b. pyaps - use Global Atmospheric Models (GAMs) data (Jolivet et al., 2011; 2014)
-##      ERA5  - ERA-5 from ECMWF [default; need to install pyaps3 on GitHub]
-##      ECMWF - ERA-Interim from ECMWF [need to install pyaps on Caltech/EarthDef]
-##      MERRA - MERRA-2 from NASA Goddard [need to install pyaps on Caltech/EarthDef]
-##      NARR  - NARR from NOAA [recommended for areas in North America; need to install pyaps on Caltech/EarthDef]
+##      ERA5  - ERA-5       from ECMWF [need to install pyaps3 on GitHub; recommended and turn ON by default]
+##      ECMWF - ERA-Interim from ECMWF [need to install pyaps  on Caltech/EarthDef]
+##      MERRA - MERRA-2     from NASA  [need to install pyaps  on Caltech/EarthDef]
+##      NARR  - NARR        from NOAA  [need to install pyaps  on Caltech/EarthDef; recommended for North America]
 mintpy.troposphericDelay.method = auto  #[pyaps / height_correlation / no], auto for pyaps
 
 ## Notes for pyaps:
 ## a. GAM data latency: with the most recent SAR data, there will be GAM data missing, the correction
-## will be applied to dates with GAM data available and skipped for the others.
+##    will be applied to dates with GAM data available and skipped for the others.
 ## b. WEATHER_DIR: if you define an environmental variable named WEATHER_DIR to contain the path to a
-## directory, then MintPy applications will download the GAM files into the indicated directory. Also MintPy
-## application will look for the GAM files in the directory before downloading a new one to prevent downloading
-## multiple copies if you work with different dataset that cover the same date/time.
+##    directory, then MintPy applications will download the GAM files into the indicated directory. Also MintPy
+##    application will look for the GAM files in the directory before downloading a new one to prevent downloading
+##    multiple copies if you work with different dataset that cover the same date/time.
 mintpy.troposphericDelay.weatherModel = auto  #[ERA5 / ECMWF / MERRA / NARR], auto for ERA5, for pyaps method
 mintpy.troposphericDelay.weatherDir   = auto  #[path2directory], auto for WEATHER_DIR or "./"
 
 ## Notes for height_correlation:
 ## Extra multilooking is applied to estimate the empirical phase/elevation ratio ONLY.
-## For an dataset with 5by15 looks, looks=8 will generate phase with (5*8)by(15*8) looks
-## to estimate the empirical parameter; then apply the correction to original phase (with 5by15 looks),
+## For an dataset with 5 by 15 looks, looks=8 will generate phase with (5*8) by (15*8) looks
+## to estimate the empirical parameter; then apply the correction to original phase (with 5 by 15 looks),
 ## if the phase/elevation correlation is larger than minCorrelation.
 mintpy.troposphericDelay.polyOrder      = auto  #[1 / 2 / 3], auto for 1, for height_correlation method
 mintpy.troposphericDelay.looks          = auto  #[1-inf], auto for 8, for height_correlation, extra multilooking number
@@ -174,13 +176,13 @@ mintpy.troposphericDelay.minCorrelation = auto  #[0.0-1.0], auto for 0, for heig
 ########## 7. deramp (optional)
 ## Estimate and remove a phase ramp for each acquisition based on the reliable pixels.
 ## Recommended for localized deformation signals, i.e. volcanic deformation, landslide and land subsidence, etc.
-## Not recommended for long spatial wavelength deformation signals, i.e. co-, post- and inter-seimic deformation.
+## NOT recommended for long spatial wavelength deformation signals, i.e. co-, post- and inter-seimic deformation.
 mintpy.deramp          = auto  #[no / linear / quadratic], auto for no - no ramp will be removed
 mintpy.deramp.maskFile = auto  #[filename / no], auto for maskTempCoh.h5, mask file for ramp estimation
 
 
 ########## 8. correct_topography (optional and recommended)
-## Topographic Residual (DEM Error) Correction
+## Topographic residual (DEM error) correction
 ## reference: Fattahi and Amelung (2013, IEEE-TGRS)
 ## stepFuncDate      - Specify stepFuncDate option if you know there are sudden displacement jump in your area,
 ##    i.e. volcanic eruption, or earthquake, and check timeseriesStepModel.h5 afterward for their estimation.
@@ -197,8 +199,8 @@ mintpy.topographicResidual.pixelwiseGeometry = auto  #[yes / no], auto for yes, 
 
 
 ########## 9.1 residual_RMS (root mean squares for noise evaluation)
-## reference: Yunjun et al. (2019)
 ## Calculate the Root Mean Square (RMS) of residual phase time-series for each acquisition
+## reference: Yunjun et al. (2019)
 ## To get rid of long wavelength component in space, a ramp is removed for each acquisition
 ## Set optimal reference date to date with min RMS
 ## Set exclude dates (outliers) to dates with RMS > cutoff * median RMS (Median Absolute Deviation)
@@ -207,8 +209,8 @@ mintpy.residualRMS.deramp   = auto  #[quadratic / linear / no], auto for quadrat
 mintpy.residualRMS.cutoff   = auto  #[0.0-inf], auto for 3
 
 ########## 9.2 reference_date
-## reference: Yunjun et al. (2019)
 ## Reference all time-series to one date in time
+## reference: Yunjun et al. (2019)
 ## no     - do not change the default reference date (1st date)
 mintpy.reference.date = auto   #[reference_date.txt / 20090214 / no], auto for reference_date.txt
 

--- a/mintpy/objects/colors.py
+++ b/mintpy/objects/colors.py
@@ -5,6 +5,8 @@
 ############################################################
 # Recommend import:
 #     from mintpy.objects.colors import ColormapExt
+#     from mintpy.utils import plot as pp
+#     cmap = pp.ColormapExt('cmy').colormap
 
 
 import os

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -11,7 +11,8 @@ import time
 import argparse
 import h5py
 import numpy as np
-from mintpy.utils import ptime
+from mintpy.objects import ifgramStack, geometry
+from mintpy.utils import ptime, readfile, utils as ut
 try:
     import gdal
 except ImportError:
@@ -20,57 +21,78 @@ except ImportError:
 
 ####################################################################################
 EXAMPLE = """example:
-  # 1. run ARIA-tools to download and extract inteferograms stack for time-series analysis.
-  # reference: https://github.com/aria-tools/ARIA-tools
-  conda activate ARIA-tools
-  ariaDownload.py -b '37.25 38.1 -122.6 -121.75' --track 42
-  ariaTSsetup.py -f 'products/*.nc' -b '37.25 38.1 -122.6 -121.75' --mask Download
-
-  # 2. run prep_aria.py to load into HDF5 files
-  prep_aria.py -w mintpy -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt 
-  prep_aria.py -w mintpy -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt 
+  prep_aria.py -t SanFranSenDT42.txt --update
+  prep_aria.py -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt
+  prep_aria.py -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt 
                -a azimuthAngle/20150605_20150512.vrt --water-mask mask/watermask.msk
 
-  # 3. run smallbaselineApp.py for time series analysis
-  conda deactivate
-  conda activate mintpy
-  smallbaselineApp.py -g #generate smallbaselineApp.cfg file (modify default auto value)
-  smallbaselineApp.py    #run routine analysis, or smallbaselineApp.py --start modify_network
+  # run ARIA-tools to download / extract / prepare inteferograms stack before MintPy.
+  # reference: https://github.com/aria-tools/ARIA-tools
+  ariaDownload.py -b '37.25 38.1 -122.6 -121.75' --track 42
+  ariaTSsetup.py -f 'products/*.nc' -b '37.25 38.1 -122.6 -121.75' --mask Download
 """
+
+TEMPLATE = """template options:
+  ########## 1. load_data
+  ## no   - save   0% disk usage, fast [default]
+  ## lzf  - save ~57% disk usage, relative slow
+  ## gzip - save ~62% disk usage, very slow [not recommend]
+  mintpy.load.processor      = aria  #[isce, aria, snap, gamma, roipac], auto for isce
+  mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
+  mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
+  ##---------interferogram datasets:
+  mintpy.load.unwFile        = ../stack/unwrapStack.vrt
+  mintpy.load.corFile        = ../stack/cohStack.vrt
+  mintpy.load.connCompFile   = ../stack/connCompStack.vrt
+  ##---------geometry datasets:
+  mintpy.load.demFile        = ../DEM/SRTM_3arcsec.dem
+  mintpy.load.incAngleFile   = ../incidenceAngle/20150605_20150512.vrt
+  mintpy.load.azAngleFile    = ../azimuthAngle/20150605_20150512.vrt
+  mintpy.load.waterMaskFile  = ../mask/watermask.msk
+"""
+
 
 def create_parser():
     """Command line parser."""
     parser = argparse.ArgumentParser(description='Prepare ARIA processed products for MintPy.',
                                      formatter_class=argparse.RawTextHelpFormatter,
-                                     epilog=EXAMPLE)
-    parser.add_argument('-w','--work-dir', dest='workDir', type=str, default="./",
-                        help='The working directory for MintPy.')
+                                     epilog=TEMPLATE+'\n'+EXAMPLE)
 
-    stack = parser.add_argument_group('Interferogram stack')
-    stack.add_argument('-s','--stack-dir', dest='stackDir', type=str, required=True,
+    parser.add_argument('-t','--template', dest='template_file', type=str,
+                        help='template file with the options')
+    parser.add_argument('--update', dest='updateMode', action='store_true',
+                        help='Enable the update mode: checking dataset already loaded.')
+    parser.add_argument('-o', '--output', type=str, nargs=2, dest='outfile',
+                        default=['./inputs/ifgramStack.h5',
+                                 './inputs/geometryGeo.h5'],
+                        help='output HDF5 file')
+
+    # ifgramStack
+    stack = parser.add_argument_group('interferogram stack')
+    stack.add_argument('-s','--stack-dir', dest='stackDir', type=str,
                        help='The directory which contains stack VRT files.')
-
-    stack.add_argument('-u','--unwrap-stack-name', dest='unwStack', type=str,
+    stack.add_argument('-u','--unwrap-stack-name', dest='unwFile', type=str,
                        default="unwrapStack.vrt",
                        help='Name of the stack VRT file of unwrapped data.\n'+
-                            'default: unwrapStack.vrt')
-    stack.add_argument('-c','--coherence-stack-name', dest='cohStack', type=str,
+                            'default: %(default)s')
+    stack.add_argument('-c','--coherence-stack-name', dest='corFile', type=str,
                        default="cohStack.vrt",
                        help='Name of the stack VRT file of coherence data.\n'+
-                            'default: cohStack.vrt')
-    stack.add_argument('-l','--conn-comp-name', dest='connCompStack', type=str,
+                            'default: %(default)s')
+    stack.add_argument('-l','--conn-comp-name', dest='connCompFile', type=str,
                        default="connCompStack.vrt",
                        help='Name of the stack VRT file of connected component data.\n' +
-                            'default: connCompStack.vrt')
+                            'default: %(default)s')
 
-    geom = parser.add_argument_group('Geometry')
-    geom.add_argument('-d','--dem', dest='dem', type=str, required=True,
+    # geometryGeo
+    geom = parser.add_argument_group('geometry')
+    geom.add_argument('-d','--dem', dest='demFile', type=str,
                       help='Name of the DEM file')
-    geom.add_argument('-i','--incidence-angle', dest='incAngle', type=str, required=True,
+    geom.add_argument('-i','--incidence-angle', dest='incAngleFile', type=str,
                       help='Name of the incidence angle file')
-    geom.add_argument('-a','--az-angle','--azimuth-angle', dest='azAngle', type=str,
+    geom.add_argument('-a','--az-angle','--azimuth-angle', dest='azAngleFile', type=str,
                       help='Name of the azimuth angle file.')
-    geom.add_argument('--water-mask', dest='waterMask', type=str,
+    geom.add_argument('--water-mask', dest='waterMaskFile', type=str,
                       help='Name of the water mask file')
     return parser
 
@@ -79,27 +101,110 @@ def cmd_line_parse(iargs = None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
 
-    # check input dir and files
-    inps.stackDir = os.path.abspath(inps.stackDir)
-    inps.cohStack = os.path.join(inps.stackDir, inps.cohStack)
-    inps.unwStack = os.path.join(inps.stackDir, inps.unwStack)
-    inps.connCompStack = os.path.join(inps.stackDir, inps.connCompStack)
-    for vrtFile in [inps.cohStack, inps.unwStack, inps.connCompStack]:
-        if not os.path.isfile(vrtFile):
-            raise FileNotFoundError(vrtFile)
+    # --template
+    if inps.template_file:
+        inps = read_template2inps(inps.template_file, inps)
+
+    # --stack-dir
+    if inps.stackDir is not None:
+        inps.stackDir = os.path.abspath(inps.stackDir)
+        inps.corFile = os.path.join(inps.stackDir, inps.corFile)
+        inps.unwFile = os.path.join(inps.stackDir, inps.unwFile)
+        inps.connCompFile = os.path.join(inps.stackDir, inps.connCompFile)
+
+    # required datasets
+    required_keys = ['unwFile', 'corFile', 'connCompFile', 'demFile', 'incAngleFile']
+    for key in required_keys:
+        fname = vars(inps)[key]
+        if not os.path.isfile(fname):
+            parser.print_usage()
+            print('required dataset "{}" not found in: {}.'.format(key, fname))
+            raise SystemExit()
 
     return inps
+
+
+def read_template2inps(template_file, inps=None):
+    """Read input template file into inps"""
+    if not inps:
+        inps = cmd_line_parse()
+    iDict = vars(inps)
+
+    print('read options from template file: {}'.format(os.path.basename(template_file)))
+    template = readfile.read_template(template_file)
+    template = ut.check_template_auto_value(template)
+
+    key_prefix = 'mintpy.load.'
+    keys = [i for i in list(iDict.keys()) if key_prefix+i in template.keys()]
+    for key in keys:
+        value = template[key_prefix+key]
+        if value:
+            iDict[key] = str(value)
+
+    return inps
+
+
+def run_or_skip(inps, dsNameDict, out_file):
+    flag = 'run'
+
+    # check 1 - update mode status
+    if not inps.updateMode:
+        return flag
+
+    # check 2 - output file existance
+    if ut.run_or_skip(out_file, check_readable=True) == 'run':
+        return flag
+
+    # check 3 - output dataset info
+    in_size = (inps.length, inps.width)
+
+    if 'unwrapPhase' in dsNameDict.keys():
+        # compare date12 and size
+        ds = gdal.Open(inps.unwFile, gdal.GA_ReadOnly)
+        in_date12_list = [ds.GetRasterBand(i+1).GetMetadata("unwrappedPhase")['Dates'] 
+                          for i in range(inps.num_pair)]
+        in_date12_list = ['_'.join(d.split('_')[::-1]) for d in in_date12_list]
+
+        out_obj = ifgramStack(out_file)
+        out_obj.open(print_msg=False)
+        out_size = (out_obj.length, out_obj.width)
+        out_date12_list = out_obj.get_date12_list(dropIfgram=False)
+
+        if out_size == in_size and set(in_date12_list).issubset(set(out_date12_list)):
+            print(('All date12   exists in file {} with same size as required,'
+                   ' no need to re-load.'.format(os.path.basename(out_file))))
+            flag = 'skip'
+
+    elif 'height' in dsNameDict.keys():
+        # compare dataset names and size
+        in_dsNames = list(dsNameDict.keys())
+
+        out_obj = geometry(out_file)
+        out_obj.open(print_msg=False)
+        out_size = (out_obj.length, out_obj.width)
+        out_dsNames = out_obj.datasetNames
+
+        if out_size == in_size and set(in_dsNames).issubset(set(out_dsNames)):
+            print(('All datasets exists in file {} with same size as required,'
+                   ' no need to re-load.'.format(os.path.basename(out_file))))
+            flag = 'skip'
+            
+    return flag
 
 
 ####################################################################################
 def extract_metadata(stack):
 
-    print('extract metadata from {}'.format(stack))
+    meta = {}
     ds = gdal.Open(stack, gdal.GA_ReadOnly)
+    if not ds:
+        raise RuntimeError('Failed to open file {} with GDAL.'.format(stack))
+
+    # read metadata from unwrapStack.vrt file
+    print('extract metadata from {}'.format(stack))
     metaUnw = ds.GetRasterBand(1).GetMetadata("unwrappedPhase")
 
-    # copy over all metadata from unwrappedPhase
-    meta = {}
+    # copy over all metadata from unwrapStack
     for key, value in metaUnw.items():
         if key not in ["Dates", "perpendicularBaseline"]:
             meta[key] = value
@@ -331,9 +436,8 @@ def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack):
     prog_bar.close()
 
     # add MODIFICATION_TIME metadata to each 3D dataset
-    h5["unwrapPhase"].attrs['MODIFICATION_TIME'] = str(time.time())
-    h5["coherence"].attrs['MODIFICATION_TIME'] = str(time.time())
-    h5["connectComponent"].attrs['MODIFICATION_TIME'] = str(time.time())
+    for dsName in ['unwrapPhase','coherence','connectComponent']:
+        h5[dsName].attrs['MODIFICATION_TIME'] = str(time.time())
 
     h5.close()
     print('finished writing to HD5 file: {}'.format(outfile))
@@ -346,60 +450,70 @@ def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack):
 ####################################################################################
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
+    if inps.updateMode:
+        print('update mode: ON')
+    else:
+        print('update mode: OFF')
 
-    # prepare metadata
-    metadata = extract_metadata(inps.unwStack)
-    length = metadata["LENGTH"]
-    width = metadata["WIDTH"]
-    numPairs = metadata["NUMBER_OF_PAIRS"]
+    # extract metadata
+    metadata = extract_metadata(inps.unwFile)
+    inps.length = metadata["LENGTH"]
+    inps.width = metadata["WIDTH"]
+    inps.num_pair = metadata["NUMBER_OF_PAIRS"]
 
     # prepare output directory
-    inputDir = os.path.join(os.path.abspath(inps.workDir), "inputs")
-    if not os.path.exists(inputDir):
-        os.makedirs(inputDir)
+    out_dir = os.path.dirname(inps.outfile[0])
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
 
-    # 1. geometryGeo
-    # define dataset structure
+    ########## output file 1 - ifgramStack
+    # define dataset structure for ifgramStack
     dsNameDict = {
-        "height": (np.float32, (length, width)),
-        "incidenceAngle": (np.float32, (length, width)),
-        "slantRangeDistance": (np.float32, (length, width)),
-    }
-    if inps.azAngle is not None:
-        dsNameDict["azimuthAngle"] = (np.float32, (length, width))
-    if inps.waterMask is not None:
-        dsNameDict["waterMask"] = (np.bool_, (length, width))
-
-    # write data to disk
-    geom_file = os.path.join(inputDir, "geometryGeo.h5")
-    metadata['FILE_TYPE'] = 'geometry'
-    layout_hdf5(geom_file, dsNameDict, metadata)
-    write_geometry(geom_file,
-                   demFile=inps.dem,
-                   incAngleFile=inps.incAngle,
-                   azAngleFile=inps.azAngle,
-                   waterMaskFile=inps.waterMask)
-
-    # 2. ifgramStack
-    # define dataset structure
-    dsNameDict = {
-        "bperp": (np.float32, (numPairs,)),
-        "coherence": (np.float32, (numPairs, length, width)),
-        "connectComponent": (np.int16, (numPairs, length, width)),
-        "date": (np.dtype('S8'), (numPairs, 2)),
-        "dropIfgram": (np.bool_, (numPairs,)),
-        "unwrapPhase": (np.float32, (numPairs, length, width)),
+        "date"             : (np.dtype('S8'), (inps.num_pair, 2)),
+        "dropIfgram"       : (np.bool_,       (inps.num_pair,)),
+        "bperp"            : (np.float32,     (inps.num_pair,)),
+        "unwrapPhase"      : (np.float32,     (inps.num_pair, inps.length, inps.width)),
+        "coherence"        : (np.float32,     (inps.num_pair, inps.length, inps.width)),
+        "connectComponent" : (np.int16,       (inps.num_pair, inps.length, inps.width)),
     }
 
-    # write data to disk
-    ifgram_file = os.path.join(inputDir, "ifgramStack.h5")
-    metadata['FILE_TYPE'] = 'ifgramStack'
-    layout_hdf5(ifgram_file, dsNameDict, metadata)
-    write_ifgram_stack(ifgram_file,
-                       inps.unwStack,
-                       inps.cohStack,
-                       inps.connCompStack)
-    return ifgram_file, geom_file
+    if run_or_skip(inps, dsNameDict, out_file=inps.outfile[0]) == 'run':
+        # initiate h5 file with defined structure
+        metadata['FILE_TYPE'] = 'ifgramStack'
+        layout_hdf5(inps.outfile[0], dsNameDict, metadata)
+
+        # write data to h5 file in disk
+        write_ifgram_stack(inps.outfile[0],
+                           inps.unwFile,
+                           inps.corFile,
+                           inps.connCompFile)
+
+    ########## output file 2 - geometryGeo
+    # define dataset structure for geometry
+    dsNameDict = {
+        "height"             : (np.float32, (inps.length, inps.width)),
+        "incidenceAngle"     : (np.float32, (inps.length, inps.width)),
+        "slantRangeDistance" : (np.float32, (inps.length, inps.width)),
+    }
+    if inps.azAngleFile is not None:
+        dsNameDict["azimuthAngle"] = (np.float32, (inps.length, inps.width))
+    if inps.waterMaskFile is not None:
+        dsNameDict["waterMask"]    = (np.bool_,   (inps.length, inps.width))
+
+    if run_or_skip(inps, dsNameDict, out_file=inps.outfile[1]) == 'run':
+        # initiate h5 file with defined structure
+        metadata['FILE_TYPE'] = 'geometry'
+        layout_hdf5(inps.outfile[1], dsNameDict, metadata)
+
+        # write data to disk
+        write_geometry(inps.outfile[1],
+                       demFile=inps.demFile,
+                       incAngleFile=inps.incAngleFile,
+                       azAngleFile=inps.azAngleFile,
+                       waterMaskFile=inps.waterMaskFile)
+
+    print('-'*50)
+    return inps.outfile
 
 
 ####################################################################################


### PR DESCRIPTION
**Description of proposed changes**

This PR support `mintpy.load.processor = aria` in smallbaselineApp.py, so that users do not need to manually run prep_aria.py anymore. Instead, one just need to setup the template file and run smallbaselineApp.py directly after ARIA-tools commands.

An example directory structure with template options for ARIA is provided in the doc.

An example template file for the San Francisco dataset is uploaded.

The jupyter notebook example in  need to be updated as well, it will be in another PR in MintPy-tutorial repo.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.