### PR TITLE
Track ramp coefficients

### DIFF
--- a/mintpy/objects/ramp.py
+++ b/mintpy/objects/ramp.py
@@ -19,16 +19,19 @@ RAMP_LIST = [
 ]
 
 
-def deramp(data, mask_in, ramp_type='linear', metadata=None, max_num_sample=1e6):
+def deramp(data, mask_in, ramp_type='linear', metadata=None, max_num_sample=1e6, coeff_file=None):
     '''Remove ramp from input data matrix based on pixel marked by mask
     Ignore data with nan or zero value.
-    Parameters: data      : 2D / 3D np.ndarray, data to be derampped
-                            If 3D, it's in size of (num_date, length, width)
-                mask_in   : 2D np.ndarray, mask of pixels used for ramp estimation
-                ramp_type : str, name of ramp to be estimated.
-                metadata  : dict, containing reference pixel info, REF_Y/X
-    Returns:    data_out  : 2D / 3D np.ndarray, data after deramping
-                ramp      : 2D / 3D np.ndarray, estimated ramp
+    Parameters: data       : 2D / 3D np.ndarray, data to be derampped
+                             If 3D, it's in size of (num_date, length, width)
+                mask_in    : 2D np.ndarray, mask of pixels used for ramp estimation
+                ramp_type  : str, name of ramp to be estimated.
+                metadata   : dict, containing reference pixel info, REF_Y/X
+                max_num_sample : float, max number of pixel sample, 
+                             above which the uniform sampling is applied to reduce sample size
+                coeff_file : str, path to the text file to save the estimated ramp coefficients
+    Returns:    data_out   : 2D / 3D np.ndarray, data after deramping
+                ramp       : 2D / 3D np.ndarray, estimated ramp
     '''
     dshape = data.shape
     length, width = dshape[-2:]
@@ -90,7 +93,13 @@ def deramp(data, mask_in, ramp_type='linear', metadata=None, max_num_sample=1e6)
     X = np.dot(np.linalg.pinv(G[mask, :], rcond=1e-15), data[mask, :])
     ramp = np.dot(G, X)
     ramp = np.array(ramp, dtype=data.dtype)
-    del X
+
+    # write estimated coefficient to text file
+    if coeff_file is not None:
+        with open(coeff_file, 'a') as f:
+            for i in range(X.T.shape[0]):
+                coeff_str = '    '.join(['{:16.6e}'.format(float(c)) for c in X.T[i,:]])
+                f.write('{}\n'.format(coeff_str))
 
     # reference in space if metadata
     if metadata and all(key in metadata.keys() for key in ['REF_X','REF_Y']):

--- a/mintpy/remove_ramp.py
+++ b/mintpy/remove_ramp.py
@@ -45,6 +45,8 @@ def create_parser():
                              'e.g.: unwrapPhase\n' +
                              '      unwrapPhase_bridging')
     parser.add_argument('-o', '--outfile', help='Output file name.')
+    parser.add_argument('--save-ramp-coeff', dest='save_ramp_coeff', action='store_true',
+                        help='Save the estimated ramp coefficients into text file.')
     parser.add_argument('--update', dest='update_mode', action='store_true',
                         help='Enable update mode, and skip inversion if:\n'+
                              '1) output file already exists, readable '+
@@ -115,7 +117,8 @@ def main(iargs=None):
                              ramp_type=inps.surface_type,
                              mask_file=inps.mask_file,
                              out_file=inps.outfile,
-                             datasetName=inps.dset)
+                             datasetName=inps.dset,
+                             save_ramp_coeff=inps.save_ramp_coeff)
 
     # config parameter
     print('add/update the following configuration metadata to file:\n{}'.format(configKeys))


### PR DESCRIPTION
**Description of proposed changes**

Update `remove_ramp.py` to produce text-files reporting function fit coefficient for given field(s). Text-file names reflect the input filename and ramp type.

For time-series files, there are n lines for each epoch with each line prepended by the epoch date.

For IFG stacks, there are n lines for each IFG with each line prepended by the IFG index.

And finally for function-fits to the TS (e.g. velocity), a single line is written out at prepended by the function-fit type.

This summary may be a bit terse, so please let me know if you’d like me to elaborate on anything.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
