### PR TITLE
Add libgfortran5 prerequisite

### DIFF
--- a/docs/conda.txt
+++ b/docs/conda.txt
@@ -5,6 +5,7 @@ dask>=1.0
 dask-jobqueue>=0.3
 defusedxml
 h5py<3
+libgfortran5
 lxml
 matplotlib
 numpy

--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -15,6 +15,7 @@ dependencies:
   - dask-jobqueue>=0.3
   - defusedxml
   - h5py<3
+  - libgfortran5
   - lxml
   - matplotlib
   - numpy


### PR DESCRIPTION
**Description of proposed changes**

Need to update dependencies to install libgfortran5 to support pysolid.
With the default libgfortran4 install, you would encounter the following error:

```
This is a prerequisite for pysolid

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/envs/mintpy/lib/python3.8/site-packages/pysolid/__init__.py", line 1, in <module>
    from .grid import *
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/envs/mintpy/lib/python3.8/site-packages/pysolid/grid.py", line 25, in <module>
    raise ImportError(msg)
ImportError: Cannot import name 'solid' from 'pysolid'!
    Maybe solid.for is NOT compiled yet.
    Check instruction at: https://github.com/insarlab/PySolid.
(mintpy) [ssangha@leffe mintpy_fullvelocity_16looks]$ 
(mintpy) [ssangha@leffe mintpy_fullvelocity_16looks]$ python -c "import pysolid; print(pysolid.__version__)"
Traceback (most recent call last):
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/envs/mintpy/lib/python3.8/site-packages/pysolid/grid.py", line 20, in <module>
    from .solid import solid_grid
ImportError: libgfortran.so.5: cannot open shared object file: No such file or directory
```

**Reminders**

- [x ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
