### PR TITLE
circle CI: add SanFranSenDT42 v0.1 for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             git clone https://github.com/yunjunz/pyaps3.git $PYAPS_HOME/pyaps3
             # install dependencies
             conda config --add channels conda-forge
-            conda install --yes --file $MINTPY_HOME/docs/conda.txt
+            conda install --yes --file $MINTPY_HOME/docs/conda.txt gdal>=3
             pip install git+https://github.com/tylere/pykml.git
             # test installation
             python -c "import mintpy; print(mintpy.version.description)"
@@ -50,6 +50,7 @@ jobs:
             cd ${HOME}/data
             ${MINTPY_HOME}/test/test_smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
             ${MINTPY_HOME}/test/test_smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
+            ${MINTPY_HOME}/test/test_smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
             ${MINTPY_HOME}/test/test_smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29
 
 workflows:

--- a/test/configs/SanFranSenDT42.txt
+++ b/test/configs/SanFranSenDT42.txt
@@ -1,14 +1,13 @@
 # vim: set filetype=cfg:
 mintpy.load.processor       = aria  #[isce, aria, snap, gamma, roipac], auto for isce
 mintpy.load.autoPath        = yes
+mintpy.load.xstep           = 2
+mintpy.load.ystep           = 2
 
-mintpy.subset.lalo          = 37.35:38.00, -122.45:-121.80
-mintpy.network.endDate      = 20170510
 mintpy.reference.lalo       = 37.69, -122.07
 mintpy.unwrapError.method   = bridging
-mintpy.deramp               = no
 
-mintpy.networkInversion.weightFunc           = no
-mintpy.troposphericDelay.method              = no
-mintpy.topographicResidual.pixelwiseGeometry = no
+mintpy.networkInversion.weightFunc              = no
+mintpy.deramp                                   = no
+mintpy.topographicResidual.pixelwiseGeometry    = no
 

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -27,7 +27,7 @@ URL_LIST = [
     'https://zenodo.org/record/3952953/files/FernandinaSenDT128.tar.xz',
     'https://zenodo.org/record/3952950/files/WellsEnvD2T399.tar.xz',
     'https://zenodo.org/record/3952917/files/KujuAlosAT422F650.tar.xz',
-    'https://zenodo.org/record/4265413/files/SanFranSenDT42.tar.xz',
+    'https://zenodo.org/record/4320005/files/SanFranSenDT42.tar.xz',
     'https://zenodo.org/record/4318134/files/WCapeSenAT29.tar.xz',
 ]
 


### PR DESCRIPTION
**Description of proposed changes**

+ circle ci:
   - install gdal to be able to run prep_aria.py
   - add SanFranSenDT42 for testing for aria

+ test:
   - configs/SanFranSenDT42: add mintpy.load.x/ystep for testing
   - test_sbApp: switch SanFranSenDT42 from v1 to v0 for smaller size and faster download / uncompression

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)