### PR TITLE
indexing readfile.read() call in view.py

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -1,0 +1,13 @@
+## Frequently Asked Questions
+
+### 1. What's the sign convention of the line-of-sight data?
+
+For line-of-sight (LOS) phase in the unit of radians, positive value represents motion away from the satellite. We assume the "date1_date2" format for the interferogram with "date1" being the earlier acquisition.
+
+For LOS displacement in the unit of meters, positive value represents motion toward the satellite (uplift for pure vertical motion).
+
+### 2. How to prepare the input for MintPy if I am using InSAR software rather than ISCE stack processors and ARIA-tools?
+
+
+
+

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -509,7 +509,7 @@ class TimeSeriesAnalysis:
     def run_quick_overview(self, step_name):
         """A quick overview on the interferogram stack for:
             1) avgPhaseVelocity.h5: possible ground deformation through interferogram stacking
-            2) numNonzeroIntClosure.h5: phase unwrapping errors through the integer ambiguity of phase closure
+            2) numTriNonzeroIntAmbiguity.h5: phase unwrapping errors through the integer ambiguity of phase closure
         """
         # check the existence of ifgramStack.h5
         stack_file = ut.check_loaded_dataset(self.workDir, print_msg=False)[1]
@@ -520,7 +520,7 @@ class TimeSeriesAnalysis:
         print('temporal_average.py', ' '.join(iargs))
         mintpy.temporal_average.main(iargs)
 
-        # 2) calculate the integer ambiguity of closure phase
+        # 2) calculate the number of interferogram triplets with non-zero integer ambiguity
         water_mask_file = 'waterMask.h5'
         iargs = [stack_file, '--water-mask', water_mask_file, '--action', 'calculate', '--update']
         print('unwrap_error_phase_closure.py', ' '.join(iargs))

--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -246,7 +246,7 @@ def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None,
         closure_int = np.round((closure_pha - ut.wrap(closure_pha)) / (2.*np.pi))
         num_nonzero_closure[r0:r1, :] = np.sum(closure_int != 0, axis=0).reshape(-1, width)
 
-        prog_bar.update(i+1, every=1)
+        prog_bar.update(i+1, every=1, suffix='line {} / {}'.format(r0, length))
     prog_bar.close()
 
     # mask

--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -172,9 +172,9 @@ def run_or_skip(inps):
 
 
 ##########################################################################################
-def calc_num_nonzero_integer_closure_phase(ifgram_file, mask_file=None, dsName='unwrapPhase',
-                                           out_file=None, step=50, update_mode=True):
-    """Calculate the number of non-zero integer ambiguity of closure phase.
+def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None, dsName='unwrapPhase',
+                                                    out_file=None, step=50, update_mode=True):
+    """Calculate the number of triplets with non-zero integer ambiguity of closure phase.
 
     T_int as shown in equation (8-9) and inline in Yunjun et al. (2019, CAGEO).
 
@@ -185,7 +185,7 @@ def calc_num_nonzero_integer_closure_phase(ifgram_file, mask_file=None, dsName='
                 step        - int, number of row in each block to calculate T_int
                 update_mode - bool
     Returns:    out_file    - str, custom output filename
-    Example:    calc_num_nonzero_integer_closure_phase('inputs/ifgramStack.h5', mask_file='waterMask.h5')
+    Example:    calc_num_triplet_with_nonzero_integer_ambiguity('inputs/ifgramStack.h5', mask_file='waterMask.h5')
     """
 
     # default output file path
@@ -193,9 +193,9 @@ def calc_num_nonzero_integer_closure_phase(ifgram_file, mask_file=None, dsName='
         out_dir = os.path.dirname(os.path.dirname(ifgram_file))
         if dsName == 'unwrapPhase':
             # skip the default dsName in output filename
-            out_file = 'numNonzeroIntClosure.h5'
+            out_file = 'numTriNonzeroIntAmbiguity.h5'
         else:
-            out_file = 'numNonzeroIntClosure4{}.h5'.format(dsName)
+            out_file = 'numTriNonzeroIntAmbiguity4{}.h5'.format(dsName)
         out_file = os.path.join(out_dir, out_file)
 
     if update_mode and os.path.isfile(out_file):
@@ -263,13 +263,13 @@ def calc_num_nonzero_integer_closure_phase(ifgram_file, mask_file=None, dsName='
     writefile.write(num_nonzero_closure, out_file, meta)
 
     # plot
-    plot_num_nonzero_integer_closure_phase(out_file)
+    plot_num_triplet_with_nonzero_integer_ambiguity(out_file)
 
     return out_file
 
 
-def plot_num_nonzero_integer_closure_phase(fname, display=False, font_size=12, fig_size=[9,3]):
-    """Plot the histogram for the number of non-zero integer ambiguity
+def plot_num_triplet_with_nonzero_integer_ambiguity(fname, display=False, font_size=12, fig_size=[9,3]):
+    """Plot the histogram for the number of triplets with non-zero integer ambiguity
 
     Fig. 3d-e in Yunjun et al. (2019, CAGEO).
     """
@@ -299,7 +299,7 @@ def plot_num_nonzero_integer_closure_phase(fname, display=False, font_size=12, f
     ax.hist(data[~np.isnan(data)].flatten(), range=(0, vmax), log=True, bins=vmax)
 
     # axis format
-    ax.set_xlabel(r'# of non-zero integer ambiguity $T_{int}$', fontsize=font_size)
+    ax.set_xlabel(r'# of triplets w non-zero int ambiguity $T_{int}$', fontsize=font_size)
     ax.set_ylabel('# of pixels', fontsize=font_size)
     ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())
     ax.yaxis.set_major_locator(ticker.LogLocator(base=10.0, numticks=15))
@@ -565,12 +565,12 @@ def main(iargs=None):
 
     else:
         # calculate the number of triplets with non-zero integer ambiguity
-        out_file = calc_num_nonzero_integer_closure_phase(inps.ifgram_file,
-                                                          mask_file=inps.waterMaskFile,
-                                                          dsName=inps.datasetNameIn,
-                                                          update_mode=inps.update_mode)
+        out_file = calc_num_triplet_with_nonzero_integer_ambiguity(inps.ifgram_file,
+                                                                   mask_file=inps.waterMaskFile,
+                                                                   dsName=inps.datasetNameIn,
+                                                                   update_mode=inps.update_mode)
         # for debug
-        #plot_num_nonzero_integer_closure_phase(out_file)
+        #plot_num_triplet_with_nonzero_integer_ambiguity(out_file)
     m, s = divmod(time.time()-start_time, 60)
     print('\ntime used: {:02.0f} mins {:02.1f} secs\nDone.'.format(m, s))
     return

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
         - Example template files: examples/input_files/README.md
         - Parallel processing with Dask: dask.md
         - Tutorials in Jupyter Notebook: https://github.com/insarlab/MintPy-tutorial
+        - Frequently Asked Questions: FAQs.md
     - Output:
         - Google Earth KMZ: google_earth.md
         - HDF-EOS5: hdfeos5.md

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -109,11 +109,11 @@ def test_dataset(dset_name, test_dir, fresh_start=True, test_pyaps=False):
     else:
         # remove existing directory
         if os.path.isdir(dset_name):
-            print('removing existing project directory: {}'.format(dset_name))
+            print('remove existing project directory: {}'.format(dset_name))
             shutil.rmtree(dset_name)
 
         # uncompress tar file
-        print('extract content from tar file: {}'.format(tar_file))
+        print('extracting content from tar file: {}'.format(tar_file))
         tar = tarfile.open(tar_file)
         tar.extractall()
         tar.close()


### PR DESCRIPTION
**Description of proposed changes**

+ support fancy indexing / slicing in utils.readfile.read() with x/ystep, to merge the reading and multilooking process into one. This should significantly reduce the memory load of view.py for large 3D dataset.

+ rename `numNonzeroIntClosure.h5` to `numTriNonzeroIntAmbiguity.h5`.

+ add docs/FAQs page

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.