### PR TITLE
load_data: fix bug when running with custom template file without off…

### DIFF
--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -560,6 +560,7 @@ def prepare_metadata(inpsDict):
 
             # observation
             obs_keys = ['mintpy.load.unwFile', 'mintpy.load.azOffFile']
+            obs_keys = [i for i in obs_keys if i in inpsDict.keys()]
             obs_paths = [inpsDict[key] for key in obs_keys if inpsDict[key].lower() != 'auto']
             if len(obs_paths) > 0:
                 obs_dir = os.path.dirname(os.path.dirname(obs_paths[0]))

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -221,7 +221,18 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, margin=[0,0,0,0]):
 
         data = multilook_data(data, lks_y, lks_x)
         dsDict[dsName] = data
+
+    # update metadata
     atr = multilook_attribute(atr, lks_y, lks_x, box=box)
+
+    # for binary file with 2 bands, always use BIL scheme
+    if (len(dsDict.keys()) == 2
+            and os.path.splitext(infile)[1] not in ['.h5','.he5']
+            and atr.get('scheme', 'BIL').upper() != 'BIL'):
+        print('the input binary file has 2 bands with band interleave as: {}'.format(atr['scheme']))
+        print('for the output binary file, change the band interleave to BIL as default.')
+        atr['scheme'] = 'BIL'
+
     writefile.write(dsDict, out_file=outfile, metadata=atr, ref_file=infile)
     return outfile
 

--- a/mintpy/save_kmz.py
+++ b/mintpy/save_kmz.py
@@ -29,6 +29,8 @@ EXAMPLE = """example:
   save_kmz.py geo/geo_velocity.h5 -u cm --wrap --wrap-range -3 7
 
   save_kmz.py geo/geo_timeseries_ERA5_ramp_demErr.h5 20101120
+  save_kmz.py geo/geo_timeseries_ERA5_demErr.h5 20200505_20200517
+
   save_kmz.py geo/geo_ifgramStack.h5 20101120_20110220
   save_kmz.py geo/geo_geometryRadar.h5 --cbar-label Elevation
 """
@@ -292,7 +294,15 @@ def main(iargs=None):
     plt.switch_backend('Agg')  # Backend setting
 
     # Read data
+    k = readfile.read_attribute(inps.file)['FILE_TYPE']
+    if k == 'timeseries' and inps.dset and '_' in inps.dset:
+        inps.ref_date, inps.dset = inps.dset.split('_')
+    else:
+        inps.ref_date = None
+
     data, atr = readfile.read(inps.file, datasetName=inps.dset)
+    if k == 'timeseries' and inps.ref_date:
+        data -= readfile.read(inps.file, datasetName=inps.ref_date)[0]
 
     # mask
     mask = pp.read_mask(inps.file, mask_file=inps.mask_file, datasetName=inps.dset, print_msg=True)[0]

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -440,6 +440,12 @@ def dload_grib_files(grib_files, tropo_model='ERA5', snwe=None):
                 elif tropo_model == 'NARR':
                     pa.NARRdload(date_list2dload, hour, grib_dir)
             except:
+                if i < 3:
+                    print('WARNING: the {} attampt to download failed, retry it.\n'.format(i))
+                else:
+                    print('\n\n'+'*'*50)
+                    print('WARNING: downloading failed for 3 times, stop trying and continue.')
+                    print('*'*50+'\n\n')
                 pass
 
     # check potentially corrupted files

--- a/mintpy/utils/isce_utils.py
+++ b/mintpy/utils/isce_utils.py
@@ -416,12 +416,19 @@ def extract_geometry_metadata(geom_dir, metadata=dict(), box=None, fbase_list=['
 
         if 'los' in os.path.basename(geom_file):
             data = readfile.read(geom_file, datasetName='az', box=box)[0]
+            # HEADING
             data[data == 0.] = np.nan
             az_angle = np.nanmean(data)
             # convert isce azimuth angle to roipac orbit heading angle
             head_angle = -1 * (270 + az_angle)
             head_angle -= np.round(head_angle / 360.) * 360.
             metadata['HEADING'] = str(head_angle)
+
+            # CENTER_INCIDENCE_ANGLE
+            data = readfile.read(geom_file, datasetName='inc', box=box)[0]
+            data[data == 0.] = np.nan
+            inc_angle = data[int(data.shape[0]/2), int(data.shape[1]/2)]
+            metadata['CENTER_INCIDENCE_ANGLE'] = str(inc_angle)
     return metadata
 
 

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -50,8 +50,8 @@ def range_distance(atr, dimension=2, print_msg=True):
     range_f = range_n + dR*(width-1)
     range_c = (range_f + range_n)/2.0
     if print_msg:
-        print('center range : %.2f m' % (range_c))
         print('near   range : %.2f m' % (range_n))
+        print('center range : %.2f m' % (range_c))
         print('far    range : %.2f m' % (range_f))
 
     if dimension == 0:
@@ -102,14 +102,14 @@ def incidence_angle(atr, dem=None, dimension=2, print_msg=True):
     range_f = range_n+dR*width
     inc_angle_n = (np.pi - np.arccos((r**2 + range_n**2 - (r+H)**2)/(2*r*range_n))) * 180.0/np.pi
     inc_angle_f = (np.pi - np.arccos((r**2 + range_f**2 - (r+H)**2)/(2*r*range_f))) * 180.0/np.pi
+    inc_angle_c = (inc_angle_n + inc_angle_f) / 2.0
     if print_msg:
         print('near   incidence angle : {:.4f} degree'.format(inc_angle_n))
+        print('center incidence angle : {:.4f} degree'.format(inc_angle_c))
         print('far    incidence angle : {:.4f} degree'.format(inc_angle_f))
 
     if dimension == 0:
-        inc_angle = (inc_angle_n + inc_angle_f) / 2.0
-        if print_msg:
-            print('center incidence angle : {:.4f} degree'.format(inc_angle))
+        inc_angle = inc_angle_c
 
     elif dimension == 1:
         inc_angle = np.linspace(inc_angle_n, inc_angle_f, num=width,
@@ -315,11 +315,12 @@ def azimuth2heading_angle(az_angle):
 
 def enu2los(e, n, u, inc_angle=34., head_angle=-168.):
     """
-    Parameters: e : np.array or float, displacement in east-west direction, east as positive
-                n : np.array or float, displacement in north-south direction, north as positive
-                u : np.array or float, displacement in vertical direction, up as positive
-                inc_angle  : np.array or float, local incidence angle from vertical
-                head_angle : np.array or float, satellite orbit from the north in clock-wise direction as positive
+    Parameters: e          - np.array or float, displacement in east-west direction, east as positive
+                n          - np.array or float, displacement in north-south direction, north as positive
+                u          - np.array or float, displacement in vertical direction, up as positive
+                inc_angle  - np.array or float, local incidence angle from vertical
+                head_angle - np.array or float, satellite orbit from the north in clock-wise direction as positive
+    Returns:    v_los      - np.array or float, displacement in line-of-sight direction, moving toward satellite as positive
     For AlosA: inc_angle = 34, head_angle = -12.873
     For AlosD: inc_angle = 34, head_angle = -167.157
     For SenD: inc_angle = 34, head_angle = -168
@@ -330,7 +331,7 @@ def enu2los(e, n, u, inc_angle=34., head_angle=-168.):
 
     inc_angle *= np.pi/180.
     head_angle *= np.pi/180.
-    v_los = (  e * np.sin(inc_angle) * np.cos(head_angle)  * -1
+    v_los = (  e * np.sin(inc_angle) * np.cos(head_angle) * -1
              + n * np.sin(inc_angle) * np.sin(head_angle) 
              + u * np.cos(inc_angle))
     return v_los


### PR DESCRIPTION
**Description of proposed changes**

load_data: fix bug when running with custom template file without offset dataset

multilook: use BIL band interleave for binary file with 2 bands

tropo_pyaps3: more verbose message when downloading failed

save_kmz: support DATE1_DATE2 format input (for time-series file only).

utils/isce_utils.extract_geometry_metadata(): extract CENTER_INCIDENCE_ANGLE metadata from los.rdr file

utils/utils0.enu2los: add return in the comment

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.