### PR TITLE
gacos: support new .tif format

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -36,6 +36,10 @@
 
 + Werner, C., U. Wegmüller, T. Strozzi, and A. Wiesmann (2000), Gamma SAR and interferometric processing software, paper presented at _Proceedings of the ERS-Envisat symposium_, Gothenburg, Sweden.
 
++ Yu, C., Z. Li, and N. T. Penna (2018), Interferometric synthetic aperture radar atmospheric correction using a GPS-based iterative tropospheric decomposition model, Remote Sensing of Environment, 204, 109-121, doi:10.1016/j.rse.2017.10.038.
+
++ Yu, C., Z. Li, N. T. Penna, and P. Crippa (2018), Generic Atmospheric Correction Model for Interferometric Synthetic Aperture Radar Observations, Journal of Geophysical Research: Solid Earth, 123(10), 9202-9222, doi:10.1029/2017JB015305.
+
 + Yunjun, Z., H. Fattahi, and F. Amelung (2019), Small baseline InSAR time series analysis: Unwrapping error correction and noise reduction, _Computers & Geosciences, 133_, 104331, doi:10.1016/j.cageo.2019.104331.
 
 + Zebker, H. A., P. A. Rosen, and S. Hensley (1997), Atmospheric effects in interferometric synthetic aperture radar surface deformation and topographic maps, _Journal of Geophysical Research: Solid Earth, 102_(B4), 7547-7563, doi:10.1029/96JB03804.

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -178,8 +178,8 @@ mintpy.solidEarthTides = auto #[yes / no], auto for no
 ##      ERA5  - ERA-5       from ECMWF [need to install PyAPS from GitHub; recommended and turn ON by default]
 ##      MERRA - MERRA-2     from NASA  [need to install PyAPS from Caltech/EarthDef]
 ##      NARR  - NARR        from NOAA  [need to install PyAPS from Caltech/EarthDef; recommended for N America]
-## c. gacos - use GACOS with the iterative tropospheric decomposition model (Yu et al., 2017, JGR; 2018, JGR; 2018, RSE)
-##      Manually download GACOS products at http://www.gacos.net/index.html for all acquisitions before running this step.
+## c. gacos - use GACOS with the iterative tropospheric decomposition model (Yu et al., 2018a, RSE; 2018b, JGR)
+##      Manually download GACOS products at http://www.gacos.net for all acquisitions before running this step.
 mintpy.troposphericDelay.method = auto  #[pyaps / height_correlation / gacos / no], auto for pyaps
 
 ## Notes for pyaps:

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -372,8 +372,10 @@ def get_lat_lon(meta, geom_file=None, box=None, dimension=2):
 
 
 def get_lat_lon_rdc(meta):
-    """Get 2D array of lat and lon.
-    For metadata dict in radar-coord
+    """Get 2D array of lat and lon for metadata dict in radar-coord.
+
+    WARNING: This is a rough lat/lon value, NOT accurate!
+
     Parameters: meta : dict, including LENGTH, WIDTH and LAT/LON_REF1/2/3/4
     Returns:    lats : 2D np.array for latitude  in size of (length, width)
                 lons : 2D np.array for longitude in size of (length, width)


### PR DESCRIPTION
For GACOS-corrections, subsets were not properly applied. Specifically, the entire GACOS field was passed. Thus, this would result in inconsistent dimension errors:

```
  File "/u/sar-r2/ssangha/conda_installation/stable_aug14_2020/MintPy/mintpy/smallbaselineApp.py", line 1182, in <module>
    main(sys.argv[1:])
  File "/u/sar-r2/ssangha/conda_installation/stable_aug14_2020/MintPy/mintpy/smallbaselineApp.py", line 1172, in main
    app.run(steps=inps.runSteps, plot=inps.plot)
  File "/u/sar-r2/ssangha/conda_installation/stable_aug14_2020/MintPy/mintpy/smallbaselineApp.py", line 1122, in run
    self.run_tropospheric_delay_correction(sname)
  File "/u/sar-r2/ssangha/conda_installation/stable_aug14_2020/MintPy/mintpy/smallbaselineApp.py", line 823, in run_tropospheric_delay_correction
    mintpy.tropo_gacos.main(iargs)
  File "/u/sar-r2/ssangha/conda_installation/stable_aug14_2020/MintPy/mintpy/tropo_gacos.py", line 340, in main
    calculate_delay_timeseries(tropo_file=inps.tropo_file,
  File "/u/sar-r2/ssangha/conda_installation/stable_aug14_2020/MintPy/mintpy/tropo_gacos.py", line 192, in calculate_delay_timeseries
    ztd_files = np.array(ztd_files)[flag].tolist()
IndexError: boolean index did not match indexed array along dimension 0; dimension is 202 but corresponding boolean dimension is 101
```

After implementing my fixes, subsets were taken as expected:

<img width="1500" alt="Screen Shot 2021-02-16 at 11 59 15 AM" src="https://user-images.githubusercontent.com/13227405/108131053-8dec1800-7065-11eb-8b67-17ceff41b823.png">

Furthermore, GACOS products appear to be distributed as ‘TIF’ files now by default, while Mintpy had still expected products with the original ‘.ztd’ extension. Now a check for both has been integrated.