### PR TITLE
readfile: support generic defined h5 with 3D matrix

### DIFF
--- a/mintpy/asc_desc2horz_vert.py
+++ b/mintpy/asc_desc2horz_vert.py
@@ -30,7 +30,7 @@ EXAMPLE = """example:
   mask.py velocity.h5 -m maskTempCoh.h5
   geocode.py velocity_msk.h5 -l inputs/geometryRadar.h5 -x 0.00027778 -y -0.00027778 --bbox 32.0 32.5 130.1 130.5
 
-  asc_desc2horz_vert.py AlosAT424/mintpy/geo_velocity_msk.py AlosDT73/mintpy/geo_velocity_msk.py
+  asc_desc2horz_vert.py AlosAT424/mintpy/geo_velocity_msk.h5 AlosDT73/mintpy/geo_velocity_msk.h5
 
   # write horz/vert to two files
   asc_desc2horz_vert.py AlosAT424/mintpy/velocity_msk.h5 AlosDT73/mintpy/velocity_msk.h5
@@ -85,10 +85,9 @@ def cmd_line_parse(iargs=None):
 
     # check spatial resolution
     if any(atr1[i] != atr2[i] for i in ['X_STEP','Y_STEP']):
-        msg = 'file1: {}\n'.format(inps.file[0])
-        msg += 'Y_STEP: {} m, X_STEP: {} m\n'.format(atr1['Y_STEP'], atr1['X_STEP'])
-        msg += 'file2: {}\n'.format(inps.file[1])
-        msg += 'Y_STEP: {} m, X_STEP: {} m'.format(atr2['Y_STEP'], atr2['X_STEP'])
+        msg  = '\tfile1: {}, Y/X_STEP: {} / {} m\n'.format(inps.file[0], atr1['Y_STEP'], atr1['X_STEP'])
+        msg += '\tfile2: {}, Y/X_STEP: {} / {} m\n'.format(inps.file[1], atr2['Y_STEP'], atr2['X_STEP'])
+        msg += '\tRe-run geocode.py --lat-step --lon-step to make them consistent.'
         raise ValueError('input files do not have the same spatial resolution\n{}'.format(msg))
 
     # check reference point
@@ -96,7 +95,10 @@ def cmd_line_parse(iargs=None):
     ref_lalo_1 = ['{:.3f}'.format(float(atr1[i])) for i in ['REF_LAT','REF_LON']]
     ref_lalo_2 = ['{:.3f}'.format(float(atr2[i])) for i in ['REF_LAT','REF_LON']]
     if ref_lalo_1 != ref_lalo_2:
-        raise ValueError('input files do not have the same reference point from REF_LAT/LON values')
+        msg  = '\tfile1: {}, REF_LAT/LON: {} {}\n'.format(inps.file[0], ref_lalo_1, atr1.get('X_UNIT', 'deg'))
+        msg += '\tfile2: {}, REF_LAT/LON: {} {}\n'.format(inps.file[1], ref_lalo_2, atr2.get('X_UNIT', 'deg'))
+        msg += '\tRe-run reference_point.py --lat --lon to make them consistent.'
+        raise ValueError('input files do not have the same reference point from REF_LAT/LON values!\n{}'.format(msg))
 
     # use ref_file for time-series file writing
     if atr1['FILE_TYPE'] == 'timeseries':

--- a/mintpy/geocode.py
+++ b/mintpy/geocode.py
@@ -31,6 +31,16 @@ EXAMPLE = """example:
   geocode.py geo_velocity.h5 --geo2radar
 """
 
+DEG2METER = """
+degrees     --> meters on equator
+0.000925926 --> 100
+0.000555556 --> 60
+0.000462963 --> 50
+0.000277778 --> 30
+0.000185185 --> 20
+0.000092593 --> 10
+"""
+
 
 def create_parser():
     parser = argparse.ArgumentParser(description='Resample radar coded files into geo coordinates, or reverse',
@@ -50,24 +60,27 @@ def create_parser():
     parser.add_argument('-t', '--template', dest='templateFile',
                         help="Template file with geocoding options.")
 
-    parser.add_argument('-b', '--bbox', dest='SNWE', type=float, nargs=4, metavar=('S', 'N', 'W', 'E'),
-                        help='Bounding box of area to be geocoded.\n' +
-                        'Include the uppler left corner of the first pixel' +
-                        '    and the lower right corner of the last pixel')
-    parser.add_argument('-y', '--lat-step', dest='latStep', type=float,
-                        help='output pixel size in degree in latitude.')
-    parser.add_argument('-x', '--lon-step', dest='lonStep', type=float,
-                        help='output pixel size in degree in longitude.')
+    out = parser.add_argument_group('output grid')
+    out.add_argument('-b', '--bbox', dest='SNWE', type=float, nargs=4, metavar=('S', 'N', 'W', 'E'),
+                     help='Bounding box of area to be geocoded.\n' +
+                     'Include the uppler left corner of the first pixel' +
+                     '    and the lower right corner of the last pixel')
+    out.add_argument('-y', '--lat-step', dest='latStep', type=float,
+                     help='output pixel size in degree in latitude.')
+    out.add_argument('-x', '--lon-step', dest='lonStep', type=float,
+                     help='output pixel size in degree in longitude.'
+                          '{}'.format(DEG2METER))
 
-    parser.add_argument('-i', '--interpolate', dest='interpMethod', choices={'nearest', 'linear'},
+    interp = parser.add_argument_group('interpolation')
+    interp.add_argument('-i', '--interpolate', dest='interpMethod', choices={'nearest', 'linear'},
                         help='interpolation/resampling method. Default: nearest', default='nearest')
-    parser.add_argument('--fill', dest='fillValue', type=float, default=np.nan,
+    interp.add_argument('--fill', dest='fillValue', type=float, default=np.nan,
                         help='Value used for points outside of the interpolation domain.\n' +
                              'Default: np.nan')
-    parser.add_argument('-n','--nprocs', dest='nprocs', type=int, default=1,
+    interp.add_argument('-n','--nprocs', dest='nprocs', type=int, default=1,
                         help='number of processors to be used for calculation. Default: 1\n' + 
                              'Note: Do not use more processes than available processor cores.')
-    parser.add_argument('-p','--processor', dest='processor', type=str, choices={'pyresample', 'scipy'},
+    interp.add_argument('-p','--processor', dest='processor', type=str, choices={'pyresample', 'scipy'},
                         help='processor module used for interpolation.')
 
     parser.add_argument('--update', dest='updateMode', action='store_true',


### PR DESCRIPTION
**Description of proposed changes**

+ support reading slice_list from an undefined 3D matrix in h5 file, for more generic IO/plot support.

+ check the number of bands in binary files, to work even if conventional data formats are not matching the conventional file extension.

+ more grouped help message for geocode.py

+ more help msg for asc_desc2horz_vert.py

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`