### PR TITLE
view.py --math/ref-lalo and update plot_insar_vs_gps_scatter to the latest GPS CSV format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
             git clone https://github.com/insarlab/PySolid.git ${HOME}/tools/PySolid
             # install dependencies
             source activate root
-            conda config --add channels conda-forge
-            conda install --yes --file $MINTPY_HOME/docs/conda.txt gdal>=3 gfortran_linux-64
-            pip install git+https://github.com/tylere/pykml.git
+            ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
+            ${HOME}/tools/miniconda3/bin/conda install --yes --file $MINTPY_HOME/docs/conda.txt gdal>=3 gfortran_linux-64
+            ${HOME}/tools/miniconda3/bin/pip install git+https://github.com/tylere/pykml.git
             # compile pysolid Fortran code
             cd ${HOME}/tools/PySolid/pysolid
             f2py -c -m solid solid.for

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,12 @@ jobs:
             chmod +x Miniconda3-latest-Linux-x86_64.sh
             ./Miniconda3-latest-Linux-x86_64.sh -b -p ${HOME}/tools/miniconda3
             ${HOME}/tools/miniconda3/bin/conda init bash
+            ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
+            ${HOME}/tools/miniconda3/bin/conda install mamba --yes
 
       - run:
           name: Installing MintPy, PyAPS and PySolid
+          no_output_timeout: 30m
           command: |
             export PYTHONUNBUFFERED=1
             # setup environment variable
@@ -36,8 +39,7 @@ jobs:
             git clone https://github.com/insarlab/PySolid.git ${HOME}/tools/PySolid
             # install dependencies
             source activate root
-            ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
-            ${HOME}/tools/miniconda3/bin/conda install --yes --file $MINTPY_HOME/docs/conda.txt gdal>=3 gfortran_linux-64
+            ${HOME}/tools/miniconda3/bin/mamba install --yes --file ${MINTPY_HOME}/docs/conda.txt gdal>=3 gfortran_linux-64
             ${HOME}/tools/miniconda3/bin/pip install git+https://github.com/tylere/pykml.git
             # compile pysolid Fortran code
             cd ${HOME}/tools/PySolid/pysolid

--- a/docs/api/colormaps.md
+++ b/docs/api/colormaps.md
@@ -40,6 +40,7 @@ The following colormaps is included by default:
 
 + BlueWhiteOrangeRed
 + DEM_print
++ differences
 + GMT_haxby
 + GMT_no_green
 + seminf-haxby

--- a/mintpy/data/colormaps/differences.cpt
+++ b/mintpy/data/colormaps/differences.cpt
@@ -1,0 +1,6 @@
+# GMT colour palette table (cpt)
+# grass2cpt ouput
+# COLOR_MODEL = RGB
+-1.000000e+00   0   0 255 0.000000e+00 255 255 255
+0.000000e+00 255 255 255 1.000000e+00 255   0   0
+N 128 128 128

--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -449,6 +449,9 @@ class GPS:
             atr = readfile.read_attribute(geom_obj)
             coord = coordinate(atr, lookup_file=geom_obj)
             y, x = coord.geo2radar(lat, lon, print_msg=print_msg)[0:2]
+            # check against image boundary
+            y = max(0, y);  y = min(int(atr['LENGTH'])-1, y)
+            x = max(0, x);  x = min(int(atr['WIDTH'])-1, x)
             box = (x, y, x+1, y+1)
             inc_angle = readfile.read(geom_obj, datasetName='incidenceAngle', box=box, print_msg=print_msg)[0][0,0]
             az_angle  = readfile.read(geom_obj, datasetName='azimuthAngle', box=box, print_msg=print_msg)[0][0,0]

--- a/mintpy/objects/insar_vs_gps.py
+++ b/mintpy/objects/insar_vs_gps.py
@@ -13,9 +13,10 @@ from scipy import stats
 from scipy.interpolate import griddata
 from datetime import datetime as dt
 from dateutil.relativedelta import relativedelta
+from matplotlib import pyplot as plt
 
 from mintpy.objects import timeseries, giantTimeseries
-from mintpy.utils import readfile, plot as pp, utils as ut
+from mintpy.utils import ptime, readfile, plot as pp, utils as ut
 from mintpy.objects.gps import GPS
 from mintpy.defaults.plot import *
 
@@ -23,56 +24,117 @@ from mintpy.defaults.plot import *
 
 ############################## utilities functions ##########################################
 
-def plot_insar_vs_gps_scatter(gps_csv_file = 'GPSSitesVel.csv', insar_vel_file = 'velocity.h5'):
-    """Plot/compare the average velocity between InSAR and GPS.
+def plot_insar_vs_gps_scatter(vel_file, ref_gps_site, csv_file='gps_enu2los.csv', msk_file=None,
+                              xname='InSAR', vlim=None):
+    """Scatter plot to compare the velocities between SAR/InSAR and GPS.
 
-    Parameters: gps_csv_file   - str, path of GPS CSV file, generated after running view.py --gps-comp
-                insar_vel_file - str, path of InSAR LOS velocity HDF5 file.
-    Example:    plot_insar_vs_gps_scatter()
+    Parameters: vel_file     - str, path of InSAR LOS velocity HDF5 file.
+                ref_gps_site - str, reference GNSS site name
+                csv_file     - str, path of GPS CSV file, generated after running view.py --gps-comp
+                msk_file     - str, path of InSAR mask file.
+                vlim         - list of 2 float, display value range in the unit of cm/yr
+                               Default is None to grab from data
+                               If set, the range will be used to prune the SAR and GPS observations
+                xname        - str, xaxis label
+    Example:
+        from mintpy.objects.insar_vs_gps import plot_insar_vs_gps_scatter
+        csv_file = os.path.join(work_dir, 'geo/gps_enu2los.csv')
+        vel_file = os.path.join(work_dir, 'geo/geo_velocity.h5')
+        msk_file = os.path.join(work_dir, 'geo/geo_maskTempCoh.h5')
+        plot_insar_vs_gps_scatter(vel_file, ref_gps_site='CACT', csv_file=csv_file, msk_file=msk_file, vlim=[-2.5, 2])
     """
-    from mintpy.utils import readfile, utils as ut
+
+    disp_unit = 'cm/yr'
+    unit_fac = 100.
 
     # read GPS velocity from CSV file (generated during view.py call)
-    print('read GPS velocity from file: {}'.format(gps_csv_file))
-    fc = np.loadtxt(gps_csv_file, dtype=bytes, delimiter=',', skiprows=1).astype(str)
-    sites = fc[:, 0]
-    lons = fc[:, 1].astype(np.float32)
-    lats = fc[:, 2].astype(np.float32)
-    vels_gps = fc[:, 3].astype(np.float32)
+    col_names = ['Site', 'Lon', 'Lat', 'LOS_displacement', 'LOS_velocity']
+    num_col = len(col_names)
+    col_types = ['U10'] + ['f8'] * (num_col - 1)
+
+    print('read GPS velocity from file: {}'.format(csv_file))
+    fc = np.genfromtxt(csv_file, dtype=col_types, delimiter=',', names=True)
+    sites = fc['Site']
+    lats = fc['Lat']
+    lons = fc['Lon']
+    gps_obs = fc['LOS_velocity'] * unit_fac
 
     # read InSAR velocity
-    print('read InSAR velocity from file: {}'.format(insar_vel_file))
-    atr = readfile.read_attribute(insar_vel_file)
+    print('read InSAR velocity from file: {}'.format(vel_file))
+    atr = readfile.read_attribute(vel_file)
     coord = ut.coordinate(atr)
     ys, xs = coord.geo2radar(lats, lons)[:2]
 
+    if msk_file:
+        msk = readfile.read(msk_file)[0]
+
     num_site = sites.size
-    vels_insar = np.zeros(num_site, dtype=np.float32)
+    insar_obs = np.zeros(num_site, dtype=np.float32) * np.nan
+    prog_bar = ptime.progressBar(maxValue=num_site)
     for i in range(num_site):
         x, y = xs[i], ys[i]
         box = (x, y, x+1, y+1)
-        vels_insar[i] = readfile.read(insar_vel_file, datasetName='velocity', box=box)[0] * 100.
+        if msk_file and not msk[y, x]:
+            box = None
+
+        if box:
+            insar_obs[i] = readfile.read(vel_file, datasetName='velocity', box=box)[0] * unit_fac
+
+        prog_bar.update(i+1, suffix='{}/{} {}'.format(i+1, num_site, sites[i]))
+    prog_bar.close()
+
+    # reference site
+    ref_ind = sites.tolist().index(ref_gps_site)
+    gps_obs -= gps_obs[ref_ind]
+    insar_obs -= insar_obs[ref_ind]
+
+    # remove NaN value
+    print('removing sites with NaN values in GPS or {}'.format(xname))
+    flag = np.multiply(~np.isnan(insar_obs), ~np.isnan(gps_obs))
+    if vlim is not None:
+        print('pruning sites with value range: {} {}'.format(vlim, disp_unit))
+        flag *= gps_obs >= vlim[0]
+        flag *= gps_obs <= vlim[1]
+        flag *= insar_obs >= vlim[0]
+        flag *= insar_obs <= vlim[1]
+
+    gps_obs = gps_obs[flag]
+    insar_obs = insar_obs[flag]
+
+    # stats
+    print('GPS   min/max: {:.2f} / {:.2f}'.format(np.nanmin(gps_obs), np.nanmax(gps_obs)))
+    print('InSAR min/max: {:.2f} / {:.2f}'.format(np.nanmin(insar_obs), np.nanmax(insar_obs)))
+
+    rmse = np.sqrt(np.sum((insar_obs - gps_obs)**2) / (gps_obs.size - 1))
+    r2 = stats.linregress(insar_obs, gps_obs)[2]
+    print('RMSE = {:.1f} cm'.format(rmse))
+    print('R^2 = {:.2f}'.format(r2))
 
     # plot
     plt.rcParams.update({'font.size': 12})
-    vmin, vmax = np.min(vels_insar), np.max(vels_insar)
-    buffer = (vmax - vmin) * 0.1
-    vmin -= buffer
-    vmax += buffer
+    if vlim is None:
+        vlim = [np.min(insar_obs), np.max(insar_obs)]
+        buffer = (vlim[1] - vlim[0]) * 0.1
+        vlim = [vlim[0] - buffer, vlim[1] + buffer]
 
-    fig, ax = plt.subplots(figsize=[6, 6])
-    ax.plot((vmin, vmax), (vmin, vmax), 'k--')
-    ax.plot(vels_insar, vels_gps, '.', ms=15)
+    fig, ax = plt.subplots(figsize=[4, 4])
+    ax.plot((vlim[0], vlim[1]), (vlim[0], vlim[1]), 'k--')
+    ax.plot(insar_obs, gps_obs, '.', ms=15)
 
     # axis format
-    ax.set_xlim(vmin, vmax)
-    ax.set_ylim(vmin, vmax)
-    ax.set_xlabel('InSAR [cm/yr]')
-    ax.set_ylabel('GPS [cm/yr]')
+    ax.set_xlim(vlim)
+    ax.set_ylim(vlim)
+    ax.set_xlabel(f'{xname} [{disp_unit}]')
+    ax.set_ylabel(f'GNSS [{disp_unit}]')
     ax.set_aspect('equal', 'box')
     fig.tight_layout()
+
+    # output
+    out_fig = '{}_vs_gps_scatter.pdf'.format(xname.lower())
+    plt.savefig(out_fig, bbox_inches='tight', transparent=True, dpi=300)
+    print('save figure to file', out_fig)
     plt.show()
-    
+
     return
 
 

--- a/mintpy/plot_transection.py
+++ b/mintpy/plot_transection.py
@@ -44,6 +44,8 @@ def create_parser():
     parser.add_argument('file', nargs='+',
                         help='input file to show transection')
     parser.add_argument('--dset', dest='dset', help='Dataset name to read')
+    parser.add_argument('-v','--vlim', dest='vlim', nargs=2, metavar=('VMIN', 'VMAX'), type=float,
+                        help='Display limits for matrix plotting.')
     parser.add_argument('--offset','--off', dest='offset', type=float, nargs='+', default=[0.05],
                         help='offset between transects [for multiple files only; default: %(default)s m].\n'
                              'number of input offsets should be:\n'
@@ -152,6 +154,8 @@ def get_view_cmd(iargs):
     """Assemble view.py command line from input arguments"""
     # define ALL parsing options from create_parser() that are common to view.py
     parser = argparse.ArgumentParser(description='view.py parser')
+    parser.add_argument('-v','--vlim', dest='vlim', nargs=2, metavar=('VMIN', 'VMAX'), type=float,
+                        help='Display limits for matrix plotting.')
     parser.add_argument('--noverbose', dest='print_msg', action='store_false',
                         help='Disable the verbose message printing.')
     parser = arg_group.add_figure_argument(parser)

--- a/mintpy/save_kmz.py
+++ b/mintpy/save_kmz.py
@@ -77,8 +77,8 @@ def create_parser():
                      default='lower left', help='Location of colorbar in the screen. Default: lower left.')
     fig.add_argument('--cbar-label', dest='cbar_label', metavar='LABEL', default='Mean LOS velocity',
                      help='Colorbar label. Default: Mean LOS velocity')
-    fig.add_argument('--cbar-bin-num', dest='cbar_bin_num', metavar='NUM', type=int, default=7,
-                     help='Colorbar bin number. Default: 7')
+    fig.add_argument('--cbar-bin-num', dest='cbar_bin_num', metavar='NUM', type=int,
+                     help='Colorbar bin number (default: %(default)s).')
 
     # Reference Pixel
     ref = parser.add_argument_group('Reference Pixel')
@@ -110,13 +110,17 @@ def cmd_line_parse(iargs=None):
 
 
 def plot_colorbar(out_file, vmin, vmax, unit='cm/year', cmap='jet', figsize=(0.18, 3.6),
-                  nbins=7, label='Mean LOS velocity'):
+                  nbins=None, label='Mean LOS velocity'):
     fig, cax = plt.subplots(figsize=figsize)
     norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
     cbar = mpl.colorbar.ColorbarBase(cax, cmap=plt.get_cmap(cmap), norm=norm, orientation='vertical')
     cbar.set_label('{} [{}]'.format(label, unit), fontsize=12)
-    cbar.locator = mpl.ticker.MaxNLocator(nbins=nbins)
-    cbar.update_ticks()
+
+    # update ticks
+    if nbins:
+        cbar.locator = mpl.ticker.MaxNLocator(nbins=nbins)
+        cbar.update_ticks()
+
     cbar.ax.tick_params(which='both', labelsize=12)
     fig.patch.set_facecolor('white')
     fig.patch.set_alpha(0.7)
@@ -126,7 +130,7 @@ def plot_colorbar(out_file, vmin, vmax, unit='cm/year', cmap='jet', figsize=(0.1
 
 
 def generate_cbar_element(cbar_file, vmin, vmax, unit='cm/year', cmap='jet', loc='lower left',
-                          nbins=7, label='Mean LOS velocity'):
+                          nbins=None, label='Mean LOS velocity'):
     # plot colobar and save as an image
     cbar_file = plot_colorbar(out_file=cbar_file,
                               vmin=vmin,

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -62,9 +62,9 @@ REFERENCE = """reference:
   2324-2341, doi:10.1002/2013JB010588.
 
   # ERA-5
-  Copernicus Climate Change Service (2017): ERA5: Fifth generation of ECMWF atmospheric reanalyses of 
-  the global climate. Copernicus Climate Change Service Climate Data Store, 
-  date of access: {your_date_of_access}. https://cds.climate.copernicus.eu/cdsapp#!/hom
+  Hersbach, H., Bell, B., Berrisford, P., Hirahara, S., Horányi, A., Muñoz-Sabater, J., et al. (2020). 
+  The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society, 146(730), 1999–2049.
+  https://doi.org/10.1002/qj.3803
 """
 
 DATA_INFO = """Global Atmospheric Models:

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -532,7 +532,7 @@ def dload_grib_files(grib_files, tropo_model='ERA5', snwe=None):
     # Get date list to download (skip already downloaded files)
     grib_files_exist = check_exist_grib_file(grib_files, print_msg=True)
     grib_files2dload = sorted(list(set(grib_files) - set(grib_files_exist)))
-    date_list2dload = [str(re.findall('\d{8}', i)[0]) for i in grib_files2dload]
+    date_list2dload = [str(re.findall('\d{8}', os.path.basename(i))[0]) for i in grib_files2dload]
     print('number of grib files to download: %d' % len(date_list2dload))
     print('------------------------------------------------------------------------------\n')
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1101,6 +1101,10 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         if inps.ref_gps_site:
             vprint('referencing all GPS LOS observations to site: {}'.format(inps.ref_gps_site))
             ref_ind = site_names.tolist().index(inps.ref_gps_site)
+            # plot label of the reference site
+            ax.annotate(site_names[ref_ind], xy=(site_lons[ref_ind], site_lats[ref_ind]),
+                        fontsize=inps.font_size)
+            # update value
             ref_val = site_obs[ref_ind]
             if not np.isnan(ref_val):
                 site_obs -= ref_val

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -523,8 +523,10 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
 
     # For colorful display of coherence
     if 'cohList'     not in p_dict.keys():  p_dict['cohList']     = None
+    if 'xlabel'      not in p_dict.keys():  p_dict['xlabel']      = 'Time [years]'
     if 'ylabel'      not in p_dict.keys():  p_dict['ylabel']      = 'Perp Baseline [m]'
     if 'cbar_label'  not in p_dict.keys():  p_dict['cbar_label']  = 'Average Spatial Coherence'
+    if 'cbar_size'   not in p_dict.keys():  p_dict['cbar_size']   = '3%'
     if 'disp_cbar'   not in p_dict.keys():  p_dict['disp_cbar']   = True
     if 'colormap'    not in p_dict.keys():  p_dict['colormap']    = 'RdBu'
     if 'vlim'        not in p_dict.keys():  p_dict['vlim']        = [0.2, 1.0]
@@ -592,7 +594,7 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
             print('display range: {}'.format(p_dict['vlim']))
 
         if p_dict['disp_cbar']:
-            cax = make_axes_locatable(ax).append_axes("right", "3%", pad="3%")
+            cax = make_axes_locatable(ax).append_axes("right", p_dict['cbar_size'], pad=p_dict['cbar_size'])
             norm = mpl.colors.Normalize(vmin=disp_min, vmax=disp_max)
             cbar = mpl.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
             cbar.ax.tick_params(labelsize=p_dict['fontsize'])
@@ -649,7 +651,7 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     ax = auto_adjust_xaxis_date(ax, datevector, fontsize=p_dict['fontsize'],
                                 every_year=p_dict['every_year'])[0]
     ax = auto_adjust_yaxis(ax, pbaseList, fontsize=p_dict['fontsize'])
-    ax.set_xlabel('Time [years]', fontsize=p_dict['fontsize'])
+    ax.set_xlabel(p_dict['xlabel'], fontsize=p_dict['fontsize'])
     ax.set_ylabel(p_dict['ylabel'], fontsize=p_dict['fontsize'])
     ax.tick_params(which='both', direction='in', labelsize=p_dict['fontsize'],
                    bottom=True, top=True, left=True, right=True)
@@ -1151,8 +1153,13 @@ def plot_colorbar(inps, im, cax):
         inps.cbar_nbins = inps.cmap_lut
 
     if inps.cbar_nbins:
-        cbar.locator = ticker.MaxNLocator(nbins=inps.cbar_nbins)
-        cbar.update_ticks()
+        if inps.cbar_nbins <= 2:
+            # manually set tick for better positions when the color step is not a common number
+            # e.g. for numInvIfgram.h5
+            cbar.set_ticks(inps.dlim)
+        else:
+            cbar.locator = ticker.MaxNLocator(nbins=inps.cbar_nbins)
+            cbar.update_ticks()
 
     cbar.ax.tick_params(which='both', direction='out', labelsize=inps.font_size, colors=inps.font_color)
 

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -634,6 +634,7 @@ def which(program):
 
 def check_parallel(file_num=1, print_msg=True, maxParallelNum=8):
     """Check parallel option based file num and installed module
+    Link: https://joblib.readthedocs.io/en/latest/parallel.html
     Examples:
         num_cores, inps.parallel, Parallel, delayed = ut.check_parallel(len(file_list))
         Parallel(n_jobs=num_cores)(delayed(subset_file)(file, vars(inps)) for file in file_list)

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -110,6 +110,14 @@ def create_parser():
     parser.add_argument('--noverbose', dest='print_msg', action='store_false',
                         help='Disable the verbose message printing (default: %(default)s).')
 
+    parser.add_argument('--math', dest='math_operation', choices={'square','sqrt','reverse','inverse'},
+                        help='Apply the math operation before displaying [for single subplot ONLY].\n'
+                             'E.g. plot the std. dev. of the variance file.\n'
+                             '  square  = x^2\n'
+                             '  sqrt    = x^1/2\n'
+                             '  reverse = x * -1\n'
+                             '  inverse = 1 / x')
+
     parser = arg_group.add_data_disp_argument(parser)
     parser = arg_group.add_dem_argument(parser)
     parser = arg_group.add_figure_argument(parser)
@@ -1482,6 +1490,7 @@ class viewer():
                                            datasetName=self.dset[0],
                                            box=self.pix_box,
                                            print_msg=False)
+
             # reference in time
             if self.ref_date:
                 data -= readfile.read(self.file,
@@ -1499,6 +1508,18 @@ class viewer():
                                          box=(ref_x, ref_y, ref_x+1, ref_y+1),
                                          print_msg=False)[0]
                 data[data != 0.] -= ref_data
+
+            # math operation
+            if self.math_operation:
+                vprint('Apply math operation: {}'.format(self.math_operation))
+                if self.math_operation == 'square':
+                    data = np.square(data)
+                elif self.math_operation == 'sqrt':
+                    data = np.sqrt(data)
+                elif self.math_operation == 'reverse':
+                    data *= -1
+                elif self.math_operation == 'inverse':
+                    data = 1. / data
 
             # masking
             if self.zero_mask:

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -275,11 +275,16 @@ def update_inps_with_file_metadata(inps, metadata):
     # Reference Point
     # Convert ref_lalo if existed, to ref_yx, and use ref_yx for the following
     # ref_yx is referenced to input data coverage, not subseted area for display
-    if inps.ref_lalo and inps.geo_box:
-        inps.ref_yx = [coord.lalo2yx(inps.ref_lalo[0], coord_type='lat'),
-                       coord.lalo2yx(inps.ref_lalo[1], coord_type='lon')]
+    if inps.ref_lalo:
         vprint('input reference point in lat/lon: {}'.format(inps.ref_lalo))
-        vprint('input reference point in y  /x  : {}'.format(inps.ref_yx))
+        if not inps.geo_box and not coord.lookup_file:
+            print('WARNING: --ref-lalo is NOT supported when 1) file is radar-coded AND 2) no lookup table file found')
+            print('    --> ignore the --ref-lalo input and continue.')
+            inps.ref_lalo = []
+
+        else:
+            inps.ref_yx = coord.geo2radar(inps.ref_lalo[0], inps.ref_lalo[1])
+            vprint('input reference point in y  /x  : {}'.format(inps.ref_yx))
 
     # ref_lalo
     if inps.ref_yx and inps.geo_box:


### PR DESCRIPTION
**Description of proposed changes**

+ colormap: add differences.cpt from cpt-city
+ view:
   - support --ref-lalo for radar-coded file if lookup table file exists
   - add --math option
+ tropo_pyaps3:
   - add Herbach et al. (2020) to the recommended reference for ERA-5
   - bugfix of date info grabbing while downloading GRIB files (https://groups.google.com/g/mintpy/c/BGBotnCE1hA)
+ objects.insar_vs_gps.plot_insar_vs_gps_scatter(): update to the new GPS CSV file format
+ plot_transection.py: add --vlim option to be able to customize the display color range of maps, to facilitate the profile selection.
+ circle CI:
   - use full path for pip to avoid warning
   - use mamba to replace conda for dependency solving and installation to speedup
   - increase the no output timeout from 10m to 30m

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.