### PR TITLE
time function fitting: k! in the denominator of the polynomial function

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -487,7 +487,7 @@ class timeseries:
             """
             A = np.zeros([len(yr_diff), degree + 1], dtype=np.float32)
             for i in range(degree+1):
-                A[:,i] = yr_diff**i
+                A[:,i] = (yr_diff**i) / np.math.factorial(i)
 
             return A
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -481,6 +481,12 @@ class timeseries:
 
         def get_design_matrix4polynomial_func(yr_diff, degree):
             """design matrix/function model of linear/polynomial velocity estimation
+
+            The k! denominator makes the estimated polynomial coefficient (c_k) physically meaningful:
+                k=1 makes c_1 the velocity;
+                k=2 makes c_2 the acceleration;
+                k=3 makes c_3 the acceleration rate;
+
             Parameters: yr_diff: time difference from refDate in decimal years
                         degree : polynomial models: 1=linear, 2=quadratic, 3=cubic, etc.
             Returns:    A      : 2D array of poly-coeff. in size of (num_date, degree+1)


### PR DESCRIPTION
**Description of proposed changes**

Add a k! in the denominator of the polynomial function for estimating time function from the time-series data.
'k' is the degree of the polynomial function specified by the user.
This k! denominator makes the estimated polynomial coefficient (c_k) physically meaningful:
k=1 makes c_1 the velocity; 
k=2 makes c_2 the acceleration; 
k=3 makes c_3 the acceleration rate; 
etc.

This is based on equation 6 of [Fattahi and Amelung (2013)](https://falkamelung.github.io/Publications/FattahiAmelung_DEMError_IEEE_2013.pdf)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->


**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
