### PR TITLE
bugfix in view.py --multilook-num

### DIFF
--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -255,9 +255,11 @@ def add_mask_argument(parser):
 def add_map_argument(parser):
     # Map
     mapg = parser.add_argument_group('Map', 'for one subplot in geo-coordinates only')
-    mapg.add_argument('--coastline', dest='coastline', type=str, default='no',
-                      choices={'10m', '50m', '110m', 'no'},
-                      help="Draw coastline with specified resolution (default: %(default)s).")
+    mapg.add_argument('--coastline', dest='coastline', type=str, choices={'10m', '50m', '110m'},
+                      help="Draw coastline with specified resolution (default: %(default)s).\n"
+                           "Link: https://scitools.org.uk/cartopy/docs/latest/matplotlib/geoaxes.html"
+                           "#cartopy.mpl.geoaxes.GeoAxes.coastlines")
+
     # lalo label
     mapg.add_argument('--lalo-loc', dest='lalo_loc', type=int, nargs=4, default=[1, 0, 0, 1],
                       metavar=('left', 'right', 'top', 'bottom'),

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -441,7 +441,7 @@ def plot_slice(ax, data, metadata, inps=None):
             vprint('map projection: {}'.format(inps.map_projection))
 
             # Draw coastline using cartopy resolution parameters
-            if inps.coastline != "no":
+            if inps.coastline:
                 vprint('draw coast line with resolution: {}'.format(inps.coastline))
                 ax.coastlines(resolution=inps.coastline)
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -921,8 +921,9 @@ def update_figure_setting(inps):
 def read_data4figure(i_start, i_end, inps, metadata):
     """Read multiple datasets for one figure into 3D matrix based on i_start/end"""
     data = np.zeros((i_end - i_start,
-                     int((inps.pix_box[3] - inps.pix_box[1]) / inps.multilook_num),
-                     int((inps.pix_box[2] - inps.pix_box[0]) / inps.multilook_num)), dtype=np.float32)
+                     np.rint((inps.pix_box[3] - inps.pix_box[1]) / inps.multilook_num - 1e-4).astype(int),
+                     np.rint((inps.pix_box[2] - inps.pix_box[0]) / inps.multilook_num - 1e-4).astype(int),
+                    ), dtype=np.float32)
 
     # fast reading for single dataset type
     if (len(inps.dsetFamilyList) == 1


### PR DESCRIPTION
**Description of proposed changes**

+ fix the initiation shape mismatch due to the recently introduced multilooking via indexing.

+ change the default value of coastline from 'no' to None, for more straightforward checking/comparison #437.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)