### PR TITLE
spatial_filter: add double difference filter option

### DIFF
--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -184,7 +184,7 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
     ds_all = readfile.get_dataset_list(fname)
     if not ds_names:
         ds_names = ds_all
-    ds_skips = set(ds_all)-set(ds_names)
+    ds_skips = list(set(ds_all) - set(ds_names))
 
     maxDigit = max([len(i) for i in ds_names])
     dsDict = dict()

--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -162,10 +162,17 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
                                      os.path.splitext(fname)[1])
 
     # filtering file
+    ds_all = readfile.get_dataset_list(fname)
     if not ds_names:
-        ds_names = readfile.get_dataset_list(fname)
+        ds_names = ds_all
+    ds_skips = set(ds_all)-set(ds_names)
+
     maxDigit = max([len(i) for i in ds_names])
     dsDict = dict()
+
+    for ds_name in ds_skips:
+        dsDict[ds_name] = readfile.read(fname, datasetName=ds_name, print_msg=False)[0]
+
     for ds_name in ds_names:
         msg = 'filtering {d:<{w}} from {f} '.format(d=ds_name, w=maxDigit, f=os.path.basename(fname))
         # read

--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
 # Author: Heresh Fattahi, Zhang Yunjun, 2013               #
 ############################################################
+# Add "double_difference" filter, Forrest Williams, May 2021
 
 
 import os
@@ -47,18 +48,19 @@ def create_parser():
     parser.add_argument('file', help='File to be filtered')
     parser.add_argument('dset', type=str, nargs='*', default=[],
                         help='optional - dataset(s) to filter (default: %(default)s).')
-    parser.add_argument('-f', '--filter_type', dest='filter_type', nargs='?', default='lowpass_gaussian',
+    parser.add_argument('-f', dest='filter_type', default='lowpass_gaussian',
                         choices=['lowpass_gaussian', 'highpass_gaussian',
                                  'lowpass_avg', 'highpass_avg',
                                  'sobel', 'roberts', 'canny', 'double_difference'],
-                        help='Type of filter. Default: lowpass_gaussian.\n' +
-                             'For more filters, check the link below:\n' +
-                             'http://scikit-image.org/docs/dev/api/skimage.filters.html')
+                        help='Filter type (default: %(default)s).\n' +
+                             'Check Bekaert et al. (2020) for double_difference;\n' +
+                             'Check scikit-image as below for the other filters:\n' +
+                             '    http://scikit-image.org/docs/dev/api/skimage.filters.html')
     parser.add_argument('-p', '--filter_par', dest='filter_par', nargs='*', type=float,
-                        help='Filter parameters for filters. Default=\n' +
-                             'Sigma       for low/high pass gaussian filter, default: 3.0\n' +
-                             'Kernel Size for low/high pass average filter, default: 5\n' +
-                             'Kernel Radius for double difference local and regional filters, default: 1 10\n')
+                        help='Filter parameters for filters. Default:\n' +
+                             '    Sigma         for low/high pass gaussian filter, default: 3.0\n' +
+                             '    Kernel Size   for low/high pass average  filter, default: 5\n' +
+                             '    Kernel Radius for double difference local and regional filters, default: 1 10\n')
     parser.add_argument('-o', '--outfile',default=None, help='Output file name.')
     return parser
 


### PR DESCRIPTION
The double difference filter as used in Bekaert et al 2020 has been shown to effectively filter out non-local modes of deformation. This particularly when using MintPy to monitor local forms of deformation, such as landslides. This commit implements the double difference filter in spatial_filter.py and reformats the filter_par parameter so that it accepts multiple arguments. Also fixes bug that caused ONLY the datasets specified to be written to the output file when inputs datasets are specified.

**Reminders**
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
