### PR TITLE
fix bool array index bug for h5 dataset

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -266,7 +266,7 @@ class timeseries:
             if box is None:
                 box = [0, 0, self.width, self.length]
 
-            data = ds[dateFlag, box[1]:box[3], box[0]:box[2]]
+            data = ds[:, box[1]:box[3], box[0]:box[2]][dateFlag]
             if squeeze:
                 data = np.squeeze(data)
         return data
@@ -701,7 +701,7 @@ class geometry:
                 else:
                     for e in datasetName:
                         dateFlag[self.dateList.index(e)] = True
-                data = ds[dateFlag, box[1]:box[3], box[0]:box[2]]
+                data = ds[:, box[1]:box[3], box[0]:box[2]][dateFlag]
                 data = np.squeeze(data)
         return data
 ################################# geometry class end ###################################
@@ -883,7 +883,7 @@ class ifgramStack:
             if box is None:
                 box = (0, 0, self.width, self.length)
 
-            data = ds[dateFlag, box[1]:box[3], box[0]:box[2]]
+            data = ds[:, box[1]:box[3], box[0]:box[2]][dateFlag]
             data = np.squeeze(data)
         return data
 
@@ -1033,7 +1033,7 @@ class ifgramStack:
             # reference value for phase
             ref_val = None
             if 'unwrapPhase' in datasetName and self.refY:
-                ref_val = dset[ifgram_flag, self.refY, self.refX]
+                ref_val = dset[:, self.refY, self.refX][ifgram_flag]
 
             # calculate lines by lines
             num_step = np.ceil(self.length / row_step).astype(int)
@@ -1041,7 +1041,7 @@ class ifgramStack:
             for i in range(num_step):
                 r0 = i * row_step
                 r1 = min(r0 + row_step, self.length)
-                data = dset[ifgram_flag, r0:r1, :]
+                data = dset[:, r0:r1, :][ifgram_flag]
 
                 # referencing / normalizing for phase
                 if 'unwrapPhase' in datasetName:
@@ -1370,7 +1370,7 @@ class HDFEOS:
                 else:
                     for e in datasetName:
                         dateFlag[self.dateList.index(e)] = True
-                data = ds[dateFlag, box[1]:box[3], box[0]:box[2]]
+                data = ds[:, box[1]:box[3], box[0]:box[2]][dateFlag]
                 data = np.squeeze(data)
         return data
 ################################# HDF-EOS5 class end ###################################

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -263,6 +263,9 @@ def read_subset_box(template_file, meta):
         length, width = int(meta['LENGTH']), int(meta['WIDTH'])
         pix_box = (0, 0, width, length)
 
+    # ensure all index are in int16
+    pix_box = tuple([int(i) for i in pix_box])
+
     return pix_box, meta
 
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -306,9 +306,9 @@ def read_hdf5_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
                     slice_flag[date_list.index(d)] = True
 
             # read data
-            data = ds[slice_flag,
+            data = ds[:,
                       box[1]:box[3],
-                      box[0]:box[2]]
+                      box[0]:box[2]][slice_flag]
             if xstep * ystep > 1:
                 data = data[:,
                             int(ystep/2)::ystep,


### PR DESCRIPTION
**Description of proposed changes**

+ `readfile` & `stack`: fix a bug of fancy indexing with numpy boolean array in h5py dataset (https://docs.h5py.org/en/stable/high/dataset.html#fancy-indexing), which is used in utils/readfile.py and objects/stack.py. This seems to be a bug in h5py side because it was working before.

+ `prep_aria`: fix a bug in gdal*.ReadAsArray() from numpy array int64 type to native python int16 type

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)