### PR TITLE
readfile.get_slice_list(): do not check num_band for .int/unw file

### DIFF
--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -25,9 +25,6 @@ EXAMPLE = """example:
   multilook.py  velocity.h5  -r 15 -a 15
   multilook.py  srtm30m.dem  -r 10 -a 10  -o srtm30m_300m.dem
 
-  # To interpolate input file into larger size file:
-  multilook.py  bperp.rdr  -10 -2 -o bperp_full.rdr
-
   # Ignore / skip marginal pixels
   multilook.py ../../geom_master/hgt.rdr.full -r 300 -a 100 --margin 58 58 58 58 -o hgt.rdr
 """

--- a/mintpy/simulation/README.md
+++ b/mintpy/simulation/README.md
@@ -2,6 +2,6 @@
 
 This module collects some toolbox to simulate different components of interferometric phases, such as the decorrelation noise, tropospheric turbulence and surface deformation, etc. 
 
-This toolbox is still in **alpha** stage, which means they will change quite frequently. 
+🚨 This toolbox is still in **alpha** stage and undergoing **rapid development**. 🚨 
 
 There are no comprehensive document on this part yet. If you want to give them a try, read the detailed function usage in the code.

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -523,13 +523,21 @@ def get_slice_list(fname):
     else:
         num_band = int(atr.get('number_bands', '1'))
         if fext in ['.trans', '.utm_to_rdc'] and num_band == 2:
+            # roipac / gamma lookup table
             slice_list = ['rangeCoord', 'azimuthCoord']
-        elif fext in ['.int', '.unw'] and num_band == 2:
-            slice_list = ['magnitude', 'phase']
+
         elif fbase.startswith('los') and num_band == 2:
+            # isce los file
             slice_list = ['incidenceAngle', 'azimuthAngle']
+
+        elif fext in ['.int', '.unw']:
+            # do not check the actual num_band in order to support
+            # mag / pha / cpx reading like "multiple bands"
+            slice_list = ['magnitude', 'phase']
+
         else:
             slice_list = ['band{}'.format(i) for i in range(1,num_band+1)]
+
     return slice_list
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ readfile.get_slice_list(): do not check num_band for .int/unw file to support amp / pha / cpx reading, which is like multiple bands, even though it's one band actually.

+ more obvious warning msg for mintpy/simulation

+ multilook: remove interpolation example as it's not implemented (#378).

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.