### PR TITLE
plot_smallbaselineApp.sh: running view.py commands in parallel

### DIFF
--- a/sh/plot_smallbaselineApp.sh
+++ b/sh/plot_smallbaselineApp.sh
@@ -45,82 +45,83 @@ view='view.py --nodisplay --dpi 150 --update '
 opt=' --dem '$dem_file' --mask '$mask_file' -u cm '
 #opt=' --dem '$dem_file' --mask '$mask_file' -u cm --vlim -2 2'
 if [ $plot_key_files -eq 1 ]; then
-    file=velocity.h5;              test -f $file && $view $file $opt               >> $log_file
-    file=temporalCoherence.h5;     test -f $file && $view $file -c gray --vlim 0 1 >> $log_file
-    file=maskTempCoh.h5;           test -f $file && $view $file -c gray --vlim 0 1 >> $log_file
-    file=inputs/geometryRadar.h5;  test -f $file && $view $file                    >> $log_file
-    file=inputs/geometryGeo.h5;    test -f $file && $view $file                    >> $log_file
+    file=velocity.h5;              test -f $file && $view $file $opt               >> $log_file &
+    file=temporalCoherence.h5;     test -f $file && $view $file -c gray --vlim 0 1 >> $log_file &
+    file=maskTempCoh.h5;           test -f $file && $view $file -c gray --vlim 0 1 >> $log_file &
+    file=inputs/geometryRadar.h5;  test -f $file && $view $file                    >> $log_file &
+    file=inputs/geometryGeo.h5;    test -f $file && $view $file                    >> $log_file &
 fi
 
 
 ## Loaded Dataset
 if [ $plot_loaded_data -eq 1 ]; then
     file=inputs/ifgramStack.h5
-    test -f $file && h5ls $file/unwrapPhase      && $view $file unwrapPhase-       --zero-mask --wrap >> $log_file
-    test -f $file && h5ls $file/unwrapPhase      && $view $file unwrapPhase-       --zero-mask        >> $log_file
-    test -f $file && h5ls $file/coherence        && $view $file coherence-         --mask no          >> $log_file
-    test -f $file && h5ls $file/connectComponent && $view $file connectComponent-  --mask no          >> $log_file
+    test -f $file && h5ls $file/unwrapPhase      && $view $file unwrapPhase-       --zero-mask --wrap >> $log_file &
+    test -f $file && h5ls $file/unwrapPhase      && $view $file unwrapPhase-       --zero-mask        >> $log_file &
+    test -f $file && h5ls $file/coherence        && $view $file coherence-         --mask no          >> $log_file &
+    test -f $file && h5ls $file/connectComponent && $view $file connectComponent-  --mask no          >> $log_file &
 
     # phase-unwrapping error correction
     for dset in unwrapPhase_bridging unwrapPhase_phaseClosure unwrapPhase_bridging_phaseClosure; do
-        test -f $file && h5ls $file/$dset        && $view $file $dset-             --zero-mask        >> $log_file
+        test -f $file && h5ls $file/$dset        && $view $file $dset-             --zero-mask        >> $log_file &
     done
 fi
 
 
 ## Auxliary Files from loaded dataset
 if [ $plot_loaded_data_aux -eq 1 ]; then
-    file=avgPhaseVelocity.h5;   test -f $file && $view $file                      >> $log_file
-    file=avgSpatialCoh.h5;      test -f $file && $view $file -c gray --vlim 0 1   >> $log_file
-    file=maskConnComp.h5;       test -f $file && $view $file -c gray --vlim 0 1   >> $log_file
+    file=avgPhaseVelocity.h5;   test -f $file && $view $file                      >> $log_file &
+    file=avgSpatialCoh.h5;      test -f $file && $view $file -c gray --vlim 0 1   >> $log_file &
+    file=maskConnComp.h5;       test -f $file && $view $file -c gray --vlim 0 1   >> $log_file &
 fi
 
 
 ## Time-series files
 opt='--mask '$mask_file' --noaxis -u cm --wrap --wrap-range -10 10 '
 if [ $plot_timeseries -eq 1 ]; then
-    file=timeseries.h5;                             test -f $file && $view $file $opt >> $log_file
+    file=timeseries.h5;                             test -f $file && $view $file $opt >> $log_file &
 
     #LOD for Envisat
-    file=timeseries_LODcor.h5;                      test -f $file && $view $file $opt >> $log_file
-    file=timeseries_LODcor_ECMWF.h5;                test -f $file && $view $file $opt >> $log_file
-    file=timeseries_LODcor_ECMWF_demErr.h5;         test -f $file && $view $file $opt >> $log_file
-    file=timeseries_LODcor_ECMWF_ramp.h5;           test -f $file && $view $file $opt >> $log_file
-    file=timeseries_LODcor_ECMWF_ramp_demErr.h5;    test -f $file && $view $file $opt >> $log_file
+    file=timeseries_LODcor.h5;                      test -f $file && $view $file $opt >> $log_file &
+    file=timeseries_LODcor_ECMWF.h5;                test -f $file && $view $file $opt >> $log_file &
+    file=timeseries_LODcor_ECMWF_demErr.h5;         test -f $file && $view $file $opt >> $log_file &
+    file=timeseries_LODcor_ECMWF_ramp.h5;           test -f $file && $view $file $opt >> $log_file &
+    file=timeseries_LODcor_ECMWF_ramp_demErr.h5;    test -f $file && $view $file $opt >> $log_file &
 
     #w tropo delay corrections
     for tropo in ERA5 ECMWF MERRA NARR tropHgt; do
-        file=timeseries_${tropo}.h5;                test -f $file && $view $file $opt >> $log_file
-        file=timeseries_${tropo}_demErr.h5;         test -f $file && $view $file $opt >> $log_file
-        file=timeseries_${tropo}_ramp.h5;           test -f $file && $view $file $opt >> $log_file
-        file=timeseries_${tropo}_ramp_demErr.h5;    test -f $file && $view $file $opt >> $log_file
+        file=timeseries_${tropo}.h5;                test -f $file && $view $file $opt >> $log_file &
+        file=timeseries_${tropo}_demErr.h5;         test -f $file && $view $file $opt >> $log_file &
+        file=timeseries_${tropo}_ramp.h5;           test -f $file && $view $file $opt >> $log_file &
+        file=timeseries_${tropo}_ramp_demErr.h5;    test -f $file && $view $file $opt >> $log_file &
     done
 
     #w/o trop delay correction
-    file=timeseries_ramp.h5;                        test -f $file && $view $file $opt >> $log_file
-    file=timeseries_demErr_ramp.h5;                 test -f $file && $view $file $opt >> $log_file
+    file=timeseries_ramp.h5;                        test -f $file && $view $file $opt >> $log_file &
+    file=timeseries_demErr_ramp.h5;                 test -f $file && $view $file $opt >> $log_file &
 fi
 
 
 ## Geo coordinates for UNAVCO Time-series InSAR Archive Product
 if [ $plot_geocoded_data -eq 1 ]; then
-    file=./geo/geo_maskTempCoh.h5;                  test -f $file && $view $file -c gray  >> $log_file
-    file=./geo/geo_temporalCoherence.h5;            test -f $file && $view $file -c gray  >> $log_file
-    file=./geo/geo_velocity.h5;                     test -f $file && $view $file velocity >> $log_file
-    file=./geo/geo_timeseries_ECMWF_demErr_ramp.h5; test -f $file && $view $file --noaxis >> $log_file
-    file=./geo/geo_timeseries_ECMWF_demErr.h5;      test -f $file && $view $file --noaxis >> $log_file
-    file=./geo/geo_timeseries_demErr_ramp.h5;       test -f $file && $view $file --noaxis >> $log_file
-    file=./geo/geo_timeseries_demErr.h5;            test -f $file && $view $file --noaxis >> $log_file
+    file=./geo/geo_maskTempCoh.h5;                  test -f $file && $view $file -c gray  >> $log_file &
+    file=./geo/geo_temporalCoherence.h5;            test -f $file && $view $file -c gray  >> $log_file &
+    file=./geo/geo_velocity.h5;                     test -f $file && $view $file velocity >> $log_file &
+    file=./geo/geo_timeseries_ECMWF_demErr_ramp.h5; test -f $file && $view $file --noaxis >> $log_file &
+    file=./geo/geo_timeseries_ECMWF_demErr.h5;      test -f $file && $view $file --noaxis >> $log_file &
+    file=./geo/geo_timeseries_demErr_ramp.h5;       test -f $file && $view $file --noaxis >> $log_file &
+    file=./geo/geo_timeseries_demErr.h5;            test -f $file && $view $file --noaxis >> $log_file &
 fi
 
 
 if [ $plot_the_rest -eq 1 ]; then
     for tropo in ERA5 ECMWF MERRA NARR; do
-        file=velocity${tropo}.h5;   test -f $file && $view $file --mask no >> $log_file
+        file=velocity${tropo}.h5;   test -f $file && $view $file --mask no >> $log_file &
     done
-    file=numInvIfgram.h5;           test -f $file && $view $file --mask no >> $log_file
+    file=numInvIfgram.h5;           test -f $file && $view $file --mask no >> $log_file &
 fi
 
+wait
 
 ## Move/copy picture files to pic folder
 echo "Copy *.txt files into ./pic folder."

--- a/sh/plot_smallbaselineApp.sh
+++ b/sh/plot_smallbaselineApp.sh
@@ -2,7 +2,7 @@
 ###############################################################
 # Plot Results from Routine Workflow with smallbaselineApp.py
 # Author: Zhang Yunjun, 2017-07-23
-# Latest update: 2020-03-20
+# Latest update: 2020-05-12
 ###############################################################
 
 


### PR DESCRIPTION
Add an '&' to all view.py commands and a 'wait' after the last one, so that they all run in parallel.  On stampede this reduces the runtime from 2 minutes to 10 seconds.  On systems that have less cores than commands  it is supposed to run as much commands in parallel as cores are available. This worked for me on linux (16 core machine, pegasus login node). It should behave equally on a Mac, but I did not try.
**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.