### PR TITLE
add support for stripmapStack in auto_path

### DIFF
--- a/mintpy/defaults/auto_path.py
+++ b/mintpy/defaults/auto_path.py
@@ -20,7 +20,7 @@ autoPath = True
 
 
 # Default path of data files from different InSAR processors to be loaded into MintPy
-isceTopsAutoPath = '''##----------Default file path of ISCE-topsStack products
+isceTopsAutoPath = '''##----------Default file path of ISCE/topsStack products
 mintpy.load.processor      = isce
 mintpy.load.metaFile       = ${PROJECT_DIR}/master/IW*.xml
 mintpy.load.baselineDir    = ${PROJECT_DIR}/baselines
@@ -41,7 +41,7 @@ mintpy.load.bperpFile      = None
 
 '''
 
-isceStripmapAutoPath = '''##----------Default file path of ISCE-topsStack products
+isceStripmapAutoPath = '''##----------Default file path of ISCE/stripmapStack products
 mintpy.load.processor      = isce
 mintpy.load.metaFile       = ${masterShelve}/masterShelve/data.dat
 mintpy.load.baselineDir    = ${PROJECT_DIR}/baselines

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -53,7 +53,8 @@ DEFAULT_TEMPLATE = """template:
 {}\n
 {}\n
 {}\n
-""".format(auto_path.isceAutoPath,
+""".format(auto_path.isceTopsAutoPath,
+           auto_path.isceStripmapAutoPath,
            auto_path.roipacAutoPath,
            auto_path.gammaAutoPath)
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -829,8 +829,6 @@ def read_template(fname, delimiter='=', print_msg=True):
     Examples:
         tmpl = read_template(KyushuT424F610_640AlosA.template)
         tmpl = read_template(R1_54014_ST5_L0_F898.000.pi, ':')
-        from mintpy.defaults.auto_path import isceAutoPath
-        tmpl = read_template(isceAutoPath, print_msg=False)
     """
     template_dict = {}
     plotAttributeDict = {}


### PR DESCRIPTION
**Description of proposed changes**

The proposed change is to support auto_path for stripmapStack as the products are in different path than topsStack.
No need to change the template file

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.