### PR TITLE
add Dask local cluster type

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -129,9 +129,10 @@ mintpy.networkInversion.minRedundancy   = auto #[1-inf], auto for 1.0, min num_i
 
 ## Parallel processing with Dask for HPC
 mintpy.networkInversion.parallel    = auto #[yes / no], auto for no, parallel processing using dask
-mintpy.networkInversion.cluster     = auto #[slurm / pbs / lsf], auto for SLURM, cluster type
+mintpy.networkInversion.cluster     = auto #[slurm / pbs / lsf / local], auto for local, cluster type
 mintpy.networkInversion.config      = auto #[slurm / pbs / lsf / no], auto for no (same as cluster), configuration name
-mintpy.networkInversion.numWorker   = auto #[int > 0], auto for 40, number of works to deploy
+mintpy.networkInversion.numWorker   = auto #[int > 0 / all], auto for 4 (local) or 40 (non-local), 'all' to use all
+                                           # local resources available, number of works to deploy
 mintpy.networkInversion.walltime    = auto #[HH:MM], auto for 00:40, walltime for each dask worker
 
 ## Temporal coherence is calculated and used to generate the mask as the reliability measure

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -55,7 +55,7 @@ mintpy.networkInversion.minNumPixel      = 100
 mintpy.networkInversion.shadowMask       = yes
 
 mintpy.networkInversion.parallel         = no
-mintpy.networkInversion.cluster          = slurm
+mintpy.networkInversion.cluster          = local
 mintpy.networkInversion.config           = no
 mintpy.networkInversion.numWorker        = 40
 mintpy.networkInversion.walltime         = 00:40

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -1095,9 +1095,12 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
 
         # Look at the ~/.config/dask/mintpy.yaml file for Changing the Dask configuration defaults
 
-        # This line submits NUM_WORKERS jobs to Pegasus to start a bunch of workers
+        # This line submits NUM_WORKERS jobs to the cluster to start a bunch of workers
         # In tests on Pegasus `general` queue in Jan 2019, no more than 40 workers could RUN
         # at once (other user's jobs gained higher priority in the general at that point)
+        #
+        # When running as a local cluster, we want to use all available cpus on the computing node, 
+        # which is accssible via the `multiprocessing` stndard library.
         NUM_WORKERS = inps.numWorker
         if inps.cluster == 'local':
             import multiprocessing as mpc
@@ -1106,9 +1109,6 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
         # FA: the following command starts the jobs
         cluster = get_cluster(cluster_type=inps.cluster, walltime=inps.walltime, config_name=inps.config)
         cluster.scale(NUM_WORKERS)
-        #print("JOB COMMAND CALLED FROM PYTHON:\n\n", cluster.job_script())
-        #with open('dask_command_run_from_python.txt', 'w') as f:
-        #      f.write(cluster.job_script() + '\n')
 
         # This line needs to be in a function or in a `if __name__ == "__main__":` block. If it is in no function
         # or "main" block, each worker will try to create its own client (which is bad) when loading the module

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -1102,9 +1102,9 @@ def ifgram_inversion(ifgram_file='ifgramStack.h5', inps=None):
         # When running as a local cluster, we want to use all available cpus on the computing node, 
         # which is accssible via the `multiprocessing` stndard library.
         NUM_WORKERS = inps.numWorker
-        if inps.cluster == 'local':
-            import multiprocessing as mpc
-            NUM_WORKERS = mpc.cpu_count()
+        # if inps.cluster == 'local':
+        #     import multiprocessing as mpc
+        #     NUM_WORKERS = mpc.cpu_count()
 
         # FA: the following command starts the jobs
         cluster = get_cluster(cluster_type=inps.cluster, walltime=inps.walltime, config_name=inps.config)

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -26,6 +26,10 @@ def get_cluster(cluster_type, **kwargs):
         raise ValueError(msg)
     print("Dask cluster type: {}".format(cluster_type))
 
+    # No need to do the extra configuration checking if using LocalCluster
+    if cluster_type == 'local':
+        return LocalCluster()
+
     # check input config name
     if 'config_name' in kwargs.keys():
         kwargs['config_name'] = check_config_name(kwargs['config_name'], cluster_type)
@@ -43,9 +47,12 @@ def get_cluster(cluster_type, **kwargs):
         cluster = PBSCluster(**kwargs)
     elif cluster_type == 'slurm':
         cluster = SLURMCluster(**kwargs)
-    else:
-        cluster = LocalCluster()
 
+    # Print and write job command file for HPC cluster types
+    print("JOB COMMAND CALLED FROM PYTHON:\n\n", cluster.job_script())
+    with open('dask_command_run_from_python.txt', 'w') as f:
+        f.write(cluster.job_script() + '\n')
+    
     return cluster
 
 

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -9,6 +9,7 @@
 try:
     import dask
     from dask_jobqueue import LSFCluster, PBSCluster, SLURMCluster
+    from dask.distributed import LocalCluster
 except ImportError:
     raise ImportError('Cannot import dask or dask_jobqueue!')
 
@@ -18,7 +19,7 @@ def get_cluster(cluster_type, **kwargs):
 
     # check input cluster type
     cluster_type = cluster_type.lower()
-    cluster_list = ['lsf','pbs','slurm']
+    cluster_list = ['lsf','pbs','slurm','local']
     if cluster_type not in cluster_list:
         msg = "Cluster type '{}' not supported".format(cluster_type)
         msg += '\nsupported cluster types: {}'.format(cluster_list)
@@ -42,6 +43,8 @@ def get_cluster(cluster_type, **kwargs):
         cluster = PBSCluster(**kwargs)
     elif cluster_type == 'slurm':
         cluster = SLURMCluster(**kwargs)
+    else:
+        cluster = LocalCluster()
 
     return cluster
 


### PR DESCRIPTION
Included ability to run `ifgram_inversion.py` in parallel on a local computer using the dask `LocalCluster` object. This adds both the ability to use multiple CPU cores through dask on a local machine, as well as run the ifgram_inversion step on all available CPU cores on a HPC node that has been allocated for other processing.

No additional configuration steps are required other than modifying the `smallbaselineApp.cfg: mintpy.networkInversion.cluster` parameter to have the value `local`.  


**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
