### PR TITLE
binary file IO: ignore file ext .geo/rdr/full/wgs84

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://img.shields.io/circleci/build/github/insarlab/MintPy.svg?color=green&logo=circleci)](https://circleci.com/gh/insarlab/MintPy)
 [![Version](https://img.shields.io/badge/version-v1.2.3-yellowgreen.svg)](https://github.com/insarlab/MintPy/releases)
 [![License](https://img.shields.io/badge/license-GPLv3-yellow.svg)](https://github.com/insarlab/MintPy/blob/main/LICENSE)
-[![Forum](https://img.shields.io/badge/forum-Google%20Group-orange.svg)](https://groups.google.com/forum/#!forum/mintpy)
+[![Forum](https://img.shields.io/badge/forum-Google%20Groups-orange.svg)](https://groups.google.com/g/mintpy)
 [![Citation](https://img.shields.io/badge/doi-10.1016%2Fj.cageo.2019.104331-blue)](https://doi.org/10.1016/j.cageo.2019.104331)
 
 ## MintPy ##
@@ -90,7 +90,7 @@ Algorithms implemented in the software are described in details at [Yunjun et al
 ### 4. Contact us ###
 
 + Most development discussion happens on GitHub. Feel free to [open an issue](https://github.com/insarlab/MintPy/issues) or comment on any open issue or pull request.
-+ Join our google group [https://groups.google.com/forum/#!forum/mintpy](https://groups.google.com/forum/#!forum/mintpy) to ask questions or leave comments.
++ Join our [user forum on google groups](https://groups.google.com/g/mintpy) or use [github discussions](https://github.com/insarlab/MintPy/discussions) to ask questions or leave comments.
 
 ### 5. Contributing ###
 

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -160,7 +160,7 @@ mintpy.networkInversion.shadowMask  = auto #[yes / no], auto for yes [if shadowM
 
 
 ########## correct_SET
-## Solid Earth tides (SET) correction [need to install insarlab/PySolid on GitHub]
+## Solid Earth tides (SET) correction [need to install insarlab/PySolid]
 ## reference: Milbert (2018); Fattahi et al. (2020, AGU)
 mintpy.solidEarthTides = auto #[yes / no], auto for no
 
@@ -169,9 +169,9 @@ mintpy.solidEarthTides = auto #[yes / no], auto for no
 ## correct tropospheric delay using the following methods:
 ## a. height_correlation - correct stratified tropospheric delay (Doin et al., 2009, J Applied Geop)
 ## b. pyaps - use Global Atmospheric Models (GAMs) data (Jolivet et al., 2011; 2014)
-##      ERA5  - ERA-5       from ECMWF [need to install PyAPS on GitHub; recommended and turn ON by default]
-##      MERRA - MERRA-2     from NASA  [need to install PyAPS on Caltech/EarthDef]
-##      NARR  - NARR        from NOAA  [need to install PyAPS on Caltech/EarthDef; recommended for N America]
+##      ERA5  - ERA-5       from ECMWF [need to install PyAPS from GitHub; recommended and turn ON by default]
+##      MERRA - MERRA-2     from NASA  [need to install PyAPS from Caltech/EarthDef]
+##      NARR  - NARR        from NOAA  [need to install PyAPS from Caltech/EarthDef; recommended for N America]
 ## c. gacos - use GACOS with the iterative tropospheric decomposition model (Yu et al., 2017, JGR; 2018, JGR; 2018, RSE)
 ##      Manually download GACOS products at http://www.gacos.net/index.html for all acquisitions before running this step.
 mintpy.troposphericDelay.method = auto  #[pyaps / height_correlation / gacos / no], auto for pyaps

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -225,7 +225,7 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='average', margin=
             outfile = os.path.basename(infile)
 
     # update metadata
-    atr = attr.updatea_attribute4multilook(atr, lks_y, lks_x, box=box)
+    atr = attr.update_attribute4multilook(atr, lks_y, lks_x, box=box)
 
     if ext in ['.h5', '.he5']:
         writefile.layout_hdf5(outfile, metadata=atr, ref_file=infile)

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -260,7 +260,14 @@ def read_data(inps):
         data = readfile.read(inps.file, datasetName=inps.dset)[0]
 
         if inps.outfile:
-            fext = os.path.splitext(inps.outfile)[1]
+            # get file extension
+            fbase, fext = os.path.splitext(inps.outfile)
+            # ignore certain meaningless file extensions
+            while fext in ['.geo', '.rdr', '.full', '.wgs84']:
+                fbase, fext = os.path.splitext(fbase)
+            if not fext:
+                fext = os.path.basename(fbase)
+
             atr['FILE_TYPE'] = fext
         else:
             # metadata

--- a/mintpy/utils/arg_group.py
+++ b/mintpy/utils/arg_group.py
@@ -206,9 +206,6 @@ def add_map_argument(parser):
     mapg.add_argument('--lalo-loc', dest='lalo_loc', type=int, nargs=4, default=[1, 0, 0, 1],
                       metavar=('left', 'right', 'top', 'bottom'),
                       help='Draw lalo label in [left, right, top, bottom] (default: %(default)s).')
-    mapg.add_argument('--lat-label', dest='lat_label_direction', type=str,
-                      choices={'horizontal', 'vertical'}, default='horizontal',
-                      help='Rotate Lat label from default horizontal to vertical (to save space).')
 
     mapg.add_argument('--projection', dest='map_projection', metavar='NAME', default='PlateCarree',
                       choices={'PlateCarree', 'LambertConformal'},

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -349,7 +349,7 @@ def auto_adjust_colormap_lut_and_disp_limit(data, num_multilook=1, max_discrete_
         vlim = [min_val, max_val]
 
     else:
-        vstep = np.min(np.diff(unique_values)).astype(float)
+        vstep = np.min(np.abs(np.diff(unique_values))).astype(float)
         min_num_step = int((max_val - min_val) / vstep + 1)
 
         # use discrete colromap for data with uniform AND limited unique values
@@ -1017,13 +1017,13 @@ def plot_dem_background(ax, geo_box=None, dem_shade=None, dem_contour=None, dem_
 
             ax.contour(xx, yy, dem_contour, dem_contour_seq, extent=geo_extent,
                        origin='upper', linewidths=inps.dem_contour_linewidth,
-                       colors='black', alpha=0.5, zorder=1)
+                       colors='black', alpha=0.5, zorder=2)
 
         # radar coordinates
         elif isinstance(ax, plt.Axes):
             ax.contour(dem_contour, dem_contour_seq, extent=rdr_extent,
                        origin='upper', linewidths=inps.dem_contour_linewidth,
-                       colors='black', alpha=0.5, zorder=1)
+                       colors='black', alpha=0.5, zorder=2)
     return ax
 
 
@@ -1168,7 +1168,7 @@ def plot_colorbar(inps, im, cax):
         cbar.set_label(inps.cbar_label, fontsize=inps.font_size, color=inps.font_color)
     elif inps.disp_unit != '1':
         cbar.set_label(inps.disp_unit,  fontsize=inps.font_size, color=inps.font_color)
-        
+
     return inps, cbar
 
 
@@ -1467,8 +1467,7 @@ def auto_lalo_sequence(geo_box, lalo_step=None, lalo_max_num=4, step_candidate=[
 
 
 def draw_lalo_label(geo_box, ax=None, lalo_step=None, lalo_loc=[1, 0, 0, 1], lalo_max_num=4,
-                    font_size=12, xoffset=None, yoffset=None, yrotate='horizontal',
-                    projection=ccrs.PlateCarree(), print_msg=True):
+                    font_size=12, xoffset=None, yoffset=None, projection=ccrs.PlateCarree(), print_msg=True):
     """Auto draw lat/lon label/tick based on coverage from geo_box
     Parameters: geo_box   : 4-tuple of float, (W, N, E, S) in degree
                 ax        : CartoPy axes.

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -796,7 +796,8 @@ def read_attribute(fname, datasetName=None, standardize=True, metafile_ext=None)
 
         # Read metadata file and FILE_TYPE
         metafile = metafiles[0]
-        while fext in ['.geo', '.rdr', '.full']:
+        # ignore certain meaningless file extensions
+        while fext in ['.geo', '.rdr', '.full', '.wgs84']:
             fbase, fext = os.path.splitext(fbase)
         if not fext:
             fext = fbase

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -503,7 +503,6 @@ def plot_slice(ax, data, metadata, inps=None):
                                    lalo_loc=inps.lalo_loc,
                                    lalo_max_num=inps.lalo_max_num,
                                    font_size=inps.font_size,
-                                   yrotate=inps.lat_label_direction,
                                    projection=inps.proj_obj,
                                    print_msg=inps.print_msg)
             else:
@@ -544,12 +543,14 @@ def plot_slice(ax, data, metadata, inps=None):
                         msg += ', v=[]'
                     else:
                         msg += ', v={:.3f}'.format(v)
+                    # DEM
                     if inps.dem_file:
                         dem_col = coord_dem.lalo2yx(x, coord_type='lon') - dem_pix_box[0]
                         dem_row = coord_dem.lalo2yx(y, coord_type='lat') - dem_pix_box[1]
                         if 0 <= dem_col < dem_wid and 0 <= dem_row < dem_len:
                             h = dem[dem_row, dem_col]
                             msg += ', h={:.0f}'.format(h)
+                    # x/y
                     msg += ', x={:.0f}, y={:.0f}'.format(col+inps.pix_box[0],
                                                          row+inps.pix_box[1])
                 return msg
@@ -591,7 +592,11 @@ def plot_slice(ax, data, metadata, inps=None):
                 row = int(np.rint((y - inps.geo_box[1]) / float(metadata['Y_STEP'])))
                 if 0 <= col < num_col and 0 <= row < num_row:
                     v = data[row, col]
-                    msg += ', v={:.3f}'.format(v)
+                    if np.isnan(v) or np.ma.is_masked(v):
+                        msg += ', v=[]'
+                    else:
+                        msg += ', v={:.3f}'.format(v)
+                    # DEM
                     if inps.dem_file:
                         h = dem[row, col]
                         msg += ', h={:.0f} m'.format(h)
@@ -663,7 +668,11 @@ def plot_slice(ax, data, metadata, inps=None):
             row = int(np.rint(y - inps.pix_box[1]))
             if 0 <= col < num_col and 0 <= row < num_row:
                 v = data[row, col]
-                msg += ', v={:.3f}'.format(v)
+                if np.isnan(v) or np.ma.is_masked(v):
+                    msg += ', v=[]'
+                else:
+                    msg += ', v={:.3f}'.format(v)
+                # DEM
                 if inps.dem_file:
                     h = dem[row, col]
                     msg += ', h={:.0f} m'.format(h)


### PR DESCRIPTION
**Description of proposed changes**

+ ignore in the following funcs the file extensions of .geo/rdr/full/wgs84 which does not provide data structure info, for improved smart file auto IO
   - readfile.read_attribute()
   - writefile.write()
   - save_roipac.read_data()

+ multilook.multilook_file: typo fix

+ view.format_coord: fix warning msg of masked array

+ utils.plot: remove deprecated --lat-label vertical/horzontal, which was added while using basemap and is not supported via current implementation of cartopy anymore.

+ utils.plot.plot_dem_background(): fix coutour zorder issue.

+ README: update links to google groups and github discussions

+ update comments on smallbaselineApp.cfg

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.