### PR TITLE
aria: example dataset on San Francisco and load_data support

### DIFF
--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -21,6 +21,27 @@ Relevant literature:
 
 + Yunjun, Z., H. Fattahi, and F. Amelung (2019), Small baseline InSAR time series analysis: Unwrapping error correction and noise reduction, _Computers & Geosciences, 133,_ 104331, doi:10.1016/j.cageo.2019.104331.
 
+#### Sentinel-1 on San Francisco Bay with ARIA ####
+
+Area: San Francisco Bay, California, USA     
+Data: Sentinel-1 A/B descending track 42 during May 2015 - March 2020 (114 acquisitoins; [Zenodo](https://zenodo.org/record/4265413))    
+Size: ~2.7 GB
+
+```bash
+wget https://zenodo.org/record/4265413/files/SanFranSenDT42.tar.xz
+tar -xvJf SanFranSenDT42.tar.xz
+cd SanFranSenDT42/mintpy
+smallbaselineApp.py ${MINTPY_HOME}/mintpy/data/input_files/SanFranSenDT42.txt     
+```
+
+<p align="left">
+  <img width="650" src="https://yunjunzhang.files.wordpress.com/2020/11/sanfransendt42_transect.jpg">
+</p>
+
+Relevant literature:
+
++ Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct connection between the Hayward and Calaveras Faults, Geophysical Research Letters, 42(8), 2734-2741, doi:10.1002/2015GL063575.
+
 #### Envisat of the 2008 Wells earthquake with Gamma ####
 
 Area: Wells, Nevada, USA       

--- a/mintpy/data/input_files/SanFranSenDT42.txt
+++ b/mintpy/data/input_files/SanFranSenDT42.txt
@@ -1,26 +1,21 @@
 # vim: set filetype=cfg:
-########## 1. load_data
-## no   - save   0% disk usage, fast [default]
-## lzf  - save ~57% disk usage, relative slow
-## gzip - save ~62% disk usage, very slow [not recommend]
-mintpy.load.processor      = aria  #[isce, aria, snap, gamma, roipac], auto for isce
-mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
-mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
+mintpy.load.processor       = aria  #[isce, aria, snap, gamma, roipac], auto for isce
 ##---------interferogram datasets:
 mintpy.load.unwFile        = ../stack/unwrapStack.vrt
 mintpy.load.corFile        = ../stack/cohStack.vrt
 mintpy.load.connCompFile   = ../stack/connCompStack.vrt
 ##---------geometry datasets:
-mintpy.load.demFile        = ../DEM/SRTM_3arcsec.dem
+mintpy.load.demFile        = ../DEM/*.dem
 mintpy.load.incAngleFile   = ../incidenceAngle/*.vrt
 mintpy.load.azAngleFile    = ../azimuthAngle/*.vrt
-mintpy.load.waterMaskFile  = ../mask/watermask.msk
+mintpy.load.waterMaskFile  = ../mask/water*.msk
 
-mintpy.reference.lalo           = 37.70, -122.07
-mintpy.network.coherenceBased   = yes
-mintpy.network.minCoherence     = 0.7
+mintpy.network.excludeIfgIndex  = auto #25, 30, 34, 40, 46, 52, 56, 57, 61, 62, 67, 70, 74, 80
+mintpy.reference.lalo           = 37.69, -122.07
+mintpy.unwrapError.method       = bridging
+mintpy.deramp                   = no
 
 ## options to speedup the processing (fast but not the best)
-mintpy.networkInversion.weightFunc              = no
-mintpy.topographicResidual.pixelwiseGeometry    = no
+mintpy.networkInversion.weightFunc           = no
+mintpy.topographicResidual.pixelwiseGeometry = no
 

--- a/mintpy/defaults/auto_path.py
+++ b/mintpy/defaults/auto_path.py
@@ -62,7 +62,6 @@ mintpy.load.processor      = roipac
 mintpy.load.unwFile        = ../PROCESS/DONE/IFG*/filt*.unw
 mintpy.load.corFile        = ../PROCESS/DONE/IFG*/filt*.cor
 mintpy.load.connCompFile   = ../PROCESS/DONE/IFG*/filt*snap_connect.byt
-mintpy.load.intFile        = None
 
 mintpy.load.demFile        = ../PROCESS/DONE/*${m_date12}*/radar_*rlks.hgt
 mintpy.load.lookupYFile    = ../PROCESS/GEO/geo_${m_date12}/geomap_*rlks.trans
@@ -78,7 +77,6 @@ mintpy.load.processor      = gamma
 mintpy.load.unwFile        = ../PROCESS/DONE/IFG*/diff*rlks.unw
 mintpy.load.corFile        = ../PROCESS/DONE/IFG*/*filt*rlks.cor
 mintpy.load.connCompFile   = None
-mintpy.load.intFile        = None
 
 mintpy.load.demFile        = ../PROCESS/SIM/sim_${m_date12}/sim*.hgt_sim
 mintpy.load.lookupYFile    = ../PROCESS/SIM/sim_${m_date12}/sim*.UTM_TO_RDC
@@ -89,11 +87,28 @@ mintpy.load.shadowMaskFile = None
 mintpy.load.bperpFile      = ../merged/baselines/*/*.base_perp
 '''
 
+AUTO_PATH_ARIA = '''##----------Default file path of ARIA products
+mintpy.load.processor      = aria
+mintpy.load.unwFile        = ../stack/unwrapStack.vrt
+mintpy.load.corFile        = ../stack/cohStack.vrt
+mintpy.load.connCompFile   = ../stack/connCompStack.vrt
+
+mintpy.load.demFile        = ../DEM/*.dem
+mintpy.load.lookupYFile    = None
+mintpy.load.lookupXFile    = None
+mintpy.load.incAngleFile   = ../incidenceAngle/*.vrt
+mintpy.load.azAngleFile    = ../azimuthAngle/*.vrt
+mintpy.load.shadowMaskFile = None
+mintpy.load.waterMaskFile  = ../mask/water*.msk
+'''
+
+
 AUTO_PATH_DICT = {
     'isce_tops'     : AUTO_PATH_ISCE_TOPS,
     'isce_stripmap' : AUTO_PATH_ISCE_STRIPMAP,
     'roipac'        : AUTO_PATH_ROIPAC,
     'gamma'         : AUTO_PATH_GAMMA,
+    'aria'          : AUTO_PATH_ARIA,
 }
 
 prefix = 'mintpy.load.'

--- a/mintpy/sh/plot_smallbaselineApp.sh
+++ b/mintpy/sh/plot_smallbaselineApp.sh
@@ -99,6 +99,9 @@ if [ $plot_timeseries -eq 1 ]; then
     #w/o trop delay correction
     file=timeseries_ramp.h5;                        test -f $file && $view $file $opt >> $log_file
     file=timeseries_demErr_ramp.h5;                 test -f $file && $view $file $opt >> $log_file
+
+    #w/o trop delay and deramp
+    file=timeseries_demErr.h5;                      test -f $file && $view $file $opt >> $log_file
 fi
 
 

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -342,25 +342,18 @@ class TimeSeriesAnalysis:
         self._copy_aux_file()
 
         # 2) loading data
-        stack_processor = self.template['mintpy.load.processor'].lower()
-        if stack_processor == 'aria':
-            from mintpy import prep_aria
-            iargs = ['--template', self.templateFile]
-            prep_aria.main(iargs)
+        # compose list of input arguments
+        # instead of using command line then split
+        # to support path with whitespace
+        iargs = ['--template', self.templateFile]
+        if self.customTemplateFile:
+            iargs += [self.customTemplateFile]
+        if self.projectName:
+            iargs += ['--project', self.projectName]
 
-        else:
-            # compose list of input arguments
-            # instead of using command line then split
-            # to support path with whitespace
-            iargs = ['--template', self.templateFile]
-            if self.customTemplateFile:
-                iargs += [self.customTemplateFile]
-            if self.projectName:
-                iargs += ['--project', self.projectName]
-
-            # run command line
-            print('load_data.py', ' '.join(iargs))
-            mintpy.load_data.main(iargs)
+        # run command line
+        print('load_data.py', ' '.join(iargs))
+        mintpy.load_data.main(iargs)
 
         # come back to working directory
         os.chdir(self.workDir)

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1323,7 +1323,8 @@ def prep_slice(cmd, auto_fig=False):
                 atr  : dict, metadata
                 inps : namespace, input argument for plot setup
     Example:
-        fig, ax = plt.subplots(figsize=[4, 3], projection=ccrs.PlateCarree())
+        subplot_kw = dict(projection=ccrs.PlateCarree())
+        fig, ax = plt.subplots(figsize=[4, 3], subplot_kw=subplot_kw)
         geo_box = (-91.670, -0.255, -91.370, -0.515)    # W, N, E, S
         cmd = 'view.py geo_velocity.h5 velocity --mask geo_maskTempCoh.h5 '
         cmd += '--sub-lon {w} {e} --sub-lat {s} {n} '.format(w=geo_box[0], n=geo_box[1], e=geo_box[2], s=geo_box[3])

--- a/test/configs/FernandinaSenDT128.txt
+++ b/test/configs/FernandinaSenDT128.txt
@@ -3,27 +3,13 @@ mintpy.compute.cluster = local
 ########## 1. Load Data (--load to exit after this step)
 ## load_data.py -H to check more details and example inputs.
 mintpy.load.processor  = isce
-##---------for ISCE only:
-mintpy.load.metaFile         = ../reference/IW*.xml
-mintpy.load.baselineDir      = ../baselines
-##---------interferogram datasets:
-mintpy.load.unwFile          = ../merged/interferograms/*/filt_*.unw
-mintpy.load.corFile          = ../merged/interferograms/*/filt_*.cor
-mintpy.load.connCompFile     = ../merged/interferograms/*/filt_*.unw.conncomp
-##---------geometry datasets:
-mintpy.load.demFile          = ../merged/geom_reference/hgt.rdr
-mintpy.load.lookupYFile      = ../merged/geom_reference/lat.rdr
-mintpy.load.lookupXFile      = ../merged/geom_reference/lon.rdr
-mintpy.load.incAngleFile     = ../merged/geom_reference/los.rdr
-mintpy.load.azAngleFile      = ../merged/geom_reference/los.rdr
-mintpy.load.shadowMaskFile   = ../merged/geom_reference/shadowMask.rdr
-mintpy.load.waterMaskFile    = None
+mintpy.load.autoPath   = yes
 
-mintpy.reference.lalo                           = -0.30,-91.43
+mintpy.reference.lalo  = -0.30,-91.43
 mintpy.networkInversion.weightFunc              = no
 mintpy.troposphericDelay.weatherModel           = ERA5
 mintpy.topographicResidual.pixelwiseGeometry    = no
 mintpy.topographicResidual.stepFuncDate         = 20170910,20180613  #eruption dates
-mintpy.deramp                                   = linear
-mintpy.save.hdfEos5                             = yes
+mintpy.deramp          = linear
+mintpy.save.hdfEos5    = yes
 

--- a/test/configs/SanFranSenDT42.txt
+++ b/test/configs/SanFranSenDT42.txt
@@ -1,0 +1,14 @@
+# vim: set filetype=cfg:
+mintpy.load.processor       = aria  #[isce, aria, snap, gamma, roipac], auto for isce
+mintpy.load.autoPath        = yes
+
+mintpy.subset.lalo          = 37.35:38.00, -122.45:-121.80
+mintpy.network.endDate      = 20170510
+mintpy.reference.lalo       = 37.69, -122.07
+mintpy.unwrapError.method   = bridging
+mintpy.deramp               = no
+
+mintpy.networkInversion.weightFunc           = no
+mintpy.troposphericDelay.method              = no
+mintpy.topographicResidual.pixelwiseGeometry = no
+

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -26,6 +26,7 @@ URL_LIST = [
     'https://zenodo.org/record/3952953/files/FernandinaSenDT128.tar.xz',
     'https://zenodo.org/record/3952950/files/WellsEnvD2T399.tar.xz',
     'https://zenodo.org/record/3952917/files/KujuAlosAT422F650.tar.xz',
+    'https://zenodo.org/record/4265413/files/SanFranSenDT42.tar.xz',
     'https://zenodo.org/record/4127335/files/WCapeSenAT29.tar.xz',
 ]
 


### PR DESCRIPTION
**Description of proposed changes**

+ docs/demo_dataset: add ARIA example dataset on San Francisco prepared by @hfattahi using ARIA-tools with link to [zenodo](https://zenodo.org/record/4265413)

+ add aria support in `load_data.py` by moving the `prep_aria.main()` call from smallbaselineApp.py to load_data.py. With this, the prep_aria.py appears to be the same as the other prep_*.py scripts (#469).

+ add 'mintpy.load.autoPath' support for aria.

+ add SanFranSenDT42 example dataset to `test/test_smallbaselineApp.py` for regular testing. Only local testing currently because downloading within circle ci every time would take quite some time.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.