### PR TITLE
constrain L >= 1

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -645,6 +645,8 @@ def calc_weight(stack_obj, box, weight_func='var', dropIfgram=True, chunk_size=1
     """Read coherence and calculate weight from it, chunk by chunk to save memory
     """
 
+    print('calculating weight from spatial coherence ...')
+
     # read coherence
     weight = read_coherence(stack_obj, box=box, dropIfgram=dropIfgram)
     num_pixel = weight.shape[1]
@@ -655,6 +657,8 @@ def calc_weight(stack_obj, box, weight_func='var', dropIfgram=True, chunk_size=1
         # use the typical ratio of resolution vs pixel size of Sentinel-1 IW mode
         L = int(stack_obj.metadata['ALOOKS']) * int(stack_obj.metadata['RLOOKS'])
         L = np.rint(L / 1.94)
+    # make sure L >= 1
+    L = max(L, 1)
 
     # convert coherence to weight chunk-by-chunk to save memory
     num_chunk = int(np.ceil(num_pixel / chunk_size))

--- a/mintpy/simulation/decorrelation.py
+++ b/mintpy/simulation/decorrelation.py
@@ -344,6 +344,9 @@ def coherence2weight(coh_data, weight_func='var', L=20, epsilon=5e-2, print_msg=
     coh_data[coh_data < epsilon] = epsilon
     coh_data = np.array(coh_data, np.float64)
 
+    # make sure L >= 1
+    L = max(L, 1)
+
     # Calculate Weight matrix
     weight_func = weight_func.lower()
     if 'var' in weight_func:


### PR DESCRIPTION
**Description of proposed changes**

Make sure the number of independent looks L >= 1 during the weight calculation from spatial coherence. 

In the case of full-resolution ifg with A/RLOOKS = 1, the previous calculation of L will lead to L = 0.

#420 

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.