### PR TITLE
asc_desc2hz_up: check ref point using REF_Y/X with --max-ref-yx-diff 

### DIFF
--- a/mintpy/load_gbis.py
+++ b/mintpy/load_gbis.py
@@ -99,7 +99,7 @@ def gbis_mat2hdf5(inv_mat_file, display=True):
         insar_mat_file = mat['insar'][i].dataPath
         if not os.path.isfile(insar_mat_file):
             inp_file = os.path.dirname(os.path.dirname(inv_mat_file))+'.inp'
-            insar_mat_file = grab_data_paths_from_inp_file(inp_file)[i]            
+            insar_mat_file = grab_data_paths_from_inp_file(inp_file)[i]
         print('-'*30)
         print('read mask from file: {}'.format(insar_mat_file))
 
@@ -121,7 +121,8 @@ def gbis_mat2hdf5(inv_mat_file, display=True):
 
         # prepare metadata
         meta = vars(sio.loadmat(insar_mat_file, struct_as_record=False, squeeze_me=True)['Metadata'])
-        temp = meta.pop('_fieldnames') # remove _fieldnames added by Matlab
+        if '_fieldnames' in meta.keys():
+            meta.pop('_fieldnames')
         meta['UNIT'] = 'm'
         meta['FILE_TYPE'] = 'displacement'
         meta['PROCESSOR'] = 'GBIS'

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1017,13 +1017,13 @@ def plot_dem_background(ax, geo_box=None, dem_shade=None, dem_contour=None, dem_
 
             ax.contour(xx, yy, dem_contour, dem_contour_seq, extent=geo_extent,
                        origin='upper', linewidths=inps.dem_contour_linewidth,
-                       colors='black', alpha=0.5, zorder=2)
+                       colors='black', alpha=0.5, zorder=1)
 
         # radar coordinates
         elif isinstance(ax, plt.Axes):
             ax.contour(dem_contour, dem_contour_seq, extent=rdr_extent,
                        origin='upper', linewidths=inps.dem_contour_linewidth,
-                       colors='black', alpha=0.5, zorder=2)
+                       colors='black', alpha=0.5, zorder=1)
     return ax
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ asc_desc2horz_vert.py:
   - check the reference point consistency using REF_Y/X (derived from REF_LAT/LON) instead of REF_LAT/LON to better handle various spatial resolution (#275).
   - add --max-ref-yx-diff option to be able to customize/relax the REF_Y/X difference if needed, with default value of 3 pixels.

+ utls.plot.plot_dem_background(): revert zorder of DEM contour back to 1, because there was no issue there (#508).

+ load_gbis: support input file reading from *.inp file if the data path saved in the result .mat file does not exist. This happens when one run GBIS in one machine and plot/do other stuff in another machine.

**Reminders**

- [x] Fix #275
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.