### PR TITLE
tsview: no ref point / auto figsize / linewidth

### DIFF
--- a/mintpy/image_stitch.py
+++ b/mintpy/image_stitch.py
@@ -240,7 +240,7 @@ def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None):
     return
 
 
-def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True):
+def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_value=None):
     """Stitch all input files into one
     """
     # printout msg
@@ -249,14 +249,19 @@ def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True):
         print('\t{}'.format(fname))
 
     # stitching
-    mat, atr = readfile.read(fnames[0])
     print('read data from file: {}'.format(fnames[0]))
+    mat, atr = readfile.read(fnames[0])
+    if no_data_value is not None:
+        print('convert no_data_value from {} to NaN'.format(no_data_value))
+        mat[mat==no_data_value] = np.nan
 
     for i in range(1, len(fnames)):
         fname = fnames[i]
         print('-'*50)
         print('read data from file: {}'.format(fname))
         mat2, atr2 = readfile.read(fname)
+        if no_data_value is not None:
+            mat2[mat2==no_data_value] = np.nan
 
         print('stitching ...')
         (mat, atr,

--- a/mintpy/plot_coherence_matrix.py
+++ b/mintpy/plot_coherence_matrix.py
@@ -165,7 +165,7 @@ class coherenceMatrixViewer():
         # auto figure size
         if not self.fig_size:
             ds_shape = readfile.read(self.img_file)[0].shape
-            fig_size = pp.auto_figure_size(ds_shape, disp_cbar=True, ratio=0.7)
+            fig_size = pp.auto_figure_size(ds_shape, disp_cbar=True, scale=0.7)
             self.fig_size = [fig_size[0]+fig_size[1], fig_size[1]]
             vprint('create figure in size of {} inches'.format(self.fig_size))
 

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -748,13 +748,19 @@ def median_abs_deviation_threshold(data, center=None, cutoff=3.):
 def ceil_to_1(x):
     """Return the most significant digit of input number and ceiling it"""
     digit = int(np.floor(np.log10(abs(x))))
-    return round(x, -digit)+10**digit
+    x_round = round(x, -digit)
+    # round to ceil
+    if x_round >= x:
+        x_ceil = x_round
+    else:
+        x_ceil = x_round + 10**digit
+    return x_ceil
 
 
 def round_to_1(x):
     """Return the most significant digit of input number"""
     digit = int(np.floor(np.log10(abs(x))))
-    return round(x, -1*digit)
+    return round(x, -digit)
 
 
 def highest_power_of_2(x):

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -881,19 +881,14 @@ def update_figure_setting(inps):
         if not inps.font_size:
             inps.font_size = 16
         if not inps.fig_size:
+            # update length/width based on lat/lon
             if inps.geo_box and inps.fig_coord == 'geo':
                 length = abs(inps.geo_box[3] - inps.geo_box[1])
                 width = abs(inps.geo_box[2] - inps.geo_box[0])
-                plot_shape = []
-            plot_shape = [width*1.25, length]
-            if not inps.disp_cbar:
-                plot_shape = [width, length]
-            fig_scale = min(pp.min_figsize_single/min(plot_shape),
-                            pp.max_figsize_single/max(plot_shape),
-                            pp.max_figsize_height/plot_shape[1])
-            inps.fig_size = [i*fig_scale for i in plot_shape]
-            #inps.fig_size = [np.floor(i*fig_scale*2)/2 for i in plot_shape]
-            vprint('figure size : [{:.2f}, {:.2f}]'.format(inps.fig_size[0], inps.fig_size[1]))
+            # auto figure size
+            inps.fig_size = pp.auto_figure_size(ds_shape=(length, width),
+                                                disp_cbar=inps.disp_cbar,
+                                                print_msg=inps.print_msg)
 
     # Multiple Plots
     else:


### PR DESCRIPTION
**Description of proposed changes**

+ tsview:
   - bugfix for --ref-yx option if input file is geocoded: 1) do not overwrite --ref-yx in cmd; 2) update ref_lalo
   - do not plot reference point if --ref-yx not set in cmd and the native default one is out of the subset box
   - use default figure size for the image from pp.auto_figure_size() same as view.py
   - larger time slider without text value on the right
   - add --marker/--linewidth option for custom point time-series plot
   - plot() instead of scatter() plot to support --linewidth option.
   - use "(default: %(default)s)" in the argparse help msg.

+ utils.plot:
   - auto_figure_size(): add disp_slider/slider_ratio for tsview. Use it in view.py and update usage in plot_coherence_matrix.py
   - remove set_shared_y/xlabel() because the used method of `bboxes.inverse_transformed(f.transFigure)` is gonna be deprecated by matplotlib very soon.
     These two functions are not used anywhere by other mintpy scripts, so no impact is expected.
     Below is a simpler method from StackOverflow (https://stackoverflow.com/questions/16150819/common-xlabel-ylabel-for-matplotlib-subplots):
```python
import matplotlib.pyplot as plt
fig, ax = plt.subplots(nrows=3, ncols=3, sharex=True, sharey=True, figsize=(6, 6))
fig.text(0.5, 0.04, 'common X', ha='center')
fig.text(0.04, 0.5, 'common Y', va='center', rotation='vertical')
```

+ buxgix for utils.utils0.ceil_to_1(). This was not used anywhere in mintpy, thus no impact is expected.

+ image_stitch.stitch_files(): add no_data_value argument.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
