### PR TITLE
ingest hyp3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 ## MintPy ##
 
-The Miami INsar Time-series software in PYthon (MintPy as /mɪnt paɪ/) is an open-source package for Interferometric Synthetic Aperture Radar (InSAR) time series analysis. It reads the stack of interferograms (coregistered and unwrapped) in [ISCE](https://github.com/isce-framework/isce2), [ARIA](https://github.com/aria-tools/ARIA-tools), [FRInGE](https://github.com/isce-framework/fringe), [SNAP](http://step.esa.int/), [GAMMA](https://www.gamma-rs.ch/no_cache/software.html) or ROI_PAC format, and produces three dimensional (2D in space and 1D in time) ground surface displacement in line-of-sight direction. It includes a routine time series analysis (`smallbaselineApp.py`) and some independent toolbox.
+The Miami INsar Time-series software in PYthon (MintPy as /mɪnt paɪ/) is an open-source package for Interferometric Synthetic Aperture Radar (InSAR) time series analysis. It reads the stack of interferograms (coregistered and unwrapped) in [ISCE](https://github.com/isce-framework/isce2), [ARIA](https://github.com/aria-tools/ARIA-tools), [FRInGE](https://github.com/isce-framework/fringe), [SNAP](http://step.esa.int/), [GAMMA](https://www.gamma-rs.ch/no_cache/software.html), [HyP3](https://hyp3.asf.alaska.edu/) or ROI_PAC format, and produces three dimensional (2D in space and 1D in time) ground surface displacement in line-of-sight direction. It includes a routine time series analysis (`smallbaselineApp.py`) and some independent toolbox.
 
 This package was called PySAR before version 1.1.1. For version 1.1.2 and onward, we use MintPy instead.
 

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -627,9 +627,9 @@ mintpy.load.lookupXFile    = $DATA_DIR/GalapagosAlosAT133/PROCESS/GEO/geo_100610
 3. Paste HyP3 interferogram metadata file (e.g. S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85.txt) into the same directory as your dem and give it the same name as your dem (e.g. dem.txt)
 4. Clip DEM and all interferograms to the same area using the hyp3lib [cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
 
-$DATA_DIR/TongariroSen
+
 ```
-$DATA_DIR/SanFranSenDT42
+$DATA_DIR/TongariroSen
 ├── DEM
 │   ├── ...
 ├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -624,7 +624,8 @@ mintpy.load.lookupXFile    = $DATA_DIR/GalapagosAlosAT133/PROCESS/GEO/geo_100610
 
 1. Request and download GUNW products using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb).
 2. Download the corresponding DEM used in processing using the [hyp3lib](https://github.com/ASFHyP3/hyp3-lib) [getDEMfor.getDemFile](https://github.com/ASFHyP3/hyp3-lib/blob/d108842345ae0c2be8078a9b6cc04bbabe9a4dee/hyp3lib/getDemFor.py#L16) function.
-3. Clip DEM and all interferograms to the same area using the hyp3lib [cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
+3. Paste HyP3 interferogram metadata file (e.g. S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85.txt) into the same directory as your dem and give it the same name as your dem (e.g. dem.txt)
+4. Clip DEM and all interferograms to the same area using the hyp3lib [cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
 
 $DATA_DIR/TongariroSen
 ```
@@ -642,6 +643,7 @@ $DATA_DIR/SanFranSenDT42
 │   ...
 ├── dem.tif
 ├── dem_clip.tif
+├── dem_clip.txt
 └── mosaiced_dem.tif
 ```
 

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -619,3 +619,39 @@ mintpy.load.demFile        = $DATA_DIR/GalapagosAlosAT133/PROCESS/DONE/IFG*10061
 mintpy.load.lookupYFile    = $DATA_DIR/GalapagosAlosAT133/PROCESS/GEO/geo_100610-100910/geomap_*rlks.trans
 mintpy.load.lookupXFile    = $DATA_DIR/GalapagosAlosAT133/PROCESS/GEO/geo_100610-100910/geomap_*rlks.trans
 ```
+
+### HyP3
+
+1. Request and download GUNW products using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb).
+2. Download the corresponding DEM used in processing using the [hyp3lib](https://github.com/ASFHyP3/hyp3-lib) [getDEMfor.getDemFile](https://github.com/ASFHyP3/hyp3-lib/blob/d108842345ae0c2be8078a9b6cc04bbabe9a4dee/hyp3lib/getDemFor.py#L16) function.
+3. Clip DEM and all interferograms to the same area using the hyp3lib [cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
+
+$DATA_DIR/TongariroSen
+```
+$DATA_DIR/SanFranSenDT42
+├── DEM
+│   ├── ...
+├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85
+│   ├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85_unw_phase.tif
+│   ├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85_unw_phase_clip.tif
+│   ├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85_corr.tif
+│   ├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85_corr_clip.tif
+│   ├── S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85.txt
+│   ├── ...
+│─── S1BB_20170428T070618_20170522T070619_VVP024_INT80_G_ueF_0CE0
+│   ...
+├── dem.tif
+├── dem_clip.tif
+└── mosaiced_dem.tif
+```
+
+The corresponding template options for `load_data`:
+
+```cfg
+mintpy.load.processor        = hyp3
+##---------interferogram datasets:
+mintpy.load.unwFile          = $DATA_DIR/tongariroSen/*/*unw_phase_clip.tif
+mintpy.load.corFile          = $DATA_DIR/tongariroSen/*/*corr_clip.tif
+##---------geometry datasets:
+mintpy.load.demFile          = $DATA_DIR/tongariroSen/dem_clip.tif
+```

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -620,10 +620,10 @@ mintpy.load.lookupYFile    = $DATA_DIR/GalapagosAlosAT133/PROCESS/GEO/geo_100610
 mintpy.load.lookupXFile    = $DATA_DIR/GalapagosAlosAT133/PROCESS/GEO/geo_100610-100910/geomap_*rlks.trans
 ```
 
-### HyP3
+### [ASF HyP3](https://hyp3.asf.alaska.edu/)
 
 1. Request and download GUNW products using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb).
-2. Download the corresponding DEM used in processing using the [hyp3lib](https://github.com/ASFHyP3/hyp3-lib) [getDEMfor.getDemFile](https://github.com/ASFHyP3/hyp3-lib/blob/d108842345ae0c2be8078a9b6cc04bbabe9a4dee/hyp3lib/getDemFor.py#L16) function.
+2. Download the corresponding DEM used in processing using the [hyp3lib](https://github.com/ASFHyP3/hyp3-lib) [getDEMfor.getDemFile()](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/getDemFor.py#L16) function.
 3. Paste HyP3 interferogram metadata file (e.g. S1BB_20170510T070618_20170522T070619_VVP012_INT80_G_ueF_FF85.txt) into the same directory as your dem and give it the same name as your dem (e.g. dem.txt)
 4. Clip DEM and all interferograms to the same area using the hyp3lib [cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
 
@@ -652,8 +652,8 @@ The corresponding template options for `load_data`:
 ```cfg
 mintpy.load.processor        = hyp3
 ##---------interferogram datasets:
-mintpy.load.unwFile          = $DATA_DIR/tongariroSen/*/*unw_phase_clip.tif
-mintpy.load.corFile          = $DATA_DIR/tongariroSen/*/*corr_clip.tif
+mintpy.load.unwFile          = $DATA_DIR/TongariroSen/*/*unw_phase_clip.tif
+mintpy.load.corFile          = $DATA_DIR/TongariroSen/*/*corr_clip.tif
 ##---------geometry datasets:
-mintpy.load.demFile          = $DATA_DIR/tongariroSen/dem_clip.tif
+mintpy.load.demFile          = $DATA_DIR/TongariroSen/dem_clip.tif
 ```

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -25,7 +25,7 @@ mintpy.compute.config    = auto #[none / slurm / pbs / lsf ], auto for none (sam
 ## no   - save   0% disk usage, fast [default]
 ## lzf  - save ~57% disk usage, relative slow
 ## gzip - save ~62% disk usage, very slow [not recommend]
-mintpy.load.processor      = auto  #[isce, aria, snap, gamma, roipac], auto for isce
+mintpy.load.processor      = auto  #[isce, aria, snap, gamma, roipac, hyp3], auto for isce
 mintpy.load.autoPath       = auto  #[yes / no], auto for no, use pre-defined auto path
 mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
 mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -469,15 +469,18 @@ def read_inps_dict2ifgram_stack_dict_object(iDict):
 
 def read_inps_dict2geometry_dict_object(iDict):
 
-    # eliminate dsName by processor
+    # eliminate lookup table dsName for input files in radar-coordinates
     if iDict['processor'] in ['isce', 'doris']:
+        # for processors with lookup table in radar-coordinates, remove azimuth/rangeCoord
         iDict['ds_name2key'].pop('azimuthCoord')
         iDict['ds_name2key'].pop('rangeCoord')
     elif iDict['processor'] in ['roipac', 'gamma']:
+        # for processors with lookup table in geo-coordinates, remove latitude/longitude
         iDict['ds_name2key'].pop('latitude')
         iDict['ds_name2key'].pop('longitude')
-    elif iDict['processor'] in ['snap']:
-        #check again when there is a SNAP product in radar coordiantes
+    elif iDict['processor'] in ['snap', 'aria', 'hyp3']:
+        # for processors with geocoded products support only, do nothing for now.
+        # check again when adding products support in radar-coordiantes
         pass
     else:
         print('Un-recognized InSAR processor: {}'.format(iDict['processor']))

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -27,7 +27,7 @@ from mintpy import subset
 
 
 #################################################################
-PROCESSOR_LIST = ['isce', 'aria', 'snap', 'gamma', 'roipac']
+PROCESSOR_LIST = ['isce', 'aria', 'snap', 'gamma', 'roipac', 'hyp3']
 
 datasetName2templateKey = {
     'unwrapPhase'     : 'mintpy.load.unwFile',
@@ -594,10 +594,12 @@ def prepare_metadata(iDict):
     print('-'*50)
     print('prepare metadata files for {} products'.format(processor))
 
-    if processor in ['gamma', 'roipac', 'snap']:
+    if processor in ['gamma', 'hyp3', 'roipac', 'snap']:
         # import prep_module
         if processor == 'gamma':
             from mintpy import prep_gamma as prep_module
+        elif processor == 'hyp3':
+            from mintpy import prep_hyp3 as prep_module
         elif processor == 'roipac':
             from mintpy import prep_roipac as prep_module
         elif processor == 'snap':

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -356,17 +356,20 @@ def extract_metadata(stack):
     meta['NCORRLOOKS'] = meta['RLOOKS'] * meta['ALOOKS'] / (rgfact * azfact)
 
     # geo transformation
-    geoTrans = ds.GetGeoTransform()
-    lon0 = geoTrans[0]
-    lat0 = geoTrans[3]
-    lon_step = geoTrans[1]
-    lat_step = geoTrans[5]
-    lon1 = lon0 + lon_step * meta["WIDTH"]
-    lat1 = lat0 + lat_step * meta["LENGTH"]
-    meta["X_FIRST"] = '{:.9f}'.format(lon0)
-    meta["Y_FIRST"] = '{:.9f}'.format(lat0)
-    meta["X_STEP"] = '{:.9f}'.format(lon_step)
-    meta["Y_STEP"] = '{:.9f}'.format(lat_step)
+    transform = ds.GetGeoTransform()
+
+    x_step = abs(transform[1])
+    y_step = abs(transform[5]) * -1.
+
+    W = transform[0] - x_step / 2.
+    N = transform[3] - y_step / 2.
+    E = W + x_step * ds.RasterXSize
+    S = N + y_step * ds.RasterYSize
+
+    meta["X_FIRST"] = '{:.9f}'.format(transform[0])
+    meta["Y_FIRST"] = '{:.9f}'.format(transform[3])
+    meta["X_STEP"] = '{:.9f}'.format(x_step)
+    meta["Y_STEP"] = '{:.9f}'.format(y_step)
     meta["X_UNIT"] = "degrees"
     meta["Y_UNIT"] = "degrees"
 
@@ -380,15 +383,24 @@ def extract_metadata(stack):
     # nominal altitude of Sentinel1 orbit
     meta["HEIGHT"] = 693000.0
 
-    meta["LON_REF1"] = lon0
-    meta["LON_REF2"] = lon1
-    meta["LON_REF3"] = lon0
-    meta["LON_REF4"] = lon1
-
-    meta["LAT_REF1"] = lat0
-    meta["LAT_REF2"] = lat0
-    meta["LAT_REF3"] = lat1
-    meta["LAT_REF4"] = lat1
+    if meta["ORBIT_DIRECTION"].startswith("asc"):
+        meta["LAT_REF1"] = str(S)
+        meta["LAT_REF2"] = str(S)
+        meta["LAT_REF3"] = str(N)
+        meta["LAT_REF4"] = str(N)
+        meta["LON_REF1"] = str(W)
+        meta["LON_REF2"] = str(E)
+        meta["LON_REF3"] = str(W)
+        meta["LON_REF4"] = str(E)
+    else:
+        meta["LAT_REF1"] = str(N)
+        meta["LAT_REF2"] = str(N)
+        meta["LAT_REF3"] = str(S)
+        meta["LAT_REF4"] = str(S)
+        meta["LON_REF1"] = str(E)
+        meta["LON_REF2"] = str(W)
+        meta["LON_REF3"] = str(E)
+        meta["LON_REF4"] = str(W)
 
     ds = None
     return meta

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -366,8 +366,8 @@ def extract_metadata(stack):
     E = W + x_step * ds.RasterXSize
     S = N + y_step * ds.RasterYSize
 
-    meta["X_FIRST"] = '{:.9f}'.format(transform[0])
-    meta["Y_FIRST"] = '{:.9f}'.format(transform[3])
+    meta["X_FIRST"] = '{:.9f}'.format(W)
+    meta["Y_FIRST"] = '{:.9f}'.format(N)
     meta["X_STEP"] = '{:.9f}'.format(x_step)
     meta["Y_STEP"] = '{:.9f}'.format(y_step)
     meta["X_UNIT"] = "degrees"
@@ -383,7 +383,7 @@ def extract_metadata(stack):
     # nominal altitude of Sentinel1 orbit
     meta["HEIGHT"] = 693000.0
 
-    if meta["ORBIT_DIRECTION"].startswith("asc"):
+    if meta["ORBIT_DIRECTION"].startswith("ASC"):
         meta["LAT_REF1"] = str(S)
         meta["LAT_REF2"] = str(S)
         meta["LAT_REF3"] = str(N)

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -2,14 +2,20 @@
 ############################################################
 # Program is part of MintPy                                #
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
-# Author: Forrest Williams                                 #
+# Author: Forrest Williams, Mar 2021                       #
 ############################################################
+
 
 import os
 import sys
 import argparse
 from datetime import datetime
-from osgeo import gdal
+
+try:
+    from osgeo import gdal
+except ImportError:
+    raise ImportError('Can not import gdal!')
+
 from mintpy.objects import sensor
 from mintpy.utils import writefile, utils as ut
 

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -148,7 +148,7 @@ def general_metadata(fname):
 
     # Earth radius probably won't be used anywhere for the geocoded data
     meta['EARTH_RADIUS'] = 6337286.638938101
-    
+
     return(meta)
 
 
@@ -171,14 +171,14 @@ def add_ifg_metadata(fname,meta):
     date1 = datetime.strptime(date1_string,'%Y%m%dT%H%M%S')
     date2 = datetime.strptime(date2_string,'%Y%m%dT%H%M%S')
     date_avg = date1 + (date2 - date1) / 2
-    
+
     ifg_meta_file = f'{os.path.join(directory,job_id)}.txt'
     ifg_meta = {}
     with open(ifg_meta_file, 'r') as f:
         for line in f:
             key, value = line.strip().split(': ')
             ifg_meta[key] = value
-    
+
     # Add relevant data to meta object
     meta['CENTER_LINE_UTC'] = date_avg.strftime('%y%m%d')
     meta['DATE12'] = f'{date1.strftime("%y%m%d")}-{date2.strftime("%y%m%d")}'

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+############################################################
+# Program is part of MintPy                                #
+# Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
+# Author: Forrest Williams                                 #
+############################################################
+
+import os
+import sys
+# import re
+import argparse
+# import numpy as np
+from datetime import datetime
+from osgeo import gdal
+from mintpy.objects import sensor
+from mintpy.utils import writefile, utils as ut #readfile, writefile, ptime,
+
+
+SPEED_OF_LIGHT = 299792458  # m/s
+
+EXAMPLE = """example:
+  prep_hyp3.py  interferograms/*/*unw_phase.tif
+  prep_hyp3.py  interferograms/*/*corr.tif
+  prep_hyp3.py  interferograms/*/*unw_phase_clip.tif
+  prep_hyp3.py  interferograms/*/*corr_clip.tif
+  prep_hyp3.py  interferograms/*/*clip.tif
+  prep_hyp3.py  dem.tif
+  prep_hyp3.py  dem_clip.tif
+"""
+
+DESCRIPTION = """
+  For each interferogram, the unwrapped interferogram, coherence, and metadata the file name is required e.g.:
+  1) S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif
+  2) S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_corr.tif
+  3) S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2.txt
+
+  A DEM is also needed e.g.:
+  1) dem.tif
+
+  This script will read these files, read the geospatial metadata from GDAL,
+  find the corresponding HyP3 metadata file (for interferograms and coherence),
+  and write to a ROI_PAC .rsc metadata file with the same name as the input file with suffix .rsc,
+  e.g. S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif.rsc
+
+  Here is an example of how your HyP3 files should look:
+
+  Before loading:
+      For each interferogram, 3 files are needed:
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_corr.tif
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2.txt
+      For the geometry file 1 file is needed:
+          dem.tif (a DEM with any name)
+
+  After running prep_hyp3.py:
+      For each interferogram:
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif.rsc
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_corr.tif
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_corr.tif.rsc
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2.txt
+      For the input DEM geometry file:
+          dem.tif
+          dem.tif.rsc
+
+  Notes:
+    HyP3 currently only supports generation of Sentinel-1 interferograms, so
+    some Sentinel-1 metadata is hard-coded. If HyP3 adds processing of interferograms
+    from other satellites, changes will be needed. 
+"""
+
+#########################################################################
+
+# CMD parsing
+def create_parser():
+    parser = argparse.ArgumentParser(description='Prepare attributes file for HyP3 InSAR product.\n'+
+                                     DESCRIPTION,
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     epilog=EXAMPLE)
+
+    parser.add_argument('file', nargs='+', help='HyP3 file(s)')
+    return parser
+
+
+def cmd_line_parse(iargs=None):
+    parser = create_parser()
+    inps = parser.parse_args(args=iargs)
+    inps.file = ut.get_file_list(inps.file, abspath=True)
+    return inps
+
+
+#########################################################################
+
+# Extract geospatial and sensor metadata
+def general_metadata(fname):
+    '''Read/extract attribute data from HyP3 gdal geotiff metadata file and add to metadata dictionary
+    Inputs:
+        *unw_phase.tif or *corr.tif file name or *dem.tif file name, e.g.
+            S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif
+            S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_corr.tif
+            dem.tif
+    Output:
+        Metadata dictionary (meta)
+    '''
+
+    meta = {}
+
+    # Geospatial Data
+    ds = gdal.Open(fname, gdal.GA_ReadOnly)
+    meta['FILE_LENGTH'] = ds.RasterYSize
+    meta['LENGTH'] = ds.RasterYSize
+    meta['WIDTH'] = ds.RasterXSize
+    geoTrans = ds.GetGeoTransform()
+    del ds
+
+    x0 = geoTrans[0]
+    y0 = geoTrans[3]
+    x_step = geoTrans[1]
+    y_step = geoTrans[5]
+    x1 = x0 + x_step * meta['WIDTH']
+    y1 = y0 + y_step * meta['LENGTH']
+
+    meta['X_FIRST'] = f'{x0:.9f}'
+    meta['Y_FIRST'] = f'{y0:.9f}'
+    meta['X_STEP'] = f'{x_step:.9f}'
+    meta['Y_STEP'] = f'{y_step:.9f}'
+    meta['X_UNIT'] = 'METERS'
+    meta['Y_UNIT'] = 'METERS'
+
+    meta["LON_REF1"] = x0
+    meta["LON_REF2"] = x1
+    meta["LON_REF3"] = x0
+    meta["LON_REF4"] = x1
+
+    meta["LAT_REF1"] = y0
+    meta["LAT_REF2"] = y0
+    meta["LAT_REF3"] = y1
+    meta["LAT_REF4"] = y1
+
+    # Satellite platform data
+    #   Note: HyP3 currently only supports Sentinel-1 data, so Sentinel-1
+    #         configuration is hard-coded.
+    meta['PROCESSOR'] = 'hyp3'
+    meta['PLATFORM'] = 'Sen'
+    meta['ANTENNA_SIDE'] = -1
+    meta['WAVELENGTH'] = SPEED_OF_LIGHT / sensor.SEN['carrier_frequency']
+    meta['HEIGHT'] = 693000.0 # nominal altitude of Sentinel1 orbit
+
+    # Earth radius probably won't be used anywhere for the geocoded data
+    meta['EARTH_RADIUS'] = 6337286.638938101
+    
+    return(meta)
+
+
+# Extract data from HyP3 interferogram metadata
+def add_ifg_metadata(fname,meta):
+    '''Read/extract attribute data from HyP3 metadata file and add to metadata dictionary
+    Inputs:
+        *unw_phase.tif or *corr.tif file name, e.g.
+            S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_unw_phase.tif
+            S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_corr.tif
+        Metadata dictionary (meta)
+    Output:
+        Metadata dictionary (meta)
+    '''
+    directory = os.path.dirname(fname)
+
+    sat, date1_string, date2_string, pol, res, soft, proc, ids, *_ = os.path.basename(fname).split('_')
+    
+    job_id = '_'.join([sat, date1_string, date2_string, pol, res, soft, proc, ids])
+    date1 = datetime.strptime(date1_string,'%Y%m%dT%H%M%S')
+    date2 = datetime.strptime(date2_string,'%Y%m%dT%H%M%S')
+    date_avg = date1 + (date2 - date1) / 2
+    
+    ifg_meta_file = f'{os.path.join(directory,job_id)}.txt'
+    ifg_meta = {}
+    with open(ifg_meta_file, 'r') as f:
+        for line in f:
+            key, value = line.strip().split(': ')
+            ifg_meta[key] = value
+    
+    # Add relevant data to meta object
+    meta['CENTER_LINE_UTC'] = date_avg.strftime('%y%m%d')
+    meta['DATE12'] = f'{date1.strftime("%y%m%d")}-{date2.strftime("%y%m%d")}'
+    meta['HEADING'] = ifg_meta['Heading']
+    meta['ORBIT_DIRECTION'] = 'ASCENDING' if float(meta['HEADING']) > -90 else 'DESCENDING'
+    meta['ALOOKS'] = ifg_meta['Azimuth looks']
+    meta['RLOOKS'] = ifg_meta['Range looks']
+    meta['P_BASELINE_TOP_HDR'] = ifg_meta['Baseline']
+    meta['P_BASELINE_BOTTOM_HDR'] = ifg_meta['Baseline']
+
+    return(meta)
+
+
+#########################################################################
+
+def main(iargs=None):
+    # read in arguments
+    inps = cmd_line_parse(iargs)
+
+    # for each filename, generate metadata rsc file
+    for fname in inps.file:
+        meta = general_metadata(fname)
+
+        # add interferogram-specific metadata
+        if any([x in fname for x in ['unw_phase','corr']]):
+            meta = add_ifg_metadata(fname, meta)
+        
+        rsc_file = fname+'.rsc'
+        writefile.write_roipac_rsc(meta, out_file=rsc_file)
+
+    return
+
+
+###################################################################################################
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -239,7 +239,7 @@ def add_sentinel1_metadata(meta):
         meta['LON_REF2'] = str(meta['WEST'])
         meta['LON_REF3'] = str(meta['EAST'])
         meta['LON_REF4'] = str(meta['WEST'])
-    
+
     del meta['NORTH'], meta['SOUTH'], meta['EAST'], meta['WEST']
 
     return(meta)

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -7,13 +7,11 @@
 
 import os
 import sys
-# import re
 import argparse
-# import numpy as np
 from datetime import datetime
 from osgeo import gdal
 from mintpy.objects import sensor
-from mintpy.utils import writefile, utils as ut #readfile, writefile, ptime,
+from mintpy.utils import writefile, utils as ut
 
 
 SPEED_OF_LIGHT = 299792458  # m/s
@@ -166,7 +164,7 @@ def add_ifg_metadata(fname,meta):
     directory = os.path.dirname(fname)
 
     sat, date1_string, date2_string, pol, res, soft, proc, ids, *_ = os.path.basename(fname).split('_')
-    
+
     job_id = '_'.join([sat, date1_string, date2_string, pol, res, soft, proc, ids])
     date1 = datetime.strptime(date1_string,'%Y%m%dT%H%M%S')
     date2 = datetime.strptime(date2_string,'%Y%m%dT%H%M%S')
@@ -205,7 +203,7 @@ def main(iargs=None):
         # add interferogram-specific metadata
         if any([x in fname for x in ['unw_phase','corr']]):
             meta = add_ifg_metadata(fname, meta)
-        
+
         rsc_file = fname+'.rsc'
         writefile.write_roipac_rsc(meta, out_file=rsc_file)
 

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -139,6 +139,8 @@ def add_geospatial_metadata(fname, meta):
     # Earth radius probably won't be used anywhere for the geocoded data
     meta['EARTH_RADIUS'] = 6337286.638938101
 
+    del ds
+
     return(meta)
 
 # extract data from HyP3 interferogram metadata

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -129,12 +129,12 @@ def add_geospatial_metadata(fname, meta):
     meta['EAST'] = E
     meta['WEST'] = W
 
-    meta['X_FIRST'] = transform[0]
-    meta['Y_FIRST'] = transform[3]
+    meta['X_FIRST'] = W
+    meta['Y_FIRST'] = N
     meta['X_STEP'] = x_step
     meta['Y_STEP'] = y_step
-    meta['X_UNIT'] = 'METERS'
-    meta['Y_UNIT'] = 'METERS'
+    meta['X_UNIT'] = 'meters'
+    meta['Y_UNIT'] = 'meters'
 
     # Earth radius probably won't be used anywhere for the geocoded data
     meta['EARTH_RADIUS'] = 6337286.638938101

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -500,15 +500,15 @@ def read_binary_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
         if 'byte order' in atr.keys() and atr['byte order'] == '0':
             byte_order = 'little-endian'
 
-    # gdal (e.g. GACOS TIF files)
-    elif processor == 'gdal':
+    # gdal (e.g. GACOS TIF files or HyP3 TIF files)
+    elif processor in ['gdal','hyp3']:
         pass
 
     else:
         print('Unknown InSAR processor: {}'.format(processor))
 
     # reading
-    if processor == 'gdal':
+    if processor in ['gdal','hyp3']:
         data = read_gdal(
             fname,
             box=box,


### PR DESCRIPTION
**Description of proposed changes**

The ASF HyP3 on-demand InSAR service is a great option for creating interferograms, but MintPy is not currently set up to ingest these products. This pull request creates a prep_hyp3.py workflow that would allow for the ingestion of these products.

**Changes**
- Creates prep_hyp3.py for the creation of rsc metadata files for HyP3 products
- Adds hyp3 to load_data.py processor list, and sets up reference to prep_hyp3 when hyp3 is the processor.
- Has readfile.read process HyP3 products as GDAL tifs

Resolves Issue: #540 