### PR TITLE
circleci: use generic fortran compiler syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             ./Miniconda3-latest-Linux-x86_64.sh -b -p ${HOME}/tools/miniconda3
             ${HOME}/tools/miniconda3/bin/conda init bash
             ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
-            ${HOME}/tools/miniconda3/bin/conda install mamba --yes
+            ${HOME}/tools/miniconda3/bin/conda install -c conda-forge --yes mamba
 
       - run:
           name: Installing MintPy, PyAPS and PySolid
@@ -39,8 +39,8 @@ jobs:
             git clone https://github.com/insarlab/PySolid.git ${HOME}/tools/PySolid
             # install dependencies
             source activate root
-            ${HOME}/tools/miniconda3/bin/mamba install --yes --file ${MINTPY_HOME}/docs/conda.txt gdal>=3 gfortran_linux-64
-            ${HOME}/tools/miniconda3/bin/pip install git+https://github.com/tylere/pykml.git
+            mamba install --verbose --yes --file ${MINTPY_HOME}/docs/conda.txt gdal>=3 fortran-compiler
+            pip install git+https://github.com/tylere/pykml.git
             # compile pysolid Fortran code
             cd ${HOME}/tools/PySolid/pysolid
             f2py -c -m solid solid.for


### PR DESCRIPTION
**Description of proposed changes**

+ use mamba install fortran-compiler as the generic name/syntax to replace gfortran_linux-64 as the mamba seems can not recognize the later.
+ do not use detailed path because mamba in the non-default env is located in an alias in miniconda3/condabin/ and not the default path.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)