### PR TITLE
ifgramStack.temporal_average: cast ds_size to int64 to avoid overflow 32-bit OS

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -1032,7 +1032,7 @@ class ifgramStack:
                 ref_val = dset[ifgram_flag, self.refY, self.refX]
 
             # get step size and number
-            ds_size = np.sum(ifgram_flag) * self.length * self.width * 4
+            ds_size = np.sum(ifgram_flag, dtype=np.int64) * self.length * self.width * 4
             num_step = int(np.ceil(ds_size * 3 / (max_memory * 1024**3)))
             row_step = int(np.rint(self.length / num_step / 10) * 10)
             num_step = int(np.ceil(self.length / row_step))


### PR DESCRIPTION
**Description of proposed changes**

Fixes potential overflow error when calculating `ds_size` by explicitly casting it has `np.int64`. `np.sum` can return `np.int32` in some cases. See #536

**Reminders**

- [x] Fix #536 
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)