### PR TITLE
ifg_inv: NaN as no-data value for offset/phase 

### DIFF
--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -271,7 +271,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ref_file=None, compress
     f = h5py.File(fname, "w")
     if print_msg:
         print('-'*50)
-        print('create HDF5 file {} with w mode'.format(fname))
+        print('create HDF5 file: {} with w mode'.format(fname))
 
     # initiate dataset
     max_digit = max([len(i) for i in ds_name_dict.keys()])
@@ -291,7 +291,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ref_file=None, compress
 
         # create empty dataset
         if print_msg:
-            print(("create dataset: {d:<{w}} of {t:<25} in size of {s} with "
+            print(("create dataset  : {d:<{w}} of {t:<25} in size of {s} with "
                    "compression = {c}").format(d=key,
                                                w=max_digit,
                                                t=str(data_type),
@@ -314,7 +314,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ref_file=None, compress
 
     f.close()
     if print_msg:
-        print('close  HDF5 file {}'.format(fname))
+        print('close  HDF5 file: {}'.format(fname))
     return fname
 
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1111,7 +1111,7 @@ def plot_subplot4figure(i, inps, ax, data, metadata):
             if num_subplot <= 20:
                 subplot_title = '{}\n{}'.format(i, title_str)
             elif num_subplot <= 50:
-                subplot_title = title_str
+                subplot_title = title_str.replace('_','\n').replace('-','\n')
             else:
                 subplot_title = '{}'.format(i)
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -759,7 +759,7 @@ def read_dataset_input(inps):
     if len(inps.dset) > 0 or len(inps.dsetNumList) > 0:
         # message
         if len(inps.dset) > 0:
-            print('input dataset: "{}"'.format(inps.dset))
+            vprint('input dataset: "{}"'.format(inps.dset))
 
         # special rule for special file types
         if inps.key == 'velocity':


### PR DESCRIPTION
**Description of proposed changes**

+ ifgram_inversion: use np.nan value as the no-data value for observations (phase or offset) to replace the previous version of using both (zero and nan).

+ ifgramStack.temporal_average(): use nanmean to replace manual mean calculation, to better handle the nan value, for improved avgSpatialSnr.h5 calculation for offset.

+ view: break date1_date2 into date1\ndate2

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.