### PR TITLE
solid_earth_tides: bugfix of missing CENTER_LINE_UTC

### DIFF
--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -286,6 +286,7 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
     prog_bar.close()
 
     # radar-coding if input in radar-coordinates
+    # use ts_file to avoid potential missing CENTER_LINE_UTC attributes in geom_file from alosStack
     atr = readfile.read_attribute(ts_file)
     if 'Y_FIRST' not in atr.keys():
         print('radar-coding the LOS tides time-series ...')

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -122,7 +122,7 @@ def prepare_los_geometry(geom_file):
     """
 
     print('read/prepare LOS geometry from file: {}'.format(geom_file))
-    atr = readfile.read_attribute(ts_file)
+    atr = readfile.read_attribute(geom_file)
 
     print('read incidence / azimuth angle')
     inc_angle = readfile.read(geom_file, datasetName='incidenceAngle')[0]
@@ -286,7 +286,7 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
     prog_bar.close()
 
     # radar-coding if input in radar-coordinates
-    atr = readfile.read_attribute(geom_file)
+    atr = readfile.read_attribute(ts_file)
     if 'Y_FIRST' not in atr.keys():
         print('radar-coding the LOS tides time-series ...')
         res_obj = resample(lut_file=geom_file)

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -122,7 +122,7 @@ def prepare_los_geometry(geom_file):
     """
 
     print('read/prepare LOS geometry from file: {}'.format(geom_file))
-    atr = readfile.read_attribute(geom_file)
+    atr = readfile.read_attribute(ts_file)
 
     print('read incidence / azimuth angle')
     inc_angle = readfile.read(geom_file, datasetName='incidenceAngle')[0]


### PR DESCRIPTION
**Description of proposed changes**

I've proposed small change on this code to used the attributes from the timeseries file instead of the geometry file. This implementation is made due to the possbile incomplete geometryRadar.h5 attributes on the alosStack(issue https://github.com/insarlab/MintPy/issues/566). This edit is also consistent with the workflow used by tropo_pyaps3.py which uses the attributes from timeseries file instead of the geometry file.

**Reminders**

- [x] Fix #566
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.