### PR TITLE
view: geo & radar support for --pts-yx/lalo/file options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,9 @@ This is research code provided to you "as is" with NO WARRANTIES OF CORRECTNESS.
 
 ### 2. Running MintPy ###
 
-#### 2.1 Running routine workflow `smallbaselineApp.py` ####
+#### 2.1 Routine workflow `smallbaselineApp.py` ####
 
-MintPy reads a stack of interferograms (unwrapped interferograms, coherence and connecting components from SNAPHU if available) and the geometry files (DEM, lookup table, incidence angle, etc.). You need to give the [path to where the files are](dir_structure.md) and MintPy takes care of the rest! 
+MintPy reads a stack of interferograms (unwrapped interferograms, coherence and connected components from SNAPHU if available) and the geometry files (DEM, lookup table, incidence angle, etc.). You need to give the [path to where the files are](dir_structure.md) and MintPy takes care of the rest! 
 
 ```bash
 smallbaselineApp.py                         #run with default template 'smallbaselineApp.cfg'
@@ -35,6 +35,10 @@ smallbaselineApp.py GalapagosSenDT128.template --dostep velocity  #run at step '
 smallbaselineApp.py GalapagosSenDT128.template --end load_data    #end after step 'load_data'
 ```
 
+Inside smallbaselineApp.py, it reads the unwrapped interferograms, references all of them to the same coherent pixel (reference point), calculates the phase closure and estimates the unwrapping errors (if it has been asked for), inverts the network of interferograms into time-series, calculates the temporal coherence to evaluate the quality of inversion, corrects local oscillator drift (for Envisat only), corrects stratified tropospheric delay (using global atmospheric models or phase-elevation-ratio approach), removes phase ramps (if it has been asked for), corrects DEM error,... and finally estimates the velocity. 
+
+Configuration parameters for each step are initiated with default values in a customizable text file [**smallbaselineApp.cfg**](../mintpy/defaults/smallbaselineApp.cfg). 
+
 #### [Example](./demo_dataset.md) on Fernandina volcano, Galápagos with Sentinel-1 data ####
 
 ```bash
@@ -48,13 +52,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/examples/input_files/FernandinaSenDT128.
   <img width="600" src="https://yunjunzhang.files.wordpress.com/2019/06/fernandinasendt128_poi.jpg">
 </p>
 
-Inside smallbaselineApp.py, it reads the unwrapped interferograms, references all of them to the same coherent pixel (reference point), calculates the phase closure and estimates the unwrapping errors (if it has been asked for), inverts the network of interferograms into time-series, calculates the temporal coherence to evaluate the quality of inversion, corrects local oscillator drift (for Envisat only), corrects stratified tropospheric delay (using global atmospheric models or phase-elevation-ratio approach), removes phase ramps (if it has been asked for), corrects DEM error,... and finally estimates the velocity. 
-
-Configuration parameters for each step are initiated with default values in a customizable text file [**smallbaselineApp.cfg**](../mintpy/defaults/smallbaselineApp.cfg). Results are plotted in **./pic** folder.
-
-#### 2.2 Data visualization ####
-
-Below are some useful scripts for data information and visulization.
+Results are plotted in **./pic** folder. To explore more data information and visualization, try the following scripts:
 
 ```bash
 info.py                    #check HDF5 file structure and metadata
@@ -67,11 +65,11 @@ save_kmz.py                #generate Google Earth KMZ file in raster image
 save_kmz_timeseries.py     #generate Goodle Earth KMZ file in points for time-series (interactive)
 ```
 
-#### 2.3 Customized processing recipe: [example](https://github.com/insarlab/MintPy/blob/master/sh/compare_velocity_with_diff_tropo.sh) ####
+#### 2.2 Customized processing recipe: [example](https://github.com/insarlab/MintPy/blob/master/sh/compare_velocity_with_diff_tropo.sh) ####
 
 MintPy is a toolbox with individual utility scripts. Simply run the script with `-h / --help` to see its usage, you could build your own customized processing recipe! Here is an example to compare the velocities estimated from displacement time-series with different tropospheric delay corrections: [link](https://github.com/insarlab/MintPy/blob/master/sh/compare_velocity_with_diff_tropo.sh)
 
-#### 2.4 Build on top of mintpy python module ####
+#### 2.3 Build on top of `mintpy` module ####
 
 MintPy is modulized in Python with utilities classes and functions and well commented in the code level. Users who are familiar with Python could build their own functions and modules on top of [`mintpy.objects`](../mintpy/objects) and [`mintpy.utils`](../mintpy/utils). However, we don't have a complete API document website yet (maybe you can contribute this!). Below is an example of reading the 3D matrix of displacement time-series from an HDF5 file.
 
@@ -100,7 +98,7 @@ Yunjun, Z., H. Fattahi, F. Amelung (2019), Small baseline InSAR time series anal
 
 In addition to the above, we recommend that you cite the original publications that describe the algorithms used in your specific analysis. They are noted briefly in the [default template file](../mintpy/defaults/smallbaselineApp.cfg) and listed in [here](./references.md).
 
-### Contributors ###
+### 6. Contributors [[guideline](./CONTRIBUTING.md)] ###
 
 * Zhang Yunjun
 * Heresh Fattahi
@@ -112,4 +110,4 @@ In addition to the above, we recommend that you cite the original publications t
 * Emre Havazli
 * Yunmeng Cao
 * Andre Theron
-* [Other community members.](https://github.com/insarlab/MintPy/graphs/contributors) [[Contribute](./CONTRIBUTING.md)]
+* [Other community members.](https://github.com/insarlab/MintPy/graphs/contributors)

--- a/mintpy/objects/coord.py
+++ b/mintpy/objects/coord.py
@@ -45,7 +45,9 @@ class coordinate:
         """
         self.src_metadata = metadata
         if lookup_file is None:
-            lookup_file = get_lookup_file(lookup_file, print_msg=False)
+            # search the default lookup file based on the directory of input file
+            work_dir = os.path.dirname(metadata['FILE_PATH'])
+            lookup_file = get_lookup_file(lookup_file, work_dir=work_dir, print_msg=False)
         if isinstance(lookup_file, str):
             lookup_file = [lookup_file, lookup_file]
         self.lookup_file = lookup_file

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -203,11 +203,16 @@ def read_init_info(inps):
     inps.coord_unit = atr.get('Y_UNIT', 'degrees').lower()
 
     # Read Error List
+    inps.ts_plot_func = plot_ts_scatter
     inps.error_ts = None
     inps.ex_error_ts = None
     if inps.error_file:
-        error_fileContent = np.loadtxt(inps.error_file, dtype=bytes).astype(str)
-        inps.error_ts = error_fileContent[:, 1].astype(np.float)*inps.unit_fac
+        # assign plot function
+        inps.ts_plot_func = plot_ts_errorbar
+        # read error file
+        error_fc = np.loadtxt(inps.error_file, dtype=bytes).astype(str)
+        inps.error_ts = error_fc[:, 1].astype(np.float)*inps.unit_fac
+        # update error file with exlcude date
         if inps.ex_date_list:
             e_ts = inps.error_ts[:]
             inps.ex_error_ts = e_ts[inps.ex_flag == 0]
@@ -723,12 +728,10 @@ class timeseriesViewer():
                 d_tsi += self.offset * (num_file - 1 - i)
 
             # plot
-            if self.error_file:
-                self.ax_pts = plot_ts_errorbar(self.ax_pts, d_tsi, self, ppar)
-            else:
-                self.ax_pts = plot_ts_scatter(self.ax_pts, d_tsi, self, ppar)
+            if not np.all(np.isnan(d_tsi)):
+                self.ax_pts = self.ts_plot_func(self.ax_pts, d_tsi, self, ppar)
 
-        # format
+        # axis format
         self.ax_pts = _adjust_ts_axis(self.ax_pts, self)
         title_ts = _get_ts_title(yx[0], yx[1], self.coord)
         if self.mask[y, x] == 0:
@@ -743,19 +746,23 @@ class timeseriesViewer():
         if len(self.ts_data) > 1:
             self.ax_pts.legend()
 
-        self.fig_pts.canvas.draw()
-
         # Print to terminal
         vprint('\n---------------------------------------')
         vprint(title_ts)
         float_formatter = lambda x: [float('{:.2f}'.format(i)) for i in x]
         vprint(float_formatter(d_ts[0]))
-        vprint('displacement range: [{:.2f}, {:.2f}] {}'.format(np.nanmin(d_ts[0]),
-                                                                np.nanmax(d_ts[0]),
-                                                                self.disp_unit))
 
-        # Slope estimation
-        estimate_slope(d_ts[0], self.yearList, ex_flag=self.ex_flag, disp_unit=self.disp_unit)
+        if not np.all(np.isnan(d_ts[0])):
+            # stat info
+            vprint('displacement range: [{:.2f}, {:.2f}] {}'.format(np.nanmin(d_ts[0]),
+                                                                    np.nanmax(d_ts[0]),
+                                                                    self.disp_unit))
+
+            # estimate (print) slope
+            estimate_slope(d_ts[0], self.yearList, ex_flag=self.ex_flag, disp_unit=self.disp_unit)
+
+            # update figure
+            self.fig_pts.canvas.draw()
         return d_ts
 
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -297,17 +297,20 @@ def add_map_argument(parser):
 
 
 def add_point_argument(parser):
-    pts = parser.add_argument_group('Point', 'Plot points defined by y/x or lat/lon')
-    pts.add_argument('--pts-yx', dest='pts_yx', type=int, nargs=2, metavar=('Y', 'X'),
-                     help='Point in (Y, X) for plot in row/col coordinates only')
-    pts.add_argument('--pts-lalo', dest='pts_lalo', type=float, nargs=2, metavar=('LAT', 'LON'),
-                     help='Point in (Lat, Lon) for plot in geo coordinates only')
-    pts.add_argument('--pts-file', dest='pts_file', type=str,
-                     help='Point(s) defined in text file in lat/lon column')
-    pts.add_argument('--pts-marker', dest='pts_marker', type=str, default='k^',
+    ppt = parser.add_argument_group('Point', 'Plot points defined by y/x or lat/lon')
+    ppt.add_argument('--pts-marker', dest='pts_marker', type=str, default='k^',
                      help='Marker of points of interest (default: %(default)s).')
-    pts.add_argument('--pts-ms', dest='pts_marker_size', type=float, default=6.,
+    ppt.add_argument('--pts-ms', dest='pts_marker_size', type=float, default=6.,
                      help='Marker size for points of interest (default: %(default)s).')
+
+    pts = ppt.add_mutually_exclusive_group(required=False)
+    pts.add_argument('--pts-yx', dest='pts_yx', type=int, nargs=2, metavar=('Y', 'X'),
+                     help='Point in Y/X')
+    pts.add_argument('--pts-lalo', dest='pts_lalo', type=float, nargs=2, metavar=('LAT', 'LON'),
+                     help='Point in Lat/Lon')
+    pts.add_argument('--pts-file', dest='pts_file', type=str,
+                     help='Text file for point(s) in lat/lon column')
+
     return parser
 
 
@@ -365,21 +368,31 @@ def add_subset_argument(parser):
 
 def read_pts2inps(inps, coord_obj):
     """Read pts_* options"""
+    ## 1. merge pts_file/lalo/yx into pts_yx
     # pts_file --> pts_lalo
     if inps.pts_file and os.path.isfile(inps.pts_file):
+        print('read points lat/lon from text file: {}'.format(inps.pts_file))
         inps.pts_lalo = np.loadtxt(inps.pts_file, dtype=bytes).astype(float)
 
     # pts_lalo --> pts_yx
     if inps.pts_lalo is not None:
         # format pts_lalo to 2D array in size of (num_pts, 2)
         inps.pts_lalo = np.array(inps.pts_lalo).reshape(-1, 2)
+        # pts_lalo --> pts_yx
         inps.pts_yx = coord_obj.geo2radar(inps.pts_lalo[:, 0],
                                           inps.pts_lalo[:, 1],
-                                          print_msg=False)
+                                          print_msg=False)[:2]
 
+    ## 2. pts_yx --> pts_yx/lalo
     if inps.pts_yx is not None:
         # format pts_yx to 2D array in size of (num_pts, 2)
         inps.pts_yx = np.array(inps.pts_yx).reshape(-1, 2)
+        # pts_yx --> pts_lalo
+        inps.pts_lalo = coord_obj.radar2geo(inps.pts_yx[:, 0],
+                                            inps.pts_yx[:, 1],
+                                            print_msg=False)[:2]
+        # format pts_lalo to 2D array in size of (num_pts, 2)
+        inps.pts_lalo = np.array(inps.pts_lalo).reshape(-1, 2)
 
     return inps
 

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -383,15 +383,21 @@ def get_file_list(file_list, abspath=False, coord=None):
     return file_list_out
 
 
-def get_lookup_file(filePattern=None, abspath=False, print_msg=True):
-    """Find lookup table file with/without input file pattern"""
+def get_lookup_file(filePattern=None, abspath=False, work_dir='./', print_msg=True):
+    """Find lookup table file with/without input file pattern
+    Parameters: filePattern - list of str
+                abspath     - bool, return absolute path or not
+                work_dir    - str, mintpy working directory
+                print_msg   - bool, printout message or not
+    Returns:    outFile     - str, path of the lookup file
+    """
     # Search Existing Files
     if not filePattern:
         filePattern = ['geometryRadar.h5',
                        'geometryGeo_tight.h5', 'geometryGeo.h5',
                        'geomap*lks_tight.trans', 'geomap*lks.trans',
                        'sim*_tight.UTM_TO_RDC', 'sim*.UTM_TO_RDC']
-        filePattern = [os.path.join('inputs', i) for i in filePattern] + filePattern
+        filePattern = [os.path.join(work_dir, 'inputs', i) for i in filePattern] + filePattern
     existFiles = []
     try:
         existFiles = get_file_list(filePattern)

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -97,7 +97,8 @@ def test_dataset(dset_name, test_dir, fresh_start=True, test_pyaps=False):
         cmd = 'wget {}'.format(dset_url)
         print(cmd)
         os.system(cmd)
-    print('tar file exists, skip re-downloading.')
+    else:
+        print('tar file exists, skip re-downloading.')
 
     # uncompress tar file
     if not fresh_start and os.path.isdir(dset_name):


### PR DESCRIPTION
**Description of proposed changes**

view: geo & radar support for --pts-yx/lalo/file options

+ utils1.get_lookup_file(): add work_dir argument to be able to specify the mintpy working directory, instead of the default current one only.

+ objects.coord: search lookup file based on the file path/dir of the input file

+ utils.plot.read_pts2inps(): fix bug on yx/lalo conversion and format output yx/lalo data type.

+ utils.plot.add_point_argument(): put --pts-lalo/yx/file as mutually exclusive group for easy management; update help msg.

tsview: fix messy terminal msg while clicking masked out nan pixels

+ For multiple files, do not plot the TS if the current point TS is all nan.

+ if the point TS from the first file is all nan:
   - do not print out dis range info
   - do not estimate slope
   - do not draw/update figure

+ use inps.ts_plot_func for simpler code.

docs/README: update running mintpy section

**Reminders**

- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.