### PR TITLE
tropo_pyaps3: support Sentinel-1 SAFE filename as a list text file

### DIFF
--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -44,10 +44,10 @@ EXAMPLE = """example:
   tropo_pyaps3.py -d SAFE_files.txt -g inputs/geometryRadar.h5
 """
 
-SAFE_FILE = """
-/data/SanAndreasSenDT42/SLC/S1B_IW_SLC__1SDV_20191117T140737_20191117T140804_018968_023C8C_82DC.zip
-/data/SanAndreasSenDT42/SLC/S1A_IW_SLC__1SDV_20191111T140819_20191111T140846_029864_036803_69CA.zip
-...
+SAFE_FILE = """SAFE_files.txt:
+    /data/SanAndreasSenDT42/SLC/S1B_IW_SLC__1SDV_20191117T140737_20191117T140804_018968_023C8C_82DC.zip
+    /data/SanAndreasSenDT42/SLC/S1A_IW_SLC__1SDV_20191111T140819_20191111T140846_029864_036803_69CA.zip
+    ...
 """
 
 REFERENCE = """reference:
@@ -103,7 +103,7 @@ def create_parser():
                         help='List of dates in YYYYMMDD or YYMMDD format. It can be:\n'
                              'a) list of strings in YYYYMMDD or YYMMDD format OR\n'
                              'b) a text file with the first column as list of date in YYYYMMDD or YYMMDD format OR\n'
-                             'c) a text file with Sentinel-1 SAFE filenames \ne.g.: '+SAFE_FILE)
+                             'c) a text file with Sentinel-1 SAFE filenames\ne.g.: '+SAFE_FILE)
     parser.add_argument('--hour', type=str, help='time of data in HH, e.g. 12, 06')
     parser.add_argument('-o', dest='cor_timeseries_file',
                         help='Output file name for trospheric corrected timeseries.')

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -606,7 +606,7 @@ def define_date(string):
     return date
 
 def define_second(string):
-    """extract CENTER_LINE_UTC frm *.SAFE"""
+    """extract CENTER_LINE_UTC from *.SAFE"""
     filename = string.split(str.encode('.'))[0].split(str.encode('/'))[-1]
     time1 = filename.split(str.encode('_'))[5][9:15]
     time2 = filename.split(str.encode('_'))[6][9:15]

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -27,26 +27,27 @@ WEATHER_MODEL_HOURS = {
     'MERRA'  : [0, 6, 12, 18],
 }
 
-verbose = False
-
 
 ###############################################################
 EXAMPLE = """example:
-  # download reanalysys dataset, calculate tropospheric delays and correct time-series file.
+  # download datasets, calculate tropospheric delays and correct time-series file.
   tropo_pyaps3.py -f timeseries.h5 -g inputs/geometryRadar.h5
 
-  # download reanalysys dataset, calculate tropospheric delays
+  # download datasets, calculate tropospheric delays
   tropo_pyaps3.py -d date.list         --hour 12 -m ERA5  -g inputs/geometryGeo.h5
   tropo_pyaps3.py -d 20151002 20151003 --hour 12 -m MERRA -g inputs/geometryRadar.h5
 
-  # download reanalysys dataset
+  # download datasets (covering the whole world)
   tropo_pyaps3.py -d date.list --hour 12
+  tropo_pyaps3.py -d SAFE_files.txt
+  # download datasets (covering the area of interest)
+  tropo_pyaps3.py -d SAFE_files.txt -g inputs/geometryRadar.h5
+"""
 
-  # only download reanalysys dataset
-  # download reanalysys dataset of the whole world
-  tropo_pyaps3.py --download_only --safe_list safe_list
-  # download reanalysys dataset only covering the interested area
-  tropo_pyaps3.py --download_only --safe_list safe_list -g inputs/geometryRadar.h5  
+SAFE_FILE = """
+/data/SanAndreasSenDT42/SLC/S1B_IW_SLC__1SDV_20191117T140737_20191117T140804_018968_023C8C_82DC.zip
+/data/SanAndreasSenDT42/SLC/S1A_IW_SLC__1SDV_20191111T140819_20191111T140846_029864_036803_69CA.zip
+...
 """
 
 REFERENCE = """reference:
@@ -56,7 +57,7 @@ REFERENCE = """reference:
 
   Jolivet, R., P. S. Agram, N. Y. Lin, M. Simons, M. P. Doin, G. Peltzer, and Z. Li (2014), Improving
   InSAR geodesy using global atmospheric models, Journal of Geophysical Research: Solid Earth, 119(3),
-  2324-2341.
+  2324-2341, doi:10.1002/2013JB010588.
 """
 
 DATA_INFO = """Global Atmospheric Models:
@@ -100,14 +101,12 @@ def create_parser():
                         help='timeseries HDF5 file, i.e. timeseries.h5')
     parser.add_argument('-d', '--date-list', dest='date_list', type=str, nargs='*',
                         help='List of dates in YYYYMMDD or YYMMDD format. It can be:\n'
-                             'a) list of strings OR\n'
-                             'b) a text file with the first column as list of date')
+                             'a) list of strings in YYYYMMDD or YYMMDD format OR\n'
+                             'b) a text file with the first column as list of date in YYYYMMDD or YYMMDD format OR\n'
+                             'c) a text file with Sentinel-1 SAFE filenames \ne.g.: '+SAFE_FILE)
     parser.add_argument('--hour', type=str, help='time of data in HH, e.g. 12, 06')
     parser.add_argument('-o', dest='cor_timeseries_file',
                         help='Output file name for trospheric corrected timeseries.')
-    parser.add_argument('--download_only', action='store_true', default=False, help='whether only download weather data.')
-    parser.add_argument('--safe_list', dest='safe_list', type=str, nargs=1, help='list of Sentinel safe files')
-
 
     # delay calculation
     delay = parser.add_argument_group('delay calculation')
@@ -117,6 +116,7 @@ def create_parser():
                        help='source of the atmospheric model (default: %(default)s).')
     delay.add_argument('--delay', dest='delay_type', default='comb', choices={'comb', 'dry', 'wet'},
                        help='Delay type to calculate, comb contains both wet and dry delays (default: %(default)s).')
+
     delay.add_argument('-w', '--dir', '--weather-dir', dest='weather_dir', default='${WEATHER_DIR}',
                        help='parent directory of downloaded weather data file (default: %(default)s).\n' +
                             'e.g.: '+WEATHER_DIR_DEMO)
@@ -124,6 +124,7 @@ def create_parser():
                        help='geometry file including height, incidenceAngle and/or latitude and longitude')
     delay.add_argument('--tropo-file', dest='tropo_file', type=str,
                        help='tropospheric delay file name')
+    delay.add_argument('--verbose', dest='verbose', action='store_true', help='Verbose message.')
     return parser
 
 
@@ -158,11 +159,10 @@ def cmd_line_parse(iargs=None):
         if fname and not os.path.isfile(fname):
             raise FileExistsError('input file not exist: {}'.format(fname))
 
-    ## required options (for date/time): --file OR --date-list, --hour OR --safe_list
+    ## required options (for date/time): --file OR --date-list
     if (not inps.timeseries_file 
-            and any(vars(inps)[key] is None for key in ['date_list', 'hour'])
-                and vars(inps)['safe_list'] is None):
-        msg = 'ERROR: --file OR (--date-list, --hour) OR --safe_list is required.'
+            and any(vars(inps)[key] is None for key in ['date_list'])):
+        msg = 'ERROR: --file OR --date-list is required.'
         msg += '\n\n'+EXAMPLE
         raise SystemExit(msg)
 
@@ -212,17 +212,22 @@ def read_inps2date_time(inps):
 
     # read dates if --date-list is text file
     if len(inps.date_list) == 1 and os.path.isfile(inps.date_list[0]):
-        print('read date list from text file: {}'.format(inps.date_list[0]))
-        inps.date_list = np.loadtxt(inps.date_list[0],
-                                    dtype=bytes,
-                                    usecols=(0,)).astype(str).tolist()
-        inps.date_list = ptime.yyyymmdd(inps.date_list)
+        date_file = inps.date_list[0]
+        if date_file.startswith('SAFE_'):
+            print('read date list and hour info from Sentinel-1 SAFE filenames: {}'.format(date_file))
+            inps.date_list, inps.hour = safe2date_time(date_file, inps.tropo_model)
+        else:
+            print('read date list from text file: {}'.format(date_file))
+            inps.date_list = np.loadtxt(date_file, dtype=bytes, usecols=(0,)).astype(str).tolist()
+            inps.date_list = ptime.yyyymmdd(inps.date_list)
 
     # at east 2 dates are required (for meaningful calculation)
     if len(inps.date_list) < 2:
-        raise SystemExit('ERROR: input date list < 2')      
+        raise AttributeError('input number of dates < 2!')
 
     # print time info
+    if inps.hour is None:
+        raise AttributeError('time info (--hour) not found!')
     print('time of cloest available product: {}:00 UTC'.format(inps.hour))
 
     return inps.date_list, inps.hour
@@ -264,30 +269,6 @@ def get_grib_info(inps):
     return inps
 
 
-###############################################################
-def closest_weather_model_hour(sar_acquisition_time, grib_source='ERA5'):
-    """Find closest available time of weather product from SAR acquisition time
-    Inputs:
-        sar_acquisition_time - string, SAR data acquisition time in seconds
-        grib_source          - string, Grib Source of weather reanalysis product
-    Output:
-        grib_hr              - string, time of closest available weather product
-    Example:
-        '06' = closest_weather_model_hour(atr['CENTER_LINE_UTC'])
-        '12' = closest_weather_model_hour(atr['CENTER_LINE_UTC'], 'NARR')
-    """
-    # get hour/min of SAR acquisition time
-    sar_time = float(sar_acquisition_time)
-
-    # find closest time in available weather products
-    grib_hr_list = WEATHER_MODEL_HOURS[grib_source]
-    grib_hr = int(min(grib_hr_list, key=lambda x: abs(x-sar_time/3600.)))
-
-    # add zero padding
-    grib_hr = "{:02d}".format(grib_hr)
-    return grib_hr
-
-
 def get_grib_filenames(date_list, hour, model, grib_dir, snwe=None):
     """Get default grib file names based on input info.
     Parameters: date_list  - list of str, date in YYYYMMDD format
@@ -315,6 +296,75 @@ def get_grib_filenames(date_list, hour, model, grib_dir, snwe=None):
         elif model == 'MERRA1': grib_file = 'merra-{}-{}.hdf'.format(d, hour)
         grib_files.append(os.path.join(grib_dir, grib_file))
     return grib_files
+
+
+###############################################################
+def closest_weather_model_hour(sar_acquisition_time, grib_source='ERA5'):
+    """Find closest available time of weather product from SAR acquisition time
+    Inputs:
+        sar_acquisition_time - string, SAR data acquisition time in seconds
+        grib_source          - string, Grib Source of weather reanalysis product
+    Output:
+        grib_hr              - string, time of closest available weather product
+    Example:
+        '06' = closest_weather_model_hour(atr['CENTER_LINE_UTC'])
+        '12' = closest_weather_model_hour(atr['CENTER_LINE_UTC'], 'NARR')
+    """
+    # get hour/min of SAR acquisition time
+    sar_time = float(sar_acquisition_time)
+
+    # find closest time in available weather products
+    grib_hr_list = WEATHER_MODEL_HOURS[grib_source]
+    grib_hr = int(min(grib_hr_list, key=lambda x: abs(x-sar_time/3600.)))
+
+    # add zero padding
+    grib_hr = "{:02d}".format(grib_hr)
+    return grib_hr
+
+
+def safe2date_time(safe_file, tropo_model):
+    """generate date_list and hour from safe_list"""
+
+    def seconds_UTC(seconds):
+        """generate second list"""
+        if isinstance(seconds, list):
+            secondsOut = []
+            for second in seconds:
+                secondsOut.append(second)
+        else:
+            print('\nUn-recognized CENTER_LINE_ UTC input!')
+            return None
+
+        return secondsOut
+
+    date_list = ptime.yyyymmdd(np.loadtxt(safe_file, dtype=bytes, converters={0:define_date}).astype(str).tolist())
+    second_list = seconds_UTC(np.loadtxt(safe_file, dtype=bytes, converters={0:define_second}).astype(str).tolist())
+
+    # change second into hour
+    hour_list = [closest_weather_model_hour(float(second), tropo_model) for second in second_list]
+    hour = ut.most_common(hour_list)
+
+    return date_list, hour
+
+
+def define_date(string):
+    """extract date from *.SAFE"""
+    filename = string.split(str.encode('.'))[0].split(str.encode('/'))[-1]
+    date = filename.split(str.encode('_'))[5][0:8]
+
+    return date
+
+
+def define_second(string):
+    """extract CENTER_LINE_UTC from *.SAFE"""
+    filename = string.split(str.encode('.'))[0].split(str.encode('/'))[-1]
+    time1 = filename.split(str.encode('_'))[5][9:15]
+    time2 = filename.split(str.encode('_'))[6][9:15]
+    time1_second = int(time1[0:2]) * 3600 + int(time1[2:4]) * 60 + int(time1[4:6])
+    time2_second = int(time2[0:2]) * 3600 + int(time2[2:4]) * 60 + int(time2[4:6])
+    CENTER_LINE_UTC = (time1_second + time2_second) / 2
+
+    return CENTER_LINE_UTC
 
 
 def ceil2multiple(x, step=10):
@@ -380,6 +430,32 @@ def snwe2str(snwe):
     return area
 
 
+def get_bounding_box(meta):
+    """Get lat/lon range (roughly), in the same order of data file
+    lat0/lon0 - starting latitude/longitude (first row/column)
+    lat1/lon1 - ending latitude/longitude (last row/column)
+    """
+    length, width = int(meta['LENGTH']), int(meta['WIDTH'])
+    if 'Y_FIRST' in meta.keys():
+        # geo coordinates
+        lat0 = float(meta['Y_FIRST'])
+        lon0 = float(meta['X_FIRST'])
+        lat_step = float(meta['Y_STEP'])
+        lon_step = float(meta['X_STEP'])
+        lat1 = lat0 + lat_step * (length - 1)
+        lon1 = lon0 + lon_step * (width - 1)
+    else:
+        # radar coordinates
+        lats = [float(meta['LAT_REF{}'.format(i)]) for i in [1,2,3,4]]
+        lons = [float(meta['LON_REF{}'.format(i)]) for i in [1,2,3,4]]
+        lat0 = np.mean(lats[0:2])
+        lat1 = np.mean(lats[2:4])
+        lon0 = np.mean(lons[0:3:2])
+        lon1 = np.mean(lons[1:4:2])
+    return lat0, lat1, lon0, lon1
+
+
+###############################################################
 def check_exist_grib_file(gfile_list, print_msg=True):
     """Check input list of grib files, and return the existing ones with right size."""
     gfile_exist = ut.get_file_list(gfile_list)
@@ -476,6 +552,9 @@ def get_delay(grib_file, inps):
     Output:
         pha - 2D np.array, absolute tropospheric phase delay relative to ref_y/x
     """
+    if inps.verbose:
+        print('GRIB FILE: {}'.format(grib_file))
+
     # initiate pyaps object
     aps_obj = pa.PyAPS(grib_file,
                        grib=inps.tropo_model,
@@ -484,7 +563,7 @@ def get_delay(grib_file, inps):
                        inc=inps.inc,
                        lat=inps.lat,
                        lon=inps.lon,
-                       verb=verbose)
+                       verb=inps.verbose)
 
     # estimate delay
     pha = np.zeros((aps_obj.ny, aps_obj.nx), dtype=np.float32)
@@ -493,31 +572,6 @@ def get_delay(grib_file, inps):
     # reverse the sign for consistency between different phase correction steps/methods
     pha *= -1
     return pha
-
-
-def get_bounding_box(meta):
-    """Get lat/lon range (roughly), in the same order of data file
-    lat0/lon0 - starting latitude/longitude (first row/column)
-    lat1/lon1 - ending latitude/longitude (last row/column)
-    """
-    length, width = int(meta['LENGTH']), int(meta['WIDTH'])
-    if 'Y_FIRST' in meta.keys():
-        # geo coordinates
-        lat0 = float(meta['Y_FIRST'])
-        lon0 = float(meta['X_FIRST'])
-        lat_step = float(meta['Y_STEP'])
-        lon_step = float(meta['X_STEP'])
-        lat1 = lat0 + lat_step * (length - 1)
-        lon1 = lon0 + lon_step * (width - 1)
-    else:
-        # radar coordinates
-        lats = [float(meta['LAT_REF{}'.format(i)]) for i in [1,2,3,4]]
-        lons = [float(meta['LON_REF{}'.format(i)]) for i in [1,2,3,4]]
-        lat0 = np.mean(lats[0:2])
-        lat1 = np.mean(lats[2:4])
-        lon0 = np.mean(lons[0:3:2])
-        lon1 = np.mean(lons[1:4:2])
-    return lat0, lat1, lon0, lon1
 
 
 def calculate_delay_timeseries(inps):
@@ -561,12 +615,17 @@ def calculate_delay_timeseries(inps):
     print('\n------------------------------------------------------------------------------')
     print('calcualting absolute delay for each date using PyAPS (Jolivet et al., 2011; 2014) ...')
     print('number of grib files used: {}'.format(num_date))
-    prog_bar = ptime.progressBar(maxValue=num_date)
+
+    if not inps.verbose:
+        prog_bar = ptime.progressBar(maxValue=num_date)
     for i in range(num_date):
         grib_file = inps.grib_files[i]
         tropo_data[i] = get_delay(grib_file, inps)
-        prog_bar.update(i+1, suffix=os.path.basename(grib_file))
-    prog_bar.close()
+
+        if not inps.verbose:
+            prog_bar.update(i+1, suffix=os.path.basename(grib_file))
+    if not inps.verbose:
+        prog_bar.close()
 
     # remove metadata related with double reference
     # because absolute delay is calculated and saved
@@ -598,68 +657,13 @@ def correct_timeseries(timeseries_file, tropo_file, out_file):
                          'using diff.py with tropospheric delay file.'))
     return out_file
 
-def define_date(string):
-    """extract date from *.SAFE"""
-    filename = string.split(str.encode('.'))[0].split(str.encode('/'))[-1]
-    date = filename.split(str.encode('_'))[5][0:8]
-
-    return date
-
-def define_second(string):
-    """extract CENTER_LINE_UTC from *.SAFE"""
-    filename = string.split(str.encode('.'))[0].split(str.encode('/'))[-1]
-    time1 = filename.split(str.encode('_'))[5][9:15]
-    time2 = filename.split(str.encode('_'))[6][9:15]
-    time1_second = int(time1[0:2]) * 3600 + int(time1[2:4]) * 60 + int(time1[4:6])
-    time2_second = int(time2[0:2]) * 3600 + int(time2[2:4]) * 60 + int(time2[4:6])
-    CENTER_LINE_UTC = (time1_second + time2_second) / 2
-
-    return CENTER_LINE_UTC
-
-def seconds_UTC(seconds):
-    """generate second list"""
-    if isinstance(seconds, list):
-        secondsOut = []
-        for second in seconds:
-            secondsOut.append(second)
-    else:
-        print('\nUn-recognized CENTER_LINE_ UTC input!')
-        return None
-
-    return secondsOut
-
-def safe_list2inps(inps):
-    """generate date_list and hour from safe_list"""
-    if os.path.isfile(inps.safe_list[0]):
-        print('read date list from text file: {}'.format(inps.safe_list[0]))
-        date_list = ptime.yyyymmdd(np.loadtxt(inps.safe_list[0],dtype=bytes,converters={0:define_date}).astype(str).tolist())
-        second_list = seconds_UTC(np.loadtxt(inps.safe_list[0],dtype=bytes,converters={0:define_second}).astype(str).tolist())
-        
-        # change second into hour
-        hour_list = []
-        for second in second_list:
-            hour = closest_weather_model_hour(float(second), inps.tropo_model)
-            hour_list.append(str(hour))
-        hour_sum = sum([float(i) for i in hour_list])
-        hour_average = int(hour_sum / (len(hour_list)))
-    
-    inps.date_list = date_list
-    inps.hour = str(hour)
-    
-    return inps
 
 ###############################################################
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
 
-    if not inps.download_only:
-        # read dates / time info
-        read_inps2date_time(inps)
-   
-    else:
-        # only download  weather data according to safe_list
-        print("\ndownload only")
-        safe_list2inps(inps)
+    # read dates / time info
+    read_inps2date_time(inps)
      
     # get corresponding grib files info
     get_grib_info(inps)
@@ -670,10 +674,10 @@ def main(iargs=None):
                                        snwe=inps.snwe)
 
     # calculate tropo delay and save to h5 file
-    if not inps.download_only and inps.geom_file:
+    if inps.geom_file:
         calculate_delay_timeseries(inps)
     else:
-        print('No input geometry file OR using download_only option, skip calculating and correcting tropospheric delays.')
+        print('No input geometry file, skip calculating and correcting tropospheric delays.')
         return
 
     # correct tropo delay from displacement time-series

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -628,7 +628,7 @@ def seconds_UTC(seconds):
 
     return secondsOut
 
-def safe_list2date_list(inps):
+def safe_list2inps(inps):
     """generate date_list and hour from safe_list"""
     if os.path.isfile(inps.safe_list[0]):
         print('read date list from text file: {}'.format(inps.safe_list[0]))
@@ -640,18 +640,8 @@ def safe_list2date_list(inps):
         for second in second_list:
             hour = closest_weather_model_hour(float(second), inps.tropo_model)
             hour_list.append(str(hour))
-        
         hour_sum = sum([float(i) for i in hour_list])
         hour_average = int(hour_sum / (len(hour_list)))
-    
-    return date_list, hour_average
-
-def check_inputs_download_only(inps):
-    
-    parser = create_parser()
-
-    # date list and hour
-    date_list,hour = safe_list2date_list(inps)
     
     inps.date_list = date_list
     inps.hour = str(hour)
@@ -668,9 +658,8 @@ def main(iargs=None):
    
     else:
         # only download  weather data according to safe_list
-        # read saft_list info
         print("\ndownload only")
-        inps = check_inputs_download_only(inps)
+        safe_list2inps(inps)
      
     # get corresponding grib files info
     get_grib_info(inps)


### PR DESCRIPTION
**Description of proposed changes**

This PR add supports of text file with Sentinel-1 SAFE filenames as the input of --date-list to support the data downloading prior to tropospheric delay correction as described in #253 

The updated usage is as below:

```
  # download datasets (covering the whole world)
  tropo_pyaps3.py -d date.list --hour 12
  tropo_pyaps3.py -d SAFE_files.txt
  # download datasets (covering the area of interest)
  tropo_pyaps3.py -d SAFE_files.txt -g inputs/geometryRadar.h5
```

where the `SAFE_files.txt` file is generated by `stackSentinel.py` from ISCE/topsStack, with an example as below:

```
/data/SanAndreasSenDT42/SLC/S1B_IW_SLC__1SDV_20191117T140737_20191117T140804_018968_023C8C_82DC.zip
/data/SanAndreasSenDT42/SLC/S1A_IW_SLC__1SDV_20191111T140819_20191111T140846_029864_036803_69CA.zip
...
```

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass testing with `$MINTPY_HOME/test/test_smallbaselineApp.py --test-pyaps`
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.