### PR TITLE
spatial_filter: allow for filtering of specific datasets

### DIFF
--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -143,9 +143,10 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
     maxDigit = max([len(i) for i in ds_names])
     dsDict = dict()
     for ds_name in ds_names:
+        msg = 'filtering {d:<{w}} from {f} '.format(d=ds_name, w=maxDigit, f=os.path.basename(fname))
+        # read
         data = readfile.read(fname, datasetName=ds_name, print_msg=False)[0]
-        msg = 'filtering {d:<{w}} from {f} '.format(
-            d=ds_name, w=maxDigit, f=os.path.basename(fname))
+        # filter
         if len(data.shape) == 3:
             num_loop = data.shape[0]
             for i in range(num_loop):
@@ -155,6 +156,7 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
             print('')
         else:
             data = filter_data(data, filter_type, filter_par)
+        # write
         dsDict[ds_name] = data
     writefile.write(dsDict, out_file=fname_out, metadata=atr, ref_file=fname)
     return fname_out


### PR DESCRIPTION
If filtering interferograms prior to inversion, it is
often desireable to filter only the unwrapPhase dataset
and not the coherence dataset. These changes to
spatial_filter.py enable this functionality. Changes the
command-line interface slightly, which may break older
workflows that use spatial_filter.py.

**Description of proposed changes**
- added functionality that will allow you to specify dataset names when using spatial_filter.py
- updated spatial_filter.py help documentation
- changed the command-line interface slightly, which may break older workflows that use spatial_filter.py

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
