### PR TITLE
replace xml.etree with defusedxml for ElementTree

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ ts_data, meta = readfile.read('timeseries_ERA5_ramp_demErr.h5')
 
 ### 3. [Documentation](https://mintpy.readthedocs.io/) ###
 
-Detailed algorithms implemented in the software are described in [Yunjun et al. (2019)](https://doi.org/10.1016/j.cageo.2019.104331).
+Algorithms implemented in the software are described in details in [Yunjun et al. (2019)](https://doi.org/10.1016/j.cageo.2019.104331).
 
 + [Tutorials in Jupyter Notebook](https://github.com/insarlab/MintPy-tutorial)
 + [Example datasets](./demo_dataset.md)

--- a/docs/conda.txt
+++ b/docs/conda.txt
@@ -4,6 +4,7 @@ cdsapi
 cvxopt
 dask>=1.0
 dask-jobqueue>=0.3
+defusedxml
 ecCodes
 h5py
 lxml

--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -14,6 +14,7 @@ dependencies:
   - cvxopt
   - dask>=1.0
   - dask-jobqueue>=0.3
+  - defusedxml
   - ecCodes
   - h5py
   - lxml

--- a/docs/ports.txt
+++ b/docs/ports.txt
@@ -70,6 +70,7 @@ swig
 swig-python
 gdal +expat +geos +hdf5 +netcdf +openjpeg +postgresql95 +sqlite3
 py37-cython
+py37-defusedxml
 py37-mpi4py +gcc7 +openmpi
 py37-numpy +gcc7 +openblas
 py37-scipy +gcc7 +openblas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 cvxopt
 dask>=1.0
 dask-jobqueue>=0.3
+defusedxml
 h5py
 lxml
 matplotlib


### PR DESCRIPTION
**Description of proposed changes**

+ use `defusedxml.ElementTree` module to replace the vulnerable `xml.etree.ElementTree` module for XML file parsing.

This was used in utils.readfile.read_isce_xml() and dem_gsi.py, both of them are now either be replaced or unused.

+ add defusedxml to dependency docs

**Reminders**

- [ ] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`