### PR TITLE
geo input dset: use center inc angle / range distance if missing in input template

### DIFF
--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -23,11 +23,10 @@ except ImportError:
 ####################################################################################
 EXAMPLE = """example:
   prep_aria.py -t SanFranSenDT42.txt --update
-  prep_aria.py -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt
-  prep_aria.py -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/20150605_20150512.vrt
-               -a azimuthAngle/20150605_20150512.vrt --water-mask mask/watermask.msk
+  prep_aria.py -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/*.vrt
+  prep_aria.py -s stack/ -d DEM/SRTM_3arcsec.dem -i incidenceAngle/*.vrt  -a azimuthAngle/*.vrt --water-mask mask/watermask.msk
 
-  # run ARIA-tools to download / extract / prepare inteferograms stack before MintPy.
+  # before above, one should run ARIA-tools to download / extract / prepare inteferograms stack.
   # reference: https://github.com/aria-tools/ARIA-tools
   ariaDownload.py -b '37.25 38.1 -122.6 -121.75' --track 42
   ariaTSsetup.py -f 'products/*.nc' -b '37.25 38.1 -122.6 -121.75' --mask Download

--- a/mintpy/prep_snap.py
+++ b/mintpy/prep_snap.py
@@ -8,11 +8,15 @@
 
 
 import os
+import sys
 import argparse
 import datetime
 import math
 from mintpy.objects.sensor import standardedSensorNames
 from mintpy.utils import readfile, writefile, utils as ut
+
+
+SPEED_OF_LIGHT = 299792458  # m / s
 
 
 ##################################################################################################
@@ -31,28 +35,6 @@ DESCRIPTION = """
   then extract the elevation band only. Use Band Subset > save BEAM-DIMAP file
 
   Currently only works for geocoded (terrain correction step in SNAP) interferograms.
-
-  Metadata extraction from .dim was built around products generated via the following
-  workflow:
-    - Read
-    - Slice assembly (if required)
-    - Apply orbit file
-    - Split product (extract relevant polarisation and subswath swaths)
-    + Following is done per subswath [IW1, IW2, IW3]
-        - Back geocoding
-        - Enhanced spectral diversity (if more than one burst)
-        - Interferogram generation
-        - TOPSAR Deburst
-        - Topophase removal
-        - Goldstein phase filtering
-    - Merge subswaths (if more than one swath was done)
-    - Add elevation
-    - Coherence
-    - Subset geometry and all seperate bands (elevation, ifg, coh) (by geometry only possible after working with bursts)
-    - Snaphu export for ifg
-    - SNAPHU phase unwrapping
-    - Snaphu import
-    - Terrain correct (all products)
 """
 
 EXAMPLE = """example:
@@ -79,8 +61,9 @@ def cmd_line_parse(iargs=None):
 ##################################################################################################
 def get_ellpsoid_local_radius(xyz):
     """Calculate satellite height and ellpsoid local radius from orbital state vector
-    Parameters: xyz : tuple of 3 float, orbital state vector
-    Reference: isce2.isceobj.Planet
+    Parameters: xyz          - tuple of 3 float, orbital state vector
+    Reference:  height       - float, satellite altitude in m
+                earth_radius - float, Earth radius in m
     """
 
     # Code simplified from from ISCE2.isceobj.Planet.xyz_to_llh())
@@ -119,13 +102,10 @@ def get_ellpsoid_local_radius(xyz):
     return height, earth_radius
 
 
-# Parse .dim file
-def utm_dim_to_rsc(fname):
-    ''' read and extract attributes from a SNAP .dim file and create mintpy .rsc file
-    Inputs: 
-        fname: SNAP .dim interferogram/coherence/unwrapped filepath
-    Outputs:
-        atr : dict, Attributes dictionary
+def extract_snap_metadata(fname):
+    ''' read and extract attributes from a SNAP .dim file
+    Parameters: fname - str, path of SNAP .dim file
+    Returns:    atr   - dict, metadata
     '''
 
     # Read XML and extract required vals - using basic file reader 
@@ -141,9 +121,10 @@ def utm_dim_to_rsc(fname):
             if "Master: " in line:
                 dates.append(line.split(": ")[1].split('">')[0])
             if "radar_frequency" in line:
-                rf = 299.792458 / float(line.split(">")[1].split("<")[0])  
+                freq = float(line.split(">")[1].split("<")[0]) * 1e6
+                wvl = SPEED_OF_LIGHT / freq
             if "NROWS" in line:
-                lenght = int(line.split(">")[1].split("<")[0])
+                length = int(line.split(">")[1].split("<")[0])
             if "NCOLS" in line:
                 width = int(line.split(">")[1].split("<")[0])
             if "DATA_TYPE" in line:
@@ -200,24 +181,25 @@ def utm_dim_to_rsc(fname):
                 y.append(line.split(">")[1].split("<")[0])
             if '"z"' in line:
                 z.append(line.split(">")[1].split("<")[0])
-            
-    # Do datetime things needed after the loop
-    # Calculate the center of the scene as floating point seconds
-    first_time_dt = datetime.datetime.strptime(first_time, '%d-%b-%Y %H:%M:%S.%f')
-    last_time_dt = datetime.datetime.strptime(last_time, '%d-%b-%Y %H:%M:%S.%f')
-    center_time_dt = first_time_dt + ((last_time_dt - first_time_dt) / 2)
-    center_time_s = float(datetime.timedelta(
-        hours=center_time_dt.hour, 
-        minutes=center_time_dt.minute,
-        seconds=center_time_dt.second,
-        microseconds=center_time_dt.microsecond).total_seconds())
-    # Extract master slave date in yymmdd format
-    master_dt = datetime.datetime.strptime(dates[0], "%d%b%Y")
-    master = master_dt.strftime("%Y%m%d")[2:8]
-    slave_dt = datetime.datetime.strptime(dates[1], "%d%b%Y")
-    slave = slave_dt.strftime("%Y%m%d")[2:8]
 
-    xyz = (float(x[0]), float(y[0]), float(z[0])) # Using first state vector for simplicity
+    atr = {}
+    # Calculate the center of the scene as floating point seconds
+    start_utc = datetime.datetime.strptime(first_time, '%d-%b-%Y %H:%M:%S.%f')
+    end_utc   = datetime.datetime.strptime(last_time,  '%d-%b-%Y %H:%M:%S.%f')
+    center_utc = start_utc + ((end_utc - start_utc) / 2)
+    center_seconds = (center_utc.hour * 3600.0 + 
+                      center_utc.minute * 60. + 
+                      center_utc.second)
+    atr["CENTER_LINE_UTC"] = center_seconds
+
+    # Extract master slave date in yymmdd format
+    date1 = datetime.datetime.strptime(dates[0], "%d%b%Y").strftime("%Y%m%d")[2:8]
+    date2 = datetime.datetime.strptime(dates[1], "%d%b%Y").strftime("%Y%m%d")[2:8]
+    atr["DATE12"] = "{}-{}".format(date1, date2)
+
+    # calculate ellipsoid radius and satellite height from state vector
+    # using first state vector for simplicity
+    xyz = (float(x[0]), float(y[0]), float(z[0]))
     height, earth_radius = get_ellpsoid_local_radius(xyz)
 
     # Calculate range/azimuth pixel sizes
@@ -225,31 +207,33 @@ def utm_dim_to_rsc(fname):
     azimuth_pixel_size = float(az_pixel[0])*((earth_radius + height)/earth_radius)
 
     # Add values to dict
-    atr = {}
     atr['PROCESSOR'] = 'snap'
     atr['FILE_TYPE'] = os.path.basename(fname).split('_')[-2] # yyyymmdd_yyyymmdd_type_tc.dim
-    atr["WAVELENGTH"] = rf
-    atr["P_BASELINE_TOP_HDR"], atr["P_BASELINE_BOTTOM_HDR"] = bp[1], bp[1]
-    atr["DATE12"] = str(master) + "-" + str(slave)
     atr["WIDTH"] = width
-    atr["LENGTH"], atr["FILE_LENGTH"]  = lenght, lenght
+    atr["LENGTH"] = length
     atr["DATA_TYPE"] = data_type
+    atr["WAVELENGTH"] = wvl
+    atr["P_BASELINE_TOP_HDR"] = bp[1]
+    atr["P_BASELINE_BOTTOM_HDR"] = bp[1]
     atr["ANTENNA_SIDE"] = antenna_side
-    atr["CENTER_LINE_UTC"] = center_time_s
     atr["LAT_REF1"], atr["LONG_REF1"] = first_near_lat, first_near_long
     atr["LAT_REF2"], atr["LONG_REF2"] = first_far_lat, first_far_long
     atr["LAT_REF3"], atr["LONG_REF3"] = last_near_lat, last_near_long
     atr["LAT_REF4"], atr["LONG_REF4"] = last_far_lat, last_far_long
     atr["ORBIT_DIRECTION"] = direction
-    atr["ALOOKS"], atr["RLOOKS"] = int(float(azimuth_looks[0])), int(float(range_looks[0]))
+    atr["ALOOKS"] = int(float(azimuth_looks[0]))
+    atr["RLOOKS"] = int(float(range_looks[0]))
     atr["PRF"] = prf
-    atr["STARTING_RANGE"] = starting_range
     atr["PLATFORM"] = standardedSensorNames[platform.replace('-','').lower()]
     atr["HEADING"] = heading
     atr["EARTH_RADIUS"] =  earth_radius
     atr["HEIGHT"] = height
     atr["RANGE_PIXEL_SIZE"] = range_pixel_size
     atr["AZIMUTH_PIXEL_SIZE"] = azimuth_pixel_size
+
+    atr['INCIDENCE_ANGLE'] = inc_angle_mid
+    atr["STARTING_RANGE"] = starting_range
+    atr["SLANT_RANGE_DISTANCE"] = ut.incidence_angle2slant_range_distance(atr, inc_angle_mid)
 
     # Convert 3.333e-4 to 0.0003333
     transform = [str(float(i)) for i in transform]
@@ -286,14 +270,15 @@ def main(iargs=None):
         dim_file = os.path.dirname(img_file)[:-4]+'dim'
 
         # get metadata dict from *.dim file
-        atr = utm_dim_to_rsc(dim_file)
+        atr = extract_snap_metadata(dim_file)
 
         # write metadata dict to *.rsc file
         rsc_file = os.path.splitext(img_file)[0]+'.rsc'
         rsc_file = write_rsc(atr, out_file=rsc_file)
+
     return
 
 
 ##################################################################################################
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/mintpy/utils/isce_utils.py
+++ b/mintpy/utils/isce_utils.py
@@ -15,6 +15,12 @@ try:
     import gdal
 except ImportError:
     raise ImportError("Can not import gdal!")
+
+# suppress matplotlib DEBUG message
+import logging
+mpl_logger = logging.getLogger('matplotlib')
+mpl_logger.setLevel(logging.WARNING)
+
 import isce
 import isceobj
 from mintpy.utils import readfile, writefile, utils1 as ut

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -131,6 +131,40 @@ def incidence_angle(atr, dem=None, dimension=2, print_msg=True):
     return inc_angle
 
 
+def incidence_angle2slant_range_distance(atr, inc_angle):
+    """Calculate the corresponding slant range distance given an incidence angle
+
+    Law of sines:
+               r + H                   r               range_dist
+       --------------------- = ----------------- = ------------------ = 2R
+        sin(pi - inc_angle)     sin(look_angle)     sin(range_angle)
+
+    where range_angle = inc_angle - look_angle
+          R is the radius of the circumcircle.
+
+    link: http://www.ambrsoft.com/TrigoCalc/Triangle/BasicLaw/BasicTriangle.htm
+
+    Parameters: atr         - dict, metadata including the following items:
+                                  EARTH_RADIUS
+                                  HEIGHT
+                inc_angle   - float, incidence angle in degree
+    Returns:    slant_range - float, slant range distance
+    """
+
+    inc_angle = float(inc_angle) / 180 * np.pi
+    r = float(atr['EARTH_RADIUS'])
+    H = float(atr['HEIGHT'])
+
+    # calculate 2R based on the law of sines
+    R2 = (r + H) / np.sin(np.pi - inc_angle)
+
+    look_angle = np.arcsin( r / R2 )
+    range_angle = inc_angle - look_angle
+    range_dist = R2 * np.sin(range_angle)
+
+    return range_dist
+
+
 def range_ground_resolution(atr, print_msg=False):
     """Get range resolution on the ground in meters,
         from ROI_PAC attributes, for file in radar coord

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -147,11 +147,12 @@ def incidence_angle2slant_range_distance(atr, inc_angle):
     Parameters: atr         - dict, metadata including the following items:
                                   EARTH_RADIUS
                                   HEIGHT
-                inc_angle   - float, incidence angle in degree
+                inc_angle   - float / np.ndarray, incidence angle in degree
     Returns:    slant_range - float, slant range distance
     """
-
-    inc_angle = float(inc_angle) / 180 * np.pi
+    if isinstance(inc_angle, str):
+        inc_angle = float(inc_angle)
+    inc_angle = np.array(inc_angle, dtype=np.float32) / 180 * np.pi
     r = float(atr['EARTH_RADIUS'])
     H = float(atr['HEIGHT'])
 


### PR DESCRIPTION
**Description of proposed changes**

+ objects/stackDict: for dataset in geo-coordinates, use the INCIDENCE_ANGLE and SLANT_RANGE_DISTANCE from metadata to create the constant 2D matrix to write to geometry files if those two datasets are missing.

+ utils/utils0: add incidence_angle2slant_range_distance() based on the law of sines

+ prep_snap:
   - add INCIDENCE_ANGLE and SLANT_RANGE_DISTANCE metadata
   - rename utm_dim_to_rsc() to extract_snap_metadata()

+ utils/isce_utils: suppress matplotlib DEBUG msg

+ prep_aria: use wildcard in example input

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
