### PR TITLE
bugfix: ptime.yyyymmdd2years() returns list of str when given str

### DIFF
--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -191,7 +191,7 @@ def read_exclude_date(inps, dateListAll):
     # 3. startDate
     if inps.startDate:
         print('start date: '+inps.startDate)
-        yy_min = ptime.yyyymmdd2years(ptime.yyyymmdd(inps.startDate))[0]
+        yy_min = ptime.yyyymmdd2years(ptime.yyyymmdd(inps.startDate))
         for i in range(len(dateListAll)):
             date = dateListAll[i]
             if yy_list_all[i] < yy_min and date not in exDateList:

--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -191,7 +191,7 @@ def read_exclude_date(inps, dateListAll):
     # 3. startDate
     if inps.startDate:
         print('start date: '+inps.startDate)
-        yy_min = ptime.yyyymmdd2years(ptime.yyyymmdd(inps.startDate))
+        yy_min = ptime.yyyymmdd2years(ptime.yyyymmdd(inps.startDate))[0]
         for i in range(len(dateListAll)):
             date = dateListAll[i]
             if yy_list_all[i] < yy_min and date not in exDateList:

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -124,15 +124,16 @@ def yyyymmdd2years(dates):
     Returns:    years - (list of) float, years including the date and time info
     """
 
+    # make a copy in list of input arg
     if isinstance(dates, str):
-        dates = [dates]
+        date_list = [dates]
     else:
-        dates = list(dates)
+        date_list = list(dates)
 
-    date_format = get_date_str_format(dates[0])
+    date_format = get_date_str_format(date_list[0])
 
     years = []
-    for date_str in dates:
+    for date_str in date_list:
         d = dt.strptime(date_str, date_format)
         y = (d.year + (d.timetuple().tm_yday - 1) / 365.25 + 
              d.hour / (365.25 * 24) + 


### PR DESCRIPTION
Bug: 
`yy_min` is defined as a list in the startDate definition in the function `read_exclude_date(inps, dateListAll).`

**Description of proposed changes**

I changed yy_min from a list to a float to avoid '<' not supported between instances of 'float' and 'list'. 
Because later in the script is it going to compare with yy_list_all[i]
`yy_list_all[i] < yy_min`

**Reminders**

- [ ] Fix a broken behavior of ptime.yyyymmdd2years() from #410 
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
