### PR TITLE
bugfix on the prep_fringe.py for the updated isce_utils.extract_geometry_metadata() args

### DIFF
--- a/mintpy/prep_fringe.py
+++ b/mintpy/prep_fringe.py
@@ -138,7 +138,7 @@ def prepare_metadata(meta_file, geom_src_dir, box=None):
 
     # add LAT/LON_REF1/2/3/4, HEADING, A/RLOOKS
     meta = isce_utils.extract_geometry_metadata(geom_src_dir,
-                                                metadata=meta,
+                                                meta=meta,
                                                 box=box,
                                                 fext_list=[geom_ext])
 


### PR DESCRIPTION
There is a bug on line 140 of the prep_fringe.py causing the code to stop working during the extraction of the metadata on the reference xml files.

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
