### PR TITLE
skip pixels with zero avgSpatialCoh/tempCoh to speedup processing

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -241,6 +241,7 @@ mintpy.velocity.bootstrapCount = auto   #[int>1], auto for 400, number of iterat
 
 
 ########## 11.1 geocode (post-processing)
+# for input dataset in radar coordinates only
 # commonly used resolution in meters and in degrees (on equator)
 # 100,         60,          50,          30,          20,          10
 # 0.000925926, 0.000555556, 0.000462963, 0.000277778, 0.000185185, 0.000092593

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -340,6 +340,13 @@ def correct_dem_error(inps, A_def):
     print('skip pixels with NaN  in ANY acquisitions')
     mask *= np.sum(np.isnan(ts_data), axis=0) == 0
 
+    tcoh_file = os.path.join(os.path.dirname(inps.timeseries_file), 'temporalCoherence.h5')
+    if os.path.isfile(tcoh_file):
+        print('skip pixels with ZERO temporal coherence')
+        tcoh = readfile.read(tcoh_file)[0].flatten()
+        mask *= tcoh != 0.
+        del tcoh
+
     if inps.rangeDist.size == 1:
         A_geom = inps.pbase / (inps.rangeDist * inps.sinIncAngle)
         A = np.hstack((A_geom, A_def))

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -104,7 +104,10 @@ def multilook_data(data, lks_y, lks_x):
         # reshape to more dimensions and collapse the extra dimensions with mean
         temp = crop_data.reshape((new_shape[0] // lks_y, lks_y,
                                   new_shape[1] // lks_x, lks_x))
-        coarse_data = np.nanmean(temp, axis=(1, 3))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            coarse_data = np.nanmean(temp, axis=(1, 3))
 
     elif len(shape) == 3:
         # crop data to the exact multiple of the multilook number
@@ -117,7 +120,10 @@ def multilook_data(data, lks_y, lks_x):
         temp = crop_data.reshape((new_shape[0],
                                   new_shape[1] // lks_y, lks_y,
                                   new_shape[2] // lks_x, lks_x))
-        coarse_data = np.nanmean(temp, axis=(2, 4))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            coarse_data = np.nanmean(temp, axis=(2, 4))
 
     return coarse_data
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -12,7 +12,7 @@ import os
 import sys
 import re
 import time
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta
 import h5py
 import numpy as np
 from mintpy.utils import ptime
@@ -183,6 +183,10 @@ class timeseries:
         # time info
         self.dateFormat = ptime.get_date_str_format(self.dateList[0])
         self.times = np.array([dt.strptime(i, self.dateFormat) for i in self.dateList])
+        # add hh/mm/ss info to the datetime objects
+        if 'T' not in self.dateFormat or all(i.hour==0 and i.minute==0 for i in self.times):
+            utc_sec = float(self.metadata['CENTER_LINE_UTC'])
+            self.times = np.array([i + timedelta(seconds=utc_sec) for i in self.times])
         self.tbase = np.array([(i.days + i.seconds / (24 * 60 * 60)) 
                                for i in (self.times - self.times[self.refIndex])],
                               dtype=np.float32)

--- a/mintpy/simulation/decorrelation.py
+++ b/mintpy/simulation/decorrelation.py
@@ -295,7 +295,7 @@ def coherence2phase_variance(coherence, L=32, scatter='DS', epsilon=1e-3, print_
     lineStr = '    number of independent looks L={}'.format(L)
     if L > 80:
         L = 80
-        lineStr += ', use L=80 to avoid dividing by 0 in calculation with negligible effect'
+        lineStr += ', use L=80 to avoid dividing by 0 with negligible effect'
     if print_msg:
         print(lineStr)
 

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -664,7 +664,7 @@ def correct_timeseries(dis_file, tropo_file, cor_dis_file):
     print('correcting relative delay for input time-series using diff.py')
     from mintpy import diff
 
-    iargs = [dis_file, tropo_file, '-o', cor_dis_file]
+    iargs = [dis_file, tropo_file, '-o', cor_dis_file, '--force']
     print('diff.py', ' '.join(iargs))
     diff.main(iargs)
     return cor_dis_file

--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -189,8 +189,8 @@ def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None,
     """
 
     # default output file path
+    out_dir = os.path.dirname(os.path.dirname(ifgram_file))
     if out_file is None:
-        out_dir = os.path.dirname(os.path.dirname(ifgram_file))
         if dsName == 'unwrapPhase':
             # skip the default dsName in output filename
             out_file = 'numTriNonzeroIntAmbiguity.h5'
@@ -251,9 +251,15 @@ def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None,
 
     # mask
     if mask_file is not None:
-        print('masking with file', mask_file)
         mask = readfile.read(mask_file)[0]
         num_nonzero_closure[mask == 0] = np.nan
+        print('mask out pixels with zero in file:', mask_file)
+
+    coh_file = os.path.join(out_dir, 'avgSpatialCoh.h5')
+    if os.path.isfile(coh_file):
+        coh = readfile.read(coh_file)[0]
+        num_nonzero_closure[coh == 0] = np.nan
+        print('mask out pixels with zero in file:', coh_file)
 
     # write to disk
     print('write to file', out_file)
@@ -572,7 +578,7 @@ def main(iargs=None):
         # for debug
         #plot_num_triplet_with_nonzero_integer_ambiguity(out_file)
     m, s = divmod(time.time()-start_time, 60)
-    print('\ntime used: {:02.0f} mins {:02.1f} secs\nDone.'.format(m, s))
+    print('time used: {:02.0f} mins {:02.1f} secs\nDone.'.format(m, s))
     return
 
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -257,20 +257,21 @@ def add_map_argument(parser):
     mapg = parser.add_argument_group('Map', 'for one subplot in geo-coordinates only')
     mapg.add_argument('--coastline', dest='coastline', type=str, choices={'10m', '50m', '110m'},
                       help="Draw coastline with specified resolution (default: %(default)s).\n"
+                           "This will enable --lalo-label option.\n"
                            "Link: https://scitools.org.uk/cartopy/docs/latest/matplotlib/geoaxes.html"
                            "#cartopy.mpl.geoaxes.GeoAxes.coastlines")
 
     # lalo label
-    mapg.add_argument('--lalo-loc', dest='lalo_loc', type=int, nargs=4, default=[1, 0, 0, 1],
-                      metavar=('left', 'right', 'top', 'bottom'),
-                      help='Draw lalo label in [left, right, top, bottom] (default: %(default)s).')
     mapg.add_argument('--lalo-label', dest='lalo_label', action='store_true',
                       help='Show N, S, E, W tick label for plot in geo-coordinate.\n'
                            'Useful for final figure output.')
-    mapg.add_argument('--lalo-max-num', dest='lalo_max_num', type=int, default=4, metavar='NUM',
-                      help='Maximum number of lalo tick label (default: %(default)s).')
     mapg.add_argument('--lalo-step', dest='lalo_step', metavar='DEG',
                       type=float, help='Lat/lon step for lalo-label option.')
+    mapg.add_argument('--lalo-max-num', dest='lalo_max_num', type=int, default=3, metavar='NUM',
+                      help='Maximum number of lalo tick label (default: %(default)s).')
+    mapg.add_argument('--lalo-loc', dest='lalo_loc', type=int, nargs=4, default=[1, 0, 0, 1],
+                      metavar=('left', 'right', 'top', 'bottom'),
+                      help='Draw lalo label in [left, right, top, bottom] (default: %(default)s).')
     mapg.add_argument('--lat-label', dest='lat_label_direction', type=str,
                       choices={'horizontal', 'vertical'}, default='horizontal',
                       help='Rotate Lat label from default horizontal to vertical (to save space).')
@@ -1714,7 +1715,7 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, print_msg=True)
         except:
             mask_file = None
             if print_msg:
-                print('Can not open mask file:', mask_file)        
+                print('Can not open mask file:', mask_file)
 
     elif k in ['HDFEOS']:
         if datasetName.split('-')[0] in timeseriesDatasetNames:

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -698,6 +698,8 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
     start_time = time.time()
     atr = readfile.read_attribute(fname)
     k = atr['FILE_TYPE']
+    length = int(atr['LENGTH'])
+    width = int(atr['WIDTH'])
 
     print('remove {} ramp from file: {}'.format(ramp_type, fname))
     if not out_file:
@@ -711,46 +713,27 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
         mask = readfile.read(mask_file)[0]
         print('read mask file: '+mask_file)
     else:
-        mask = np.ones((int(atr['LENGTH']), int(atr['WIDTH'])))
+        mask = np.ones((length, width), dtype=np.bool_)
         print('use mask of the whole area')
 
     # deramping
     if k == 'timeseries':
-        # initialize dataset structure
-        ts_obj = timeseries(fname)
-        ts_obj.open(print_msg=False)
-        date_list  = ts_obj.dateList
-        num_date   = len(date_list)
-        date_dtype = np.dtype('S{}'.format(len(date_list[0])))
-        dsNameDict = {
-            "date"       : (date_dtype, (num_date,)),
-            "bperp"      : (np.float32, (num_date,)),
-            "timeseries" : (np.float32, (num_date, ts_obj.length, ts_obj.width)),
-        }
-
         # write HDF5 file with defined metadata and (empty) dataset structure
-        writefile.layout_hdf5(out_file, dsNameDict, atr, print_msg=False)
-
-        # write date time-series
-        date_list_utf8 = [dt.encode('utf-8') for dt in date_list]
-        writefile.write_hdf5_block(out_file, date_list_utf8, datasetName='date', print_msg=False)
-
-        # write bperp time-series
-        bperp = ts_obj.pbase
-        writefile.write_hdf5_block(out_file, bperp, datasetName='bperp', print_msg=False)
+        writefile.layout_hdf5(out_file, ref_file=fname, print_msg=True)
 
         print('estimating phase ramp one date at a time ...')
+        date_list = timeseries(fname).get_date_list()
+        num_date = len(date_list)
         prog_bar = ptime.progressBar(maxValue=num_date)
         for i in range(num_date):
             # read
-            dsName = 'timeseries-{}'.format(date_list[i])
-            data = readfile.read(fname, datasetName=dsName)[0]
+            data = readfile.read(fname, datasetName=date_list[i])[0]
             # deramp
             data = deramp(data, mask, ramp_type=ramp_type, metadata=atr)[0]
             # write
             writefile.write_hdf5_block(out_file, data,
                                        datasetName='timeseries',
-                                       block=[i, i+1, 0, ts_obj.length, 0, ts_obj.width],
+                                       block=[i, i+1, 0, length, 0, width],
                                        print_msg=False)
             prog_bar.update(i+1, suffix='{}/{}'.format(i+1, num_date))
         prog_bar.close()
@@ -769,7 +752,7 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
                 print('access HDF5 dataset /{}'.format(dsNameOut))
             else:
                 dsOut = f.create_dataset(dsNameOut,
-                                         shape=(obj.numIfgram, obj.length, obj.width),
+                                         shape=(obj.numIfgram, length, width),
                                          dtype=np.float32,
                                          chunks=True,
                                          compression=None)

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -444,6 +444,7 @@ def plot_slice(ax, data, metadata, inps=None):
             if inps.coastline:
                 vprint('draw coast line with resolution: {}'.format(inps.coastline))
                 ax.coastlines(resolution=inps.coastline)
+                inps.lalo_label = True
 
             # Plot DEM
             if inps.dem_file:


### PR DESCRIPTION
**Description of proposed changes**

+ skip invalid pixels in numTriNonzeroIntAmbiguity calculation, network inversion and topo residual correction, to speedup the processing

+ utils.writefile.layout_hdf5(): support `ref_file` as an alternative of ds_name_dict and metadata, for easy use

+ timeseries: add precise UTC time info to `self.times`

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.