### PR TITLE
insar_vs_gps: set insar time to zero

### DIFF
--- a/mintpy/objects/insar_vs_gps.py
+++ b/mintpy/objects/insar_vs_gps.py
@@ -142,7 +142,9 @@ class insar_vs_gps:
         ts_obj.open(print_msg=False)
         self.metadata = dict(ts_obj.metadata)
         self.num_date = ts_obj.numDate
-        self.insar_datetime = ts_obj.times
+        # remove time info from insar_datetime to be consistent with gps_datetime
+        self.insar_datetime = np.array([i.replace(hour=0, minute=0, second=0, microsecond=0)
+                                        for i in ts_obj.times])
 
         # default start/end
         if self.start_date is None:


### PR DESCRIPTION
**Description of proposed changes**

+ `insar_vs_gps`: set insar time to zero to be consistent with the GPS datetime, as suggested by @alevasca.  Closes https://github.com/insarlab/MintPy/issues/553.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.