### PR TITLE
stackDict.py, readfile.py: follow-up edit of passing geom from tmpl

### DIFF
--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -368,15 +368,21 @@ class geometryDict:
             return None
 
         if 'Y_FIRST' in self.extraMetadata.keys():
-            # for dataset in geo-coordinates, use contant value from SLANT_RANGE_DISTANCE.
+            # for dataset in geo-coordinates, use:
+            # 1) incidenceAngle matrix if available OR
+            # 2) contant value from SLANT_RANGE_DISTANCE.
+            ds_name = 'incidenceAngle'
             key = 'SLANT_RANGE_DISTANCE'
-            print('geocoded input, use contant value from metadata {}'.format(key))
-            if key in self.extraMetadata.keys():
+            if ds_name in self.dsNames:
+                print('geocoded input, use incidenceAngle from file {}'.format(self.datasetDict[ds_name]))
+                inc_angle = self.read(family=ds_name)[0].astype(np.float32)
+                data = ut.incidence_angle2slant_range_distance(self.extraMetadata, inc_angle)
+            elif key in self.extraMetadata.keys():            
+                print('geocoded input, use contant value from metadata {}'.format(key))
                 length = int(self.extraMetadata['LENGTH'])
                 width = int(self.extraMetadata['WIDTH'])
                 range_dist = float(self.extraMetadata[key])
                 data = np.ones((length, width), dtype=np.float32) * range_dist
-
             else:
                 return None
 

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -377,7 +377,7 @@ class geometryDict:
                 print('geocoded input, use incidenceAngle from file {}'.format(self.datasetDict[ds_name]))
                 inc_angle = self.read(family=ds_name)[0].astype(np.float32)
                 data = ut.incidence_angle2slant_range_distance(self.extraMetadata, inc_angle)
-            elif key in self.extraMetadata.keys():            
+            elif key in self.extraMetadata.keys():
                 print('geocoded input, use contant value from metadata {}'.format(key))
                 length = int(self.extraMetadata['LENGTH'])
                 width = int(self.extraMetadata['WIDTH'])

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -824,9 +824,12 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             fname + '.aux.xml',
         ]
         metafiles = [i for i in metafiles if os.path.isfile(i)]
-        # force to use the specified metadata file
+
+        # use metadata files with the specified extension if requested
         if metafile_ext:
-            metafiles = [i for i in metafiles if i.endswith(metafile_ext)]        
+            metafiles = [i for i in metafiles if i.endswith(metafile_ext)]
+
+        # use the GDAL supported data file is no metadata file found
         if len(metafiles) == 0:
             # for .tif/.grd files, extract metadata from the file itself
             if fext in GDAL_FILE_EXTS:

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -403,7 +403,7 @@ def read_binary_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
         elif k in ['slc']:
             cpx_band = 'magnitude'
 
-        elif k in ['los'] and datasetName and datasetName.startswith(('band2','az','head')):
+        elif k.startswith('los') and datasetName and datasetName.startswith(('band2','az','head')):
             band = min(2, num_band)
 
         elif k in ['incLocal']:
@@ -824,6 +824,9 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             fname + '.aux.xml',
         ]
         metafiles = [i for i in metafiles if os.path.isfile(i)]
+        # force to use the specified metadata file
+        if metafile_ext:
+            metafiles = [i for i in metafiles if i.endswith(metafile_ext)]        
         if len(metafiles) == 0:
             # for .tif/.grd files, extract metadata from the file itself
             if fext in GDAL_FILE_EXTS:


### PR DESCRIPTION
Please review the following changes made on `stackDict.py` and `readfile.py`. This would help to compute slant range distance when loading geometry files from topsApp geometry products. 

+ stackDict.py
    - Generate 2D slant range distance if missing from input template file:
        For dataset in geo-coordinates, use:
            1) incidenceAngle matrix if available OR
            2) constant value from SLANT_RANGE_DISTANCE.

+ readfile.py
    - binary filename for los.rdr or los.geo, ... is now more flexible in read_binary_file(): filenames start with 'los' is allowable
    - force to use the specified metadata file in read_attribute()

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
