### PR TITLE
resample: more flexible API with example usage

### DIFF
--- a/mintpy/geocode.py
+++ b/mintpy/geocode.py
@@ -252,6 +252,7 @@ def run_geocode(inps):
                        software=inps.software,
                        print_msg=True)
     res_obj.open()
+    res_obj.prepare()
 
     # resample input files one by one
     for infile in inps.file:
@@ -268,16 +269,10 @@ def run_geocode(inps):
 
         ## prepare output
         # update metadata
-        shape2d = (res_obj.length, res_obj.width)
         if inps.radar2geo:
-            atr = attr.update_attribute4radar2geo(atr,
-                                                  shape2d=shape2d,
-                                                  lalo_step=res_obj.lalo_step,
-                                                  SNWE=res_obj.SNWE,
-                                                  lut_file=res_obj.lut_file)
+            atr = attr.update_attribute4radar2geo(atr, res_obj=res_obj)
         else:
-            atr = attr.update_attribute4geo2radar(atr,
-                                                  shape2d=shape2d)
+            atr = attr.update_attribute4geo2radar(atr, res_obj=res_obj)
 
         # instantiate output file
         file_is_hdf5 = os.path.splitext(infile)[1] in ['.h5', '.he5']

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -350,8 +350,14 @@ class geometryDict:
 
     def read(self, family, box=None, xstep=1, ystep=1):
         self.file = self.datasetDict[family]
+        # relax dataset name constraint for HDF5 file
+        # to support reading waterMask from waterMask.h5 file with /mask dataset
+        if self.file.endswith('.h5'):
+            dsName = None
+        else:
+            dsName = family
         data, metadata = readfile.read(self.file,
-                                       datasetName=family,
+                                       datasetName=dsName,
                                        box=box,
                                        xstep=xstep,
                                        ystep=ystep)

--- a/mintpy/utils/attribute.py
+++ b/mintpy/utils/attribute.py
@@ -81,15 +81,22 @@ def update_attribute4multilook(atr_in, lks_y, lks_x, box=None, print_msg=True):
     return atr
 
 
-def update_attribute4geo2radar(atr_in, shape2d, print_msg=True):
+def update_attribute4geo2radar(atr_in, shape2d=None, res_obj=None, print_msg=True):
     """update input dictionary of attributes due to resampling from geo to radar coordinates
 
     Parameters: atr_in  - dict, input dictionary of attributes
+                # combination 1
                 shape2d - tuple of 2 int in (length, width)
+                # combination 2
+                res_obj   - mintpy.objects.resample.resample object
     Returns:    atr     - dict, updated dictionary of attributes
     """
     # make a copy of original meta dict
     atr = dict(atr_in)
+
+    # grab info from res_obj
+    if res_obj is not None:
+        shape2d = (res_obj.length, res_obj.width)
 
     # update shape
     atr['LENGTH'] = shape2d[0]
@@ -105,18 +112,29 @@ def update_attribute4geo2radar(atr_in, shape2d, print_msg=True):
     return atr
 
 
-def update_attribute4radar2geo(atr_in, shape2d, lalo_step, SNWE, lut_file, print_msg=True):
+def update_attribute4radar2geo(atr_in, shape2d=None, lalo_step=None, SNWE=None, lut_file=None,
+                               res_obj=None, print_msg=True):
     """update input dictionary of attributes due to resampling from radar to geo coordinates
 
     Parameters: atr_in  - dict, input dictionary of attributes
+                # combination 1
                 shape2d - tuple of 2 int in (length, width)
                 lalo_step - tuple of 2 float, step size in lat/lon direction
                 SNWE      - tuple of 4 float
                 lut_file  - str, path of lookup table file
+                # combination 2
+                res_obj   - mintpy.objects.resample.resample object
     Returns:    atr     - dict, updated dictionary of attributes
     """
     # make a copy of original meta dict
     atr = dict(atr_in)
+
+    # grab info from res_obj
+    if res_obj is not None:
+        shape2d = (res_obj.length, res_obj.width)
+        lalo_step = res_obj.lalo_step
+        SNWE = res_obj.SNWE
+        lut_file = res_obj.lut_file
 
     atr['LENGTH'] = shape2d[0]
     atr['WIDTH'] = shape2d[1]


### PR DESCRIPTION
**Description of proposed changes**

+ separate open/prepare() to support matrix/dict IO without src file on the disk for a more flexible API.

+ set max_memory=0 by default to disable block-by-block IO

+ add comoments for explicit example usage of resample object

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.