### PR TITLE
bugfix of x/ystep in load_data for gamma/roipac

### DIFF
--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -712,6 +712,7 @@ def print_write_setting(iDict):
     print('-'*50)
     print('updateMode : {}'.format(updateMode))
     print('compression: {}'.format(comp))
+    print('x/ystep: {}/{}'.format(iDict['xstep'], iDict['ystep']))
 
     # box
     box = iDict['box']
@@ -721,15 +722,7 @@ def print_write_setting(iDict):
     else:
         boxGeo = box
 
-    # step
-    xyStep = (iDict['xstep'], iDict['ystep'])
-    if not iDict.get('geocoded', False):
-        xyStepGeo = (1, 1)
-    else:
-        xyStepGeo = xyStep
-    print('x/ystep: {}/{}'.format(xyStep[0], xyStep[1]))
-
-    return updateMode, comp, box, boxGeo, xyStep, xyStepGeo
+    return updateMode, comp, box, boxGeo
 
 
 def get_extra_metadata(iDict):
@@ -767,7 +760,7 @@ def main(iargs=None):
     geomRadarObj, geomGeoObj = read_inps_dict2geometry_dict_object(iDict)
 
     # prepare write
-    updateMode, comp, box, boxGeo, xyStep, xyStepGeo = print_write_setting(iDict)
+    updateMode, comp, box, boxGeo = print_write_setting(iDict)
     if any([stackObj, geomRadarObj, geomGeoObj]) and not os.path.isdir(inps.outdir):
         os.makedirs(inps.outdir)
         print('create directory: {}'.format(inps.outdir))
@@ -778,8 +771,8 @@ def main(iargs=None):
         stackObj.write2hdf5(outputFile=inps.outfile[0],
                             access_mode='w',
                             box=box,
-                            xstep=xyStep[0],
-                            ystep=xyStep[1],
+                            xstep=iDict['xstep'],
+                            ystep=iDict['ystep'],
                             compression=comp,
                             extra_metadata=extraDict)
 
@@ -788,8 +781,8 @@ def main(iargs=None):
         geomRadarObj.write2hdf5(outputFile=inps.outfile[1],
                                 access_mode='w',
                                 box=box,
-                                xstep=xyStep[0],
-                                ystep=xyStep[1],
+                                xstep=iDict['xstep'],
+                                ystep=iDict['ystep'],
                                 compression='lzf',
                                 extra_metadata=extraDict)
 
@@ -798,8 +791,8 @@ def main(iargs=None):
         geomGeoObj.write2hdf5(outputFile=inps.outfile[2],
                               access_mode='w',
                               box=boxGeo,
-                              xstep=xyStepGeo[0],
-                              ystep=xyStepGeo[1],
+                              xstep=iDict['xstep'],
+                              ystep=iDict['ystep'],
                               compression='lzf')
 
     # time info

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -35,7 +35,7 @@ from mintpy.utils import (
 
 ########################################################################################
 class ifgramStackDict:
-    '''
+    """
     IfgramStack object for a set of InSAR pairs from the same platform and track.
 
     Example:
@@ -48,7 +48,7 @@ class ifgramStackDict:
                      }
         stackObj = ifgramStackDict(pairsDict=pairsDict)
         stackObj.write2hdf5(outputFile='ifgramStack.h5', box=(200,500,300,600))
-    '''
+    """
 
     def __init__(self, name='ifgramStack', pairsDict=None, dsName0=ifgramDatasetNames[0]):
         self.name = name
@@ -95,7 +95,7 @@ class ifgramStackDict:
 
     def write2hdf5(self, outputFile='ifgramStack.h5', access_mode='w', box=None, xstep=1, ystep=1,
                    compression=None, extra_metadata=None):
-        '''Save/write an ifgramStackDict object into an HDF5 file with the structure defined in:
+        """Save/write an ifgramStackDict object into an HDF5 file with the structure defined in:
 
         https://mintpy.readthedocs.io/en/latest/api/data_structure/#ifgramstack
 
@@ -104,7 +104,7 @@ class ifgramStackDict:
                     box : tuple, subset range in (x0, y0, x1, y1)
                     extra_metadata : dict, extra metadata to be added into output file
         Returns:    outputFile
-        '''
+        """
 
         self.pairs = sorted([pair for pair in self.pairsDict.keys()])
         self.dsNames = list(self.pairsDict[self.pairs[0]].datasetDict.keys())
@@ -308,7 +308,7 @@ class ifgramDict:
 
 ########################################################################################
 class geometryDict:
-    '''
+    """
     Geometry object for Lat, Lon, Heigt, Incidence, Heading, Bperp, ... from the same platform and track.
 
     Example:
@@ -331,7 +331,7 @@ class geometryDict:
         metadata = readfile.read_attribute('$PROJECT_DIR/merged/interferograms/20160629_20160723/filt_fine.unw')
         geomObj = geometryDict(processor='isce', datasetDict=datasetDict, extraMetadata=metadata)
         geomObj.write2hdf5(outputFile='geometryRadar.h5', access_mode='w', box=(200,500,300,600))
-    '''
+    """
 
     def __init__(self, name='geometry', processor=None, datasetDict={}, extraMetadata=None):
         self.name = name
@@ -507,10 +507,9 @@ class geometryDict:
 
     def write2hdf5(self, outputFile='geometryRadar.h5', access_mode='w', box=None, xstep=1, ystep=1,
                    compression='lzf', extra_metadata=None):
-        ''' Save/write to HDF5 file with structure defined in:
-
-        https://mintpy.readthedocs.io/en/latest/api/data_structure/#geometry
-        '''
+        """Save/write to HDF5 file with structure defined in:
+            https://mintpy.readthedocs.io/en/latest/api/data_structure/#geometry
+        """
         if len(self.datasetDict) == 0:
             print('No dataset file path in the object, skip HDF5 file writing.')
             return None
@@ -568,7 +567,7 @@ class geometryDict:
                     data = np.array(self.dateList, dtype=dsDataType)
                     ds = f.create_dataset(dsName, data=data)
 
-                # 2D datasets containing height, latitude, incidenceAngle, shadowMask, etc.
+                # 2D datasets containing height, latitude/longitude, range/azimuthCoord, incidenceAngle, shadowMask, etc.
                 else:
                     dsDataType = np.float32
                     if dsName.lower().endswith('mask'):
@@ -595,11 +594,19 @@ class geometryDict:
                         print(('    input file "{}" is water body (-1/0 for water/land), '
                                'convert to water mask (0/1 for water/land).'.format(fname)))
 
-                    if dsName == 'height':
+                    elif dsName == 'height':
                         noDataValueDEM = -32768
                         if np.any(data == noDataValueDEM):
                             data[data == noDataValueDEM] = np.nan
                             print('    convert no-data value for DEM {} to NaN.'.format(noDataValueDEM))
+
+                    elif dsName == 'rangeCoord' and xstep != 1:
+                        print('    scale value of {:<15} by 1/{} due to multilooking'.format(dsName, xstep))
+                        data /= xstep
+
+                    elif dsName == 'azimuthCoord' and ystep != 1:
+                        print('    scale value of {:<15} by 1/{} due to multilooking'.format(dsName, ystep))
+                        data /= ystep
 
                     # write
                     ds = f.create_dataset(dsName,
@@ -656,7 +663,7 @@ class geometryDict:
 
 ########################################################################################
 def read_isce_bperp_file(fname, full_shape, box=None, xstep=1, ystep=1):
-    '''Read ISCE coarse grid perpendicular baseline file, and project it to full size
+    """Read ISCE coarse grid perpendicular baseline file, and project it to full size
     Parameters: self : geometry object,
                 fname : str, bperp file name
                 outShape : tuple of 2int, shape of file in full resolution
@@ -664,7 +671,7 @@ def read_isce_bperp_file(fname, full_shape, box=None, xstep=1, ystep=1):
     Returns:    data : 2D array of float32
     Example:    fname = '$PROJECT_DIR/merged/baselines/20160418/bperp'
                 data = self.read_sice_bperp_file(fname, (3600,2200), box=(200,400,1000,1000))
-    '''
+    """
     # read original data
     data_c = readfile.read(fname)[0]
 

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -639,15 +639,17 @@ def calc_delay_timeseries(inps):
         inps.dem[:] = inps.custom_height
 
     if 'latitude' in geom_obj.datasetNames:
-        # for dataset in geo OR radar coord with lookup table in radar-coord (isce, doris)
+        # for lookup table in radar-coord (isce, doris)
         inps.lat = geom_obj.read(datasetName='latitude')
         inps.lon = geom_obj.read(datasetName='longitude')
+
     elif 'Y_FIRST' in geom_obj.metadata:
-        # for geo-coded dataset (gamma, roipac)
+        # for lookup table in geo-coded (gamma, roipac) and obs. in geo-coord
         inps.lat, inps.lon = ut.get_lat_lon(geom_obj.metadata)
+
     else:
-        # for radar-coded dataset (gamma, roipac)
-        inps.lat, inps.lon = ut.get_lat_lon_rdc(geom_obj.metadata)
+        # for lookup table in geo-coded (gamma, roipac) and obs. in radar-coord
+        inps.lat, inps.lon = ut.get_lat_lon_rdc(inps.atr)
 
 
     ## 2. prepare output file

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -343,26 +343,32 @@ def auto_adjust_colormap_lut_and_disp_limit(data, num_multilook=1, max_discrete_
     unique_values = np.unique(data[~np.isnan(data)])
     min_val = np.min(unique_values).astype(float)
     max_val = np.max(unique_values).astype(float)
-    vstep = np.min(np.diff(unique_values)).astype(float)
-    min_num_step = int((max_val - min_val) / vstep + 1)
 
-    # use discrete colromap for data with uniform AND limited unique values
-    # e.g. unwrapError time-series
-    if min_num_step <= max_discrete_num_step:
-        cmap_lut = min_num_step
-        vlim = [min_val - vstep/2, max_val + vstep/2]
-
-        if print_msg:
-            msg = 'data has uniform and limited number ({} <= {})'.format(unique_values.size, max_discrete_num_step)
-            msg += ' of unique values --> discretize colormap'
-            print(msg)
+    if min_val == max_val:
+        cmap_lut = 256
+        vlim = [min_val, max_val]
 
     else:
-        from mintpy.multilook import multilook_data
-        data_mli = multilook_data(data, num_multilook, num_multilook)
+        vstep = np.min(np.diff(unique_values)).astype(float)
+        min_num_step = int((max_val - min_val) / vstep + 1)
 
-        cmap_lut = 256
-        vlim = [np.nanmin(data_mli), np.nanmax(data_mli)]
+        # use discrete colromap for data with uniform AND limited unique values
+        # e.g. unwrapError time-series
+        if min_num_step <= max_discrete_num_step:
+            cmap_lut = min_num_step
+            vlim = [min_val - vstep/2, max_val + vstep/2]
+
+            if print_msg:
+                msg = 'data has uniform and limited number ({} <= {})'.format(unique_values.size, max_discrete_num_step)
+                msg += ' of unique values --> discretize colormap'
+                print(msg)
+
+        else:
+            from mintpy.multilook import multilook_data
+            data_mli = multilook_data(data, num_multilook, num_multilook)
+
+            cmap_lut = 256
+            vlim = [np.nanmin(data_mli), np.nanmax(data_mli)]
 
     return cmap_lut, vlim
 

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -384,10 +384,10 @@ def get_lat_lon_rdc(meta):
     length, width = int(meta['LENGTH']), int(meta['WIDTH'])
     lats = [float(meta['LAT_REF{}'.format(i)]) for i in [1,2,3,4]]
     lons = [float(meta['LON_REF{}'.format(i)]) for i in [1,2,3,4]]
-    
+
     lat = np.zeros((length,width),dtype = np.float32)
     lon = np.zeros((length,width),dtype = np.float32)
-    
+
     for i in range(length):
         for j in range(width):
             lat[i,j] = lats[0] + j*(lats[1] - lats[0])/width + i*(lats[2] - lats[0])/length

--- a/test/configs/WellsEnvD2T399.txt
+++ b/test/configs/WellsEnvD2T399.txt
@@ -16,13 +16,16 @@ mintpy.load.azAngleFile    = None
 mintpy.load.shadowMaskFile = None
 mintpy.load.waterMaskFile  = None
 
+mintpy.load.xstep          = 2
+mintpy.load.ystep          = 2
 mintpy.subset.lalo         = 41.02:41.32, -115.10:-114.65
+
 mintpy.reference.lalo      = 41.03, -114.70
 mintpy.network.coherenceBased     = yes       #[yes / no], auto for yes, exclude interferograms with coherence < minCoherence
 mintpy.network.keepMinSpanTree    = no
 mintpy.network.excludeDate        = 20071231, 20080204, 20080310
 mintpy.networkInversion.weightFunc              = no
-mintpy.troposphericDelay.weatherModel           = ERA5
+mintpy.troposphericDelay.method                 = no
 mintpy.topographicResidual.stepFuncDate         = 20080221
 mintpy.topographicResidual.pixelwiseGeometry    = no
 mintpy.save.hdfEos5         = yes


### PR DESCRIPTION
**Description of proposed changes**

+ load_data: apply the same number of looks to geo geometry file if obs is in radar coord (for GAMMA / ROI_PAC), for simplicity.

+ stackDict.geometryDict.write2hdf5(): update value of range/azimuthCoord if multilooking is applied, which fix the geocoding bug identified here: https://groups.google.com/g/mintpy/c/8kHIQKH5IXM

+ tropo_pyaps3: use LAT/LON_REF1/2/3/4 from displacement file if they are required (for GAMMA products in radar-coord) because they are missing in the geometryRadar.h5 file (at least sometimes)

+ plot.auto_adjust_colormap_lut_and_disp_limit(): fix potential bug when input data has the same value everywhere.

+ test: test x/ystep in Wells EQ example for GAMMA

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.