### PR TITLE
prep_aria: load amplitude with --amp-stack-name as optional

### DIFF
--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -306,8 +306,9 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ref_file=None, compress
         data_shape = ds_name_dict[key][1]
 
         # turn ON compression for conn comp
+        ds_comp = compression
         if key in ['connectComponent']:
-            compression = 'lzf'
+            ds_comp = 'lzf'
 
         # changable dataset shape
         if len(data_shape) == 3:
@@ -322,13 +323,13 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ref_file=None, compress
                                                w=max_digit,
                                                t=str(data_type),
                                                s=str(data_shape),
-                                               c=compression))
+                                               c=ds_comp))
         ds = f.create_dataset(key,
                               shape=data_shape,
                               maxshape=max_shape,
                               dtype=data_type,
                               chunks=True,
-                              compression=compression)
+                              compression=ds_comp)
 
         # write auxliary data
         if len(ds_name_dict[key]) > 2 and ds_name_dict[key][2] is not None:


### PR DESCRIPTION
**Description of proposed changes**

Hi @dbekaert and @sssangha, this PR adds `prep_aria.py --amp-stack-name` option to be able to load interferogram amplitude data from ARIA into ifgramStack.h5 file as a 3D dataset named "magnitude", in the same level as "unwrapPhase".

It's optional with a default value of `ampStack.vrt`, which will be set to None if not exist. Of course, it could be changed into whatever name you choose on the ARIA-tools side (https://github.com/aria-tools/ARIA-tools/issues/244).

Could you please try it to see if it works?

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.