### PR TITLE
timeseries2velocity: add --exp and --log time funcs velocity fitting

### DIFF
--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -553,7 +553,7 @@ class timeseries:
                 # loop for charateristic time(s)
                 for exp_tau in exp_dict[exp_onset]:
                     # convert time from days to years
-                    exp_tau /= 36.525
+                    exp_tau /= 365.25
                     A[:, i] = np.array(t > exp_T).flatten() * (1 - np.exp(-1 * (t - exp_T) / exp_tau))
                     i += 1
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -473,6 +473,7 @@ class timeseries:
 
             return A
 
+
         def get_design_matrix4periodic_func(yr_diff, periods):
             """design matrix/function model of periodic velocity estimation
             Parameters: yr_diff : 1D array of time difference from refDate in decimal years
@@ -511,19 +512,23 @@ class timeseries:
 
         def get_design_matrix4exp_func(date_list, exp_dict):
             """design matrix/function model of exponential postseismic relaxation estimation
+
+            Reference: Eq. (5) in Hetland et al. (2012, JGR).
+            Note that there is a typo in the paper for this equation, based on the MInTS code, it should be:
+                Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t-T_i)/tau_i)] }
+            instead of the one below shown in the paper:
+                Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t)/tau_i)] }
+            where:
+                a_i         amplitude      of i-th exp term
+                T_i         onset time     of i-th exp term
+                tau_i       char time      of i-th exp term (relaxation time)
+                H(t-T_i)    Heaviside func of i-th exp term (ensuring the exp func is one-sided)
+
             Parameters: date_list      : list of dates in YYYYMMDD format
                         exp_dict       : dict of exp func(s) onset time(s) with date in YYYYMMDD;
                                          list of exp_char_time(s) in decimal days
             Returns:    A              : 2D array of zeros & ones in size of (num_date, num_exp)
             """
-            ## Exponential equation for relaxation processes
-            # using Eq. (5) from Hetland et. al. (2012, JGR)
-            # typo in the paper: it should be e^(-(t_T_i)/tau_i) in Eq. (5).
-            # F(t) = Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t-T_i)/tau_i)] }
-            #   a_i         amplitude      of i-th exp term
-            #   T_i         onset time     of i-th exp term
-            #   tau_i       char time      of i-th exp term (relaxation time)
-            #   H(t-T_i)    Heaviside func of i-th exp term (ensuring the exp func is one-sided)
             num_date = len(date_list)
             num_exp  = sum([len(exp_dict[x]) for x in exp_dict])
             A = np.zeros((num_date, num_exp), dtype=np.float32)
@@ -542,19 +547,23 @@ class timeseries:
 
         def get_design_matrix4log_func(date_list, log_dict):
             """design matrix/function model of logarithmic postseismic relaxation estimation
+
+            Reference: Eq. (4) in Hetland et al. (2012, JGR)
+            Note that there is a typo in the paper for this equation, based on the MInTS code, it should be:
+                Sum_i{ a_i * H(t-Ti) * [1 + log((t-T_i)/tau_i)] }
+            instead of the one below shown in the paper:
+                Sum_i{ a_i * H(t-Ti) * [1 + log((t)/tau_i)] }
+            where:
+                a_i         amplitude      of i-th log term
+                T_i         onset time     of i-th log term
+                tau_i       char time      of i-th log term (relaxation time)
+                H(t-T_i)    Heaviside func of i-th log term (ensuring the log func is one-sided)
+
             Parameters: date_list      : list of dates in YYYYMMDD format
                         log_dict       : dict of log func(s) onset time(s) with date in YYYYMMDD;
                                          list of log_char_time(s) in decimal days
             Returns:    A              : 2D array of zeros & ones in size of (num_date, num_log)
             """
-            ## Logarithmic equation for relaxation processes
-            # using Eq. (4) from Hetland et. al. (2012, JGR)
-            # typo in the paper: it should be log((t_T_i)/tau_i) in Eq. (4).
-            # F(t) = Sum_i{ a_i * H(t-Ti) * [1 + log((t-T_i)/tau_i)] }
-            #   a_i         amplitude      of i-th log term
-            #   T_i         onset time     of i-th log term
-            #   tau_i       char time      of i-th log term (relaxation time)
-            #   H(t-T_i)    Heaviside func of i-th log term (ensuring the log func is one-sided)
             num_date = len(date_list)
             num_log  = sum([len(log_dict[x]) for x in log_dict])
             A = np.zeros((num_date, num_log), dtype=np.float32)

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -545,7 +545,8 @@ class timeseries:
 
             t = np.array(ptime.yyyymmdd2years(date_list))
             # loop for onset time(s)
-            for i, exp_onset in enumerate(exp_dict.keys()):
+            i = 0
+            for exp_onset in exp_dict.keys():
                 # convert string to float in years
                 exp_T = ptime.yyyymmdd2years(exp_onset)
 
@@ -553,7 +554,8 @@ class timeseries:
                 for exp_tau in exp_dict[exp_onset]:
                     # convert time from days to years
                     exp_tau /= 36.525
-                    A[:, i] = np.array(t > exp_T) * (1 - np.exp(-1 * (t - exp_T) / exp_tau))
+                    A[:, i] = np.array(t > exp_T).flatten() * (1 - np.exp(-1 * (t - exp_T) / exp_tau))
+                    i += 1
 
             return A
 
@@ -588,7 +590,8 @@ class timeseries:
 
             t = np.array(ptime.yyyymmdd2years(date_list))
             # loop for onset time(s)
-            for i, log_onset in enumerate(log_dict.keys()):
+            i = 0
+            for log_onset in log_dict.keys():
                 # convert string to float in years
                 log_T = ptime.yyyymmdd2years(log_onset)
 
@@ -598,8 +601,9 @@ class timeseries:
                     log_tau /= 365.25
 
                     olderr = np.seterr(invalid='ignore', divide='ignore')
-                    A[:, i] = np.array(t > log_T) * np.nan_to_num(np.log(1 + (t - log_T) / log_tau), nan=0, neginf=0)
+                    A[:, i] = np.array(t > log_T).flatten() * np.nan_to_num(np.log(1 + (t - log_T) / log_tau), nan=0, neginf=0)
                     np.seterr(**olderr)
+                    i += 1
 
             return A
 

--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -60,8 +60,9 @@ EXAMPLE = """example:
 
   # complex time functions
   timeseries2velocity.py timeseries_ERA5_ramp_demErr.h5 --poly 3 --period 1 0.5 --step 20170910
-  timeseries2velocity.py timeseries_ERA5_demErr.py      --poly 1 --exp 20170910 90 300
-  timeseries2velocity.py timeseries_ERA5_demErr.py      --poly 1 --log 20171014 60.4 200 --log 20171026 200.7
+  timeseries2velocity.py timeseries_ERA5_demErr.h5      --poly 1 --exp 20170910 90
+  timeseries2velocity.py timeseries_ERA5_demErr.h5      --poly 1 --log 20170910 60.4
+  timeseries2velocity.py timeseries_ERA5_demErr.h5      --poly 1 --log 20170910 60.4 200 --log 20171026 200.7
 """
 
 DROP_DATE_TXT = """exclude_date.txt:


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

This PR is also responding to this issue raised in the NISAR-Solid repo (<https://github.com/nisar-solid/ATBD/issues/4>).

In the current post-processing of InSAR time series, MintPy supports the following time functions (or models) in the velocity-estimation stage:
- polynomial: A multi-degree polynomial function. Modeling secular velocity with input:
    - int, polynomial order, e.g. 1 (linear), 2 (quadratic), 3 (cubic), etc.
- periodic: A series of periodic function(s). Modeling seasonal processes with input:
    - list of float, period(s) in years, e.g. 1.0 (annual), 0.5 (semi-annual), etc.
- step: A series of step function(s). Modeling coseismic processes with input:
    - list of str, dates of the step functions.

Now we added two more time functions:
- exp: A series of exponential function(s). Modeling the amplitude of post-seismic relaxation with input:
     - list of str, dates of the onset of exp function(s), e.g., '20161231', '20190125'.
     - list of float, exp characteristic time(s) in days, e.g., 80.5, 200.

- log: A series of logarithmic function(s). Modeling the amplitude of post-seismic relaxation with input:
     - list of str, dates of the onset of log function(s), e.g., '20181231', '20200125'.
     - list of float, log characteristic time(s) in days, e.g., 60.2, 120.

# An example of usage

```bash
  timeseries2velocity.py timeseries.h5 --poly 1 --period 1 0.5 --step 20170910 --exp 20170910 90 300 --log 20171014 60.4 200 --log 20171026 200.7
```

#### Inputs:
1. An InSAR time-series dataset, [timeseries.h5](https://mintpy.readthedocs.io/en/latest/api/data_structure/#timeseries)
2. A user-defined complex model, which is a superposition of the following time functions:
   - a polynomial function of degree = 1 (i.e., a line with intercept and slope)
   - an annual periodic function (period = 1.0 yr)
   - a semi-annual periodic function (period = 0.5 yr)
   - a step function at 20170910
   - an exp function starting from 20170910, with two-layer characteristic times:
         <img src="https://render.githubusercontent.com/render/math?math=\tau=90"> days and 
         <img src="https://render.githubusercontent.com/render/math?math=\tau=300"> days
   - a log function starting from 20171014, with two-layer characteristic times:
         <img src="https://render.githubusercontent.com/render/math?math=\tau=60.4"> days and
         <img src="https://render.githubusercontent.com/render/math?math=\tau=200"> days
   - a log function starting from 20171026, with a characteristic time, <img src="https://render.githubusercontent.com/render/math?math=\tau=200.7"> days

#### Outputs:
Will output a file called velocity.h5 [HDF-EOS5 format](https://mintpy.readthedocs.io/en/latest/hdfeos5/), which contains the following HDF5 datasets: 
```bash

## Amplitude of the annual periodic function 
HDF5 dataset "/annualAmp              ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Amplitude of the exp function at 20160910 with tau=90 days
HDF5 dataset "/exp20160910Tau90.0     ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Std. dev. of the exp function at 20160910 with tau=90 days
HDF5 dataset "/exp20160910Tau90.0Std  ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Amplitude of the exp function at 20160910 with tau=300 days
HDF5 dataset "/exp20160910Tau300.0    ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Std. dev. of the exp function at 20160910 with tau=300 days
HDF5 dataset "/exp20160910Tau300.0Std ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Amplitude of the log function at 20171014 with tau=60.4 days
HDF5 dataset "/log20171014Tau60.4     ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Std. dev. of the log function at 20171014 with tau=60.4 days
HDF5 dataset "/log20171014Tau60.4Std  ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Amplitude of the log function at 20171014 with tau=200 days
HDF5 dataset "/log20171014Tau200.0    ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Std. dev. of the log function at 20171014 with tau=200 days
HDF5 dataset "/log20171014Tau200.0Std ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Amplitude of the log function at 20171026 with tau=200.7 days
HDF5 dataset "/log20171026Tau200.7    ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Std. dev. of the log function at 20171026 with tau=200.7 days
HDF5 dataset "/log20171026Tau200.7Std ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Amplitude of the semi-annual periodic function 
HDF5 dataset "/semiAnnualAmp          ": shape (len, wid)          , dtype <float32>
  UNIT    m

## Velocity (slope of the degree 1 polynomial function)
HDF5 dataset "/velocity               ": shape (len, wid)          , dtype <float32>
  UNIT    m/year

## Std. dev. of Velocity
HDF5 dataset "/velocityStd            ": shape (len, wid)          , dtype <float32>
  UNIT    m/year
```

<br />

# Major modifications

## 1. `mintpy/objects/stack.py `
### [`get_design_matrix4time_func()`](https://github.com/insarlab/MintPy/compare/main...yuankailiu:funcfitVelo?expand=1#diff-bcae08013b38036b87aa00d8b4c8246b4c9b513de587268e3e005bee084a5e95R444)
Translate the input time function setup into the design matrix. 
Now it can take extra model inputs corresponding to the exponential and logarithmic time function model setups. The extra setups are appended to the design matrix. The new func() for exp and log design matrix are as below:

#### a. [`get_design_matrix4exp_func()`](https://github.com/insarlab/MintPy/compare/main...yuankailiu:funcfitVelo?expand=1#diff-bcae08013b38036b87aa00d8b4c8246b4c9b513de587268e3e005bee084a5e95R512)
A new func for design matrix/function model of exponential postseismic relaxation estimation

#### b. [`get_design_matrix4log_func()`](https://github.com/insarlab/MintPy/compare/main...yuankailiu:funcfitVelo?expand=1#diff-bcae08013b38036b87aa00d8b4c8246b4c9b513de587268e3e005bee084a5e95R532)
A new func for design matrix/function model of logarithmic postseismic relaxation estimation


## 2. `mintpy/timeseries2velocity.py`

### A. [`estimate_time_func()`](https://github.com/insarlab/MintPy/compare/main...yuankailiu:funcfitVelo?expand=1#diff-bcae08013b38036b87aa00d8b4c8246b4c9b513de587268e3e005bee084a5e95R444)
Deformation model estimator, using a suite of linear, periodic, step, exponential, and logarithmic function(s).

### B. [`layout_hdf5 ()`](https://github.com/insarlab/MintPy/compare/main...yuankailiu:funcfitVelo?expand=1#diff-bcae08013b38036b87aa00d8b4c8246b4c9b513de587268e3e005bee084a5e95R444)
Add exp and log structures when creating HDF5 file for estimated time functions with defined metadata and (empty) dataset structure.

### C. [`write_hdf5_block()`](https://github.com/insarlab/MintPy/compare/main...yuankailiu:funcfitVelo?expand=1#diff-e4b23017fd507db572bc7b28bbe1e74c88da9aa6abac10864936be14e1735e49R679)
Add exp and log data when writing the estimated time function parameters to file.


<br />

# Minor changes
- Append parsers for exponential and logarithmic user-defined input arguments in `mintpy/timeseries2velocity.py`
- Append examples and helps for the newly added exponential and logarithmic time function fitting functionalities.
- Typos fixed


<br />

# Caveats
- The updated code is quickly tested on an [InSAR time-series dataset](https://mintpy.readthedocs.io/en/latest/api/data_structure/#timeseries). It can successfully output the --exp and --log model parameters based on the user-specified setups. However, the time-series dataset used for testing is not thought to contain post-seismic geophysical signals, thus the inverted exp and log model parameters cannot really be validated. A dataset with real post-seismic relaxation processes should be used to test the code and validate the results later.


**Reminders**

- [x] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
