### PR TITLE
Improve memory efficiency in the steps of calculating ramp, deramp, residual_RMS

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -1002,8 +1002,7 @@ def ifgram_inversion(inps=None):
     meta['UNIT'] = 'm'
     meta['REF_DATE'] = date_list[0]
 
-    ts_obj = timeseries(inps.tsFile)
-    ts_obj.layout_hdf5(dsNameDict, meta)
+    writefile.layout_hdf5(inps.tsFile, dsNameDict, meta)
 
     # write date time-series
     date_list_utf8 = [dt.encode('utf-8') for dt in date_list]

--- a/mintpy/objects/ramp.py
+++ b/mintpy/objects/ramp.py
@@ -75,6 +75,7 @@ def deramp(data, mask_in, ramp_type='linear', metadata=None):
     # estimate ramp
     X = np.dot(np.linalg.pinv(G[mask, :], rcond=1e-15), data[mask, :])
     ramp = np.dot(G, X)
+    ramp = np.array(ramp, dtype=data.dtype)
     del X
 
     # reference in space if metadata
@@ -85,7 +86,6 @@ def deramp(data, mask_in, ramp_type='linear', metadata=None):
 
     # do not change pixel with original zero value
     ramp[data == 0] = 0
-    ramp = np.array(ramp, dtype=data.dtype)
 
     data_out = data - ramp
     if len(dshape) == 3:

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -404,7 +404,9 @@ class timeseries:
             print('read mask from file: '+maskFile)
             mask = singleDataset(maskFile).read()
             data[:, mask == 0] = np.nan
-        self.rms = np.sqrt(np.nanmean(np.square(data), axis=(1, 2)))
+        self.rms = np.zeros(data.shape[0]) * np.nan
+        for i in range(data.shape[0]):
+            self.rms[i] = np.sqrt(np.nanmean(np.square(data[i,:]), axis=(0, 1)))
 
         # Write text file
         header = 'Root Mean Square in space for each acquisition of time-series\n'

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -398,15 +398,26 @@ class timeseries:
         """Calculate the Root Mean Square for each acquisition of time-series
             and output result to a text file.
         """
-        # Calculate RMS
-        data = self.read()
+        # Get date list
+        date_list = self.get_date_list()
+        num_date  = len(date_list)
+
+        # Get mask
         if maskFile and os.path.isfile(maskFile):
             print('read mask from file: '+maskFile)
             mask = singleDataset(maskFile).read()
-            data[:, mask == 0] = np.nan
-        self.rms = np.zeros(data.shape[0]) * np.nan
-        for i in range(data.shape[0]):
-            self.rms[i] = np.sqrt(np.nanmean(np.square(data[i,:]), axis=(0, 1)))
+
+        # Calculate RMS one date at a time
+        self.rms = np.zeros(num_date) * np.nan
+        print('reading {} data from file: {} ...'.format(self.name, self.file))
+        prog_bar = ptime.progressBar(maxValue=num_date)
+        for i in range(num_date):
+            data = self.read(datasetName='{}'.format(date_list[i]), print_msg=False)
+            if maskFile and os.path.isfile(maskFile):
+                data[mask == 0] = np.nan
+            self.rms[i] = np.sqrt(np.nanmean(np.square(data), axis=(0, 1)))
+            prog_bar.update(i+1, suffix='{}/{}'.format(i+1, num_date))
+        prog_bar.close()
 
         # Write text file
         header = 'Root Mean Square in space for each acquisition of time-series\n'

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -796,7 +796,7 @@ def read_attribute(fname, datasetName=None, standardize=True, metafile_ext=None)
             'cfloat': 'complex64',
         }
         data_type = atr.get('DATA_TYPE', 'none').lower()
-        if data_type is not 'none' and data_type in dataTypeDict.keys():
+        if data_type != 'none' and data_type in dataTypeDict.keys():
             atr['DATA_TYPE'] = dataTypeDict[data_type]
 
     # UNIT

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -717,29 +717,27 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
     # deramping
     if k == 'timeseries':
         # initialize dataset structure
-        ts_obj     = timeseries(fname)
-        ts_obj.open()
+        ts_obj = timeseries(fname)
+        ts_obj.open(print_msg=False)
         date_list  = ts_obj.dateList
         num_date   = len(date_list)
-        length     = int(atr['LENGTH'])
-        width      = int(atr['WIDTH'])
         date_dtype = np.dtype('S{}'.format(len(date_list[0])))
         dsNameDict = {
             "date"       : (date_dtype, (num_date,)),
             "bperp"      : (np.float32, (num_date,)),
-            "timeseries" : (np.float32, (num_date, length, width)),
+            "timeseries" : (np.float32, (num_date, ts_obj.length, ts_obj.width)),
         }
-     
+
         # write HDF5 file with defined metadata and (empty) dataset structure
-        writefile.layout_hdf5(out_file, dsNameDict, atr)
+        writefile.layout_hdf5(out_file, dsNameDict, atr, print_msg=False)
 
         # write date time-series
         date_list_utf8 = [dt.encode('utf-8') for dt in date_list]
-        writefile.write_hdf5_block(out_file, date_list_utf8, datasetName='date')
+        writefile.write_hdf5_block(out_file, date_list_utf8, datasetName='date', print_msg=False)
 
         # write bperp time-series
         bperp = ts_obj.pbase
-        writefile.write_hdf5_block(out_file, bperp, datasetName='bperp')
+        writefile.write_hdf5_block(out_file, bperp, datasetName='bperp', print_msg=False)
 
         print('estimating phase ramp one date at a time ...')
         prog_bar = ptime.progressBar(maxValue=num_date)
@@ -752,11 +750,11 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
             # write
             writefile.write_hdf5_block(out_file, data,
                                        datasetName='timeseries',
-                                       block=[i, i+1, 0, length, 0, width],
+                                       block=[i, i+1, 0, ts_obj.length, 0, ts_obj.width],
                                        print_msg=False)
             prog_bar.update(i+1, suffix='{}/{}'.format(i+1, num_date))
         prog_bar.close()
-        print('finished writing to file: {}'.format(fname))
+        print('finished writing to file: {}'.format(out_file))
 
     elif k == 'ifgramStack':
         obj = ifgramStack(fname)

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -719,7 +719,8 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
         print('reading data ...')
         data = readfile.read(fname)[0]
         print('estimating phase ramp ...')
-        data = deramp(data, mask, ramp_type=ramp_type, metadata=atr)[0]
+        for i in range(data.shape[0]):
+            data[i,:] = deramp(data[i,:], mask, ramp_type=ramp_type, metadata=atr)[0]
         writefile.write(data, out_file, ref_file=fname)
 
     elif k == 'ifgramStack':
@@ -741,7 +742,8 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
             prog_bar = ptime.progressBar(maxValue=obj.numIfgram)
             for i in range(obj.numIfgram):
                 data = ds[i, :, :]
-                data = deramp(data, mask, ramp_type=ramp_type, metadata=atr)[0]
+                for j in range(data.shape[0]):
+                    data[j,:] = deramp(data[j,:], mask, ramp_type=ramp_type, metadata=atr)[0]
                 dsOut[i, :, :] = data
                 prog_bar.update(i+1, suffix='{}/{}'.format(i+1, obj.numIfgram))
             prog_bar.close()
@@ -750,7 +752,8 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
     # Single Dataset File
     else:
         data = readfile.read(fname)[0]
-        data = deramp(data, mask, ramp_type, metadata=atr)[0]
+        for i in range(data.shape[0]):
+            data[i,:] = deramp(data[i,:], mask, ramp_type=ramp_type, metadata=atr)[0]
         print('writing >>> {}'.format(out_file))
         writefile.write(data, out_file=out_file, ref_file=fname)
 

--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -266,7 +266,7 @@ def layout_hdf5(fname, dsNameDict, metadata):
     return fname
 
 
-def write_hdf5_block(fname, data, datasetName, block=None, mode='a'):
+def write_hdf5_block(fname, data, datasetName, block=None, mode='a', print_msg=True):
     """Write data to existing HDF5 dataset in disk block by block.
     Parameters: data        - np.ndarray 1/2/3D matrix
                 datasetName - str, dataset name
@@ -299,11 +299,11 @@ def write_hdf5_block(fname, data, datasetName, block=None, mode='a'):
                      0, shape[2]]
 
     # write
-    print('-'*50)
-    print('open  HDF5 file {} in {} mode'.format(fname, mode))
-    with h5py.File(fname, mode) as f:
+    if print_msg is True:
+        print('-'*50)
+        print('open  HDF5 file {} in {} mode'.format(fname, mode))
         print("writing dataset /{:<25} block: {}".format(datasetName, block))
-
+    with h5py.File(fname, mode) as f:
         if len(block) == 6:
             f[datasetName][block[0]:block[1],
                            block[2]:block[3],
@@ -315,8 +315,9 @@ def write_hdf5_block(fname, data, datasetName, block=None, mode='a'):
 
         elif len(block) == 2:
             f[datasetName][block[0]:block[1]] = data
-
-    print('close HDF5 file {}.'.format(fname))
+    
+    if print_msg is True:
+        print('close HDF5 file {}.'.format(fname))
     return fname
 
 

--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -191,7 +191,7 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None)
 
 #########################################################################
 
-def layout_hdf5(fname, dsNameDict, metadata):
+def layout_hdf5(fname, dsNameDict, metadata, print_msg=True):
     """Create HDF5 file with defined metadata and (empty) dataset structure
 
     Parameters: fname      - str, HDF5 file path
@@ -226,9 +226,10 @@ def layout_hdf5(fname, dsNameDict, metadata):
     }
     """
 
-    print('-'*50)
-    print('create HDF5 file {} with w mode'.format(fname))
     h5 = h5py.File(fname, "w")
+    if print_msg:
+        print('-'*50)
+        print('create HDF5 file {} with w mode'.format(fname))
 
     # initiate dataset
     for key in dsNameDict.keys():
@@ -247,9 +248,10 @@ def layout_hdf5(fname, dsNameDict, metadata):
         else:
             maxShape = data_shape
 
-        print("create dataset: {d:<25} of {t:<25} in size of {s}".format(d=key,
-                                                                         t=str(data_type),
-                                                                         s=data_shape))
+        if print_msg:
+            print("create dataset: {d:<25} of {t:<25} in size of {s}".format(d=key,
+                                                                             t=str(data_type),
+                                                                             s=data_shape))
         h5.create_dataset(key,
                           shape=data_shape,
                           maxshape=maxShape,
@@ -262,7 +264,8 @@ def layout_hdf5(fname, dsNameDict, metadata):
         h5.attrs[key] = metadata[key]
 
     h5.close()
-    print('close  HDF5 file {}'.format(fname))
+    if print_msg:
+        print('close  HDF5 file {}'.format(fname))
     return fname
 
 
@@ -299,7 +302,7 @@ def write_hdf5_block(fname, data, datasetName, block=None, mode='a', print_msg=T
                      0, shape[2]]
 
     # write
-    if print_msg is True:
+    if print_msg:
         print('-'*50)
         print('open  HDF5 file {} in {} mode'.format(fname, mode))
         print("writing dataset /{:<25} block: {}".format(datasetName, block))
@@ -315,8 +318,8 @@ def write_hdf5_block(fname, data, datasetName, block=None, mode='a', print_msg=T
 
         elif len(block) == 2:
             f[datasetName][block[0]:block[1]] = data
-    
-    if print_msg is True:
+
+    if print_msg:
         print('close HDF5 file {}.'.format(fname))
     return fname
 


### PR DESCRIPTION
**Description of proposed changes**

Deramp the dataset day-by-day instead of doing it at once with a large array.
Calculate the time-series residual RMS of the dataset day-by-day instead of doing it at once with a large array.

When dealing with large datasets (large width, length with many dates in time series), we may have a memory issue when trying to allocate a big array. So we chop it down to day-by-day calculation.

In addition, a syntax bug in readfile.py is also spotted and fixed. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.