### PR TITLE
save_gbis: maskout pixels w zero phase value

### DIFF
--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -218,12 +218,16 @@ def save2mat(inps):
     mdict['Mask'] = inps.mask
     mdict['Metadata'] = inps.metadata
     mdict['Phase'][mdict['Phase']==0] = np.nan
+    placeholderRef = np.where((mdict['Lat'] == inps.metadata['REF_LAT']) & (mdict['Lon']==inps.metadata['REF_LON']))
+    mdict['Phase'][placeholderRef] = 0
     dataList = ['Lon', 'Lat', 'Inc', 'Heading','Height','Phase']
     for listFile in dataList:
         mdict[listFile] = mdict[listFile][~np.isnan(mdict['Phase'])].reshape(-1,1)
+    print('remaining pixels are {}' .format(mdict['Phase'].size))
     # save to mat file
     sio.savemat(inps.outfile, mdict, long_field_names=True)
     print('save to file: {}'.format(os.path.abspath(inps.outfile)))
+    
     return
 
 

--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -227,7 +227,6 @@ def save2mat(inps):
     # save to mat file
     sio.savemat(inps.outfile, mdict, long_field_names=True)
     print('save to file: {}'.format(os.path.abspath(inps.outfile)))
-    
     return
 
 

--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -217,6 +217,10 @@ def save2mat(inps):
     mdict['Height'] = inps.height[inps.mask].reshape(-1,1)
     mdict['Mask'] = inps.mask
     mdict['Metadata'] = inps.metadata
+    mdict['Phase'][mdict['Phase']==0] = np.nan
+    dataList = ['Lon', 'Lat', 'Inc', 'Heading','Height','Phase']
+    for listFile in dataList:
+        mdict[listFile] = mdict[listFile][~np.isnan(mdict['Phase'])].reshape(-1,1)
     # save to mat file
     sio.savemat(inps.outfile, mdict, long_field_names=True)
     print('save to file: {}'.format(os.path.abspath(inps.outfile)))

--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -103,8 +103,6 @@ def read_data(inps):
 
         # update mask to exclude pixel with NaN value
         inps.mask *= ~np.isnan(inps.phase)
-        # set all masked out pixel to NaN
-        inps.phase[inps.mask==0] = np.nan
     else:
         raise ValueError("input file not support yet: {}".format(k))
     print('number of pixels: {}'.format(np.sum(inps.mask)))
@@ -121,6 +119,13 @@ def read_data(inps):
         inps.metadata['REF_LON'] = ref_lon
         inps.metadata['REF_Y'] = ref_y
         inps.metadata['REF_X'] = ref_x
+
+    # mask out pixels with zero phase value
+    ref_y = int(inps.metadata['REF_Y'])
+    ref_x = int(inps.metadata['REF_X'])
+    inps.mask *= inps.phase != 0
+    inps.mask[ref_y, ref_x] = 1
+    print('number of pixels after excluding zero phase value: {}'.format(np.sum(inps.mask)))
 
     # read geometry
     inps.lat, inps.lon = ut.get_lat_lon(inps.metadata)
@@ -148,6 +153,8 @@ def read_data(inps):
         msg += '\n\tby subtracting a constant offset of {:.2f} m'.format(h_offset)
         print(msg)
 
+    # masking
+    inps.phase[inps.mask==0] = np.nan
     inps.lat[inps.mask==0] = np.nan
     inps.lon[inps.mask==0] = np.nan
     inps.inc_angle[inps.mask==0] = np.nan
@@ -176,7 +183,7 @@ def plot_data(inps):
     defo = inps.phase / inps.range2phase * 100. #convert to deformation in cm
     dmin, dmax = np.nanmin(defo), np.nanmax(defo)
     dlim = max(abs(dmin), abs(dmax))
-    im = axs[0].imshow(defo, vmin=-dlim, vmax=dlim, cmap='jet');
+    im = axs[0].imshow(defo, vmin=-dlim, vmax=dlim, cmap='jet', interpolation='nearest')
     # reference point
     axs[0].plot(int(inps.metadata['REF_X']),
                 int(inps.metadata['REF_Y']), 'ks', ms=6)
@@ -189,7 +196,7 @@ def plot_data(inps):
     for ax, data, title in zip(axs[1:],
                                [inps.lat, inps.lon, inps.inc_angle, inps.head_angle, inps.height],
                                ['Latitude', 'Longitude', 'Incidence Angle', 'Head Angle', 'Height']):
-        im = ax.imshow(data, cmap='jet')
+        im = ax.imshow(data, cmap='jet', interpolation='nearest')
         ax.set_title(title)
         cbar = fig.colorbar(im, ax=ax)
         if title == 'Height':
@@ -217,13 +224,6 @@ def save2mat(inps):
     mdict['Height'] = inps.height[inps.mask].reshape(-1,1)
     mdict['Mask'] = inps.mask
     mdict['Metadata'] = inps.metadata
-    mdict['Phase'][mdict['Phase']==0] = np.nan
-    placeholderRef = np.where((mdict['Lat'] == inps.metadata['REF_LAT']) & (mdict['Lon']==inps.metadata['REF_LON']))
-    mdict['Phase'][placeholderRef] = 0
-    dataList = ['Lon', 'Lat', 'Inc', 'Heading','Height','Phase']
-    for listFile in dataList:
-        mdict[listFile] = mdict[listFile][~np.isnan(mdict['Phase'])].reshape(-1,1)
-    print('remaining pixels are {}' .format(mdict['Phase'].size))
     # save to mat file
     sio.savemat(inps.outfile, mdict, long_field_names=True)
     print('save to file: {}'.format(os.path.abspath(inps.outfile)))


### PR DESCRIPTION
My officemate noticed that the output using save_gbis.py contains 0 values in waterbody areas and areas masked out using the connected component file from the geo_velocity.h5 file. GBIS requires 0 and NaN values be removed on the .mat file before doing the inversion.

The top figure shows the 0 values (waterbody) indicated as red areas while the bottom figure shows the removal of the 0 values after applying the modification on the save_gbis.py.

![with_0](https://user-images.githubusercontent.com/21336508/112748444-2fb03e80-8fee-11eb-9e89-036b71438d54.jpg)

![without_0](https://user-images.githubusercontent.com/21336508/112748449-39d23d00-8fee-11eb-90e2-4c6d0b5df051.jpg)


*Added lines of code to remove 0 and NaN values prior to exporting to the .mat file.


**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.