### PR TITLE
create mst after selection by other thresholds

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -64,18 +64,7 @@ mintpy.subset.lalo         = auto    #[S:N,W:E / no], auto for no
 
 ########## 2. modify_network
 ## reference: Yunjun et al. (2019, section 4.2 and 5.3.1); Chaussard et al. (2015, GRL)
-## 1) Coherence-based network modification = (threshold + MST) by default
-## It calculates a average coherence value for each interferogram using spatial coherence and input mask (with AOI)
-## Then it finds a minimum spanning tree (MST) network with inverse of average coherence as weight (keepMinSpanTree)
-## For all interferograms except for MST's, exclude those with average coherence < minCoherence.
-mintpy.network.coherenceBased  = auto  #[yes / no], auto for no, exclude interferograms with coherence < minCoherence
-mintpy.network.keepMinSpanTree = auto  #[yes / no], auto for yes, keep interferograms in Min Span Tree network
-mintpy.network.minCoherence    = auto  #[0.0-1.0], auto for 0.7
-mintpy.network.maskFile        = auto  #[file name, no], auto for waterMask.h5 or no [if no waterMask.h5 found]
-mintpy.network.aoiYX           = auto  #[y0:y1,x0:x1 / no], auto for no, area of interest for coherence calculation
-mintpy.network.aoiLALO         = auto  #[S:N,W:E / no], auto for no - use the whole area
-
-## 2) Network modification based on temporal/perpendicular baselines, date etc.
+## 1) Network modification based on temporal/perpendicular baselines, date, num of connections etc.
 mintpy.network.tempBaseMax     = auto  #[1-inf, no], auto for no, max temporal baseline in days
 mintpy.network.perpBaseMax     = auto  #[1-inf, no], auto for no, max perpendicular spatial baseline in meter
 mintpy.network.connNumMax      = auto  #[1-inf, no], auto for no, max number of neighbors for each acquisition
@@ -84,6 +73,17 @@ mintpy.network.endDate         = auto  #[20110101 / no], auto for no
 mintpy.network.excludeDate     = auto  #[20080520,20090817 / no], auto for no
 mintpy.network.excludeIfgIndex = auto  #[1:5,25 / no], auto for no, list of ifg index (start from 0)
 mintpy.network.referenceFile   = auto  #[date12_list.txt / ifgramStack.h5 / no], auto for no
+
+## 2) Coherence-based network modification = (threshold + MST) by default
+## It calculates a average coherence for each interferogram using spatial coherence based on input mask (with AOI)
+## Then it finds a minimum spanning tree (MST) network with inverse of average coherence as weight (keepMinSpanTree)
+## Next it excludes interferograms if a) the average coherence < minCoherence AND b) not in the MST network.
+mintpy.network.coherenceBased  = auto  #[yes / no], auto for no, exclude interferograms with coherence < minCoherence
+mintpy.network.keepMinSpanTree = auto  #[yes / no], auto for yes, keep interferograms in Min Span Tree network
+mintpy.network.minCoherence    = auto  #[0.0-1.0], auto for 0.7
+mintpy.network.maskFile        = auto  #[file name, no], auto for waterMask.h5 or no [if no waterMask.h5 found]
+mintpy.network.aoiYX           = auto  #[y0:y1,x0:x1 / no], auto for no, area of interest for coherence calculation
+mintpy.network.aoiLALO         = auto  #[S:N,W:E / no], auto for no - use the whole area
 
 
 ########## 3. reference_point

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -20,14 +20,6 @@ mintpy.subset.lalo       = no
 
 
 ########## modify_network
-## Coherence-based
-mintpy.network.coherenceBased    = no
-mintpy.network.keepMinSpanTree   = yes
-mintpy.network.minCoherence      = 0.7
-mintpy.network.maskFile          = waterMask.h5
-mintpy.network.aoiYX             = no
-mintpy.network.aoiLALO           = no
-
 ## temp/perp baseline, dates
 mintpy.network.tempBaseMax       = no
 mintpy.network.perpBaseMax       = no
@@ -37,6 +29,14 @@ mintpy.network.endDate           = no
 mintpy.network.excludeDate       = no
 mintpy.network.excludeIfgIndex   = no
 mintpy.network.referenceFile     = no
+
+## Coherence-based
+mintpy.network.coherenceBased    = no
+mintpy.network.keepMinSpanTree   = yes
+mintpy.network.minCoherence      = 0.7
+mintpy.network.maskFile          = waterMask.h5
+mintpy.network.aoiYX             = no
+mintpy.network.aoiLALO           = no
 
 
 ########## reference_point

--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -352,9 +352,8 @@ def get_date12_to_drop(inps):
         date12_to_drop += tempList
         print('--------------------------------------------------')
         print('Drop ifgrams with the following index number: {}'.format(len(tempList)))
-        for i in range(len(tempList)):
-            print('{} : {}'.format(i, tempList[i]))
-            #len(tempList), zip(inps.excludeIfgIndex, tempList)))
+        for i, date12 in enumerate(tempList):
+            print('{} : {}'.format(i, date12))
 
     # excludeDate
     if inps.excludeDate:

--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -26,11 +26,11 @@ from mintpy.utils import (
 
 ###############################  Usage  ################################
 REFERENCE = """reference:
-  Yunjun, Z., H. Fattahi, and F. Amelung (2019), Small baseline InSAR time series analysis:
+  Yunjun, Z., Fattahi, H. and Amelung, F. (2019), Small baseline InSAR time series analysis:
   Unwrapping error correction and noise reduction, Computers & Geosciences, 133, 104331,
   doi:10.1016/j.cageo.2019.104331.
 
-  Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson
+  Chaussard, E., Bürgmann, R., Fattahi, H., Nadeau, R. M., Taira, T., Johnson, C. W. and Johanson, I.
   (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct
   connection between the Hayward and Calaveras Faults, Geophysical Research Letters, 42(8),
   2734-2741, doi:10.1002/2015GL063575.

--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -58,7 +58,7 @@ def create_parser():
                         help='Do not update auxilary files, e.g.\n' +
                              'maskConnComp.h5 or avgSpatialCoh.h5 from ifgramStack.h5')
 
-    # 1
+    # 1. temp/perp baseline, num of conn., dates, pair index, etc.
     parser.add_argument('--max-tbase', dest='tempBaseMax',
                         type=float, help='max temporal baseline in days')
     parser.add_argument('--max-pbase', dest='perpBaseMax',
@@ -77,7 +77,7 @@ def create_parser():
     parser.add_argument('--end-date', '--max-date', dest='endDate',
                         help='remove/drop interferograms with date later than end-date in YYMMDD or YYYYMMDD format')
 
-    # 2. Coherence-based network
+    # 2. coherence-based network
     cohBased = parser.add_argument_group('Coherence-based Network',
                                          'Drop/modify network based on spatial coherence')
     cohBased.add_argument('--coherence-based', dest='coherenceBased', action='store_true',
@@ -97,7 +97,7 @@ def create_parser():
                           help='Lookup table/mapping transformation file for geo/radar coordinate conversion.\n' +
                                'Needed for mask AOI in lalo')
 
-    # 3 Manually select network
+    # 3. manual selection
     manual = parser.add_argument_group('Manual Network', 'Manually select/drop/modify network')
     manual.add_argument('--manual', action='store_true',
                         help='display network to manually choose line/interferogram to remove')
@@ -404,7 +404,7 @@ def get_date12_to_drop(inps):
                                      saveList=True)[0]
 
         # get coherence-based network
-        coh_date12_list = list(np.array(coh_date_list)[np.array(cohList) >= inps.minCoherence])
+        coh_date12_list = list(np.array(date12ListAll)[np.array(cohList) >= inps.minCoherence])
 
         # get MST network
         if inps.keepMinSpanTree:


### PR DESCRIPTION
**Description of proposed changes**

Calculate minimum spanning tree from network (based on average coherence) after dropping interferograms based on other user criteria.

Previously, the minimum spanning tree was first created from all possible interfograms. Subsequently, interferograms would be dropped from the network based on user specifications (e.g., average temporal coherence), potentially breaking the network.

Now, the minimum spanning tree is calculated after all other considerations (again, e.g. average temporal coherence) from the remaining network. Note this doesn't guarantee the network will be connected, and also does not apply to the `manual` option for dropping network nodes.

More details can be found at the discussion [here](https://groups.google.com/g/mintpy/c/1JXBYEo8iB4).

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.