### PR TITLE
view: better handle multi-subplots with diff units

### DIFF
--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -538,7 +538,7 @@ def dload_grib_files(grib_files, tropo_model='ERA5', snwe=None):
 
     # Download grib file using PyAPS
     if len(date_list2dload) > 0:
-        hour = re.findall('\d{8}[-_]\d{2}', grib_files2dload[0])[0].replace('-', '_').split('_')[1]
+        hour = re.findall('\d{8}[-_]\d{2}', os.path.basename(grib_files2dload[0]))[0].replace('-', '_').split('_')[1]
         grib_dir = os.path.dirname(grib_files2dload[0])
 
         # try 3 times to download, then use whatever downloaded to calculate delay
@@ -628,7 +628,7 @@ def calc_delay_timeseries(inps):
             print('1) output file exists and is newer than all GRIB files.')
 
             # check dataset size in space / time
-            date_list = [str(re.findall('\d{8}', i)[0]) for i in grib_files]
+            date_list = [str(re.findall('\d{8}', os.path.basename(i))[0]) for i in grib_files]
             if (get_dataset_size(tropo_file) != get_dataset_size(geom_file) 
                     or any(i not in timeseries(tropo_file).get_date_list() for i in date_list)):
                 flag = 'run'
@@ -698,7 +698,7 @@ def calc_delay_timeseries(inps):
     # instantiate time-series
     length, width = int(atr['LENGTH']), int(atr['WIDTH'])
     num_date = len(inps.grib_files)
-    date_list = [str(re.findall('\d{8}', i)[0]) for i in inps.grib_files]
+    date_list = [str(re.findall('\d{8}', os.path.basename(i))[0]) for i in inps.grib_files]
     dates = np.array(date_list, dtype=np.string_)
     ds_name_dict = {
         "date"       : [dates.dtype, (num_date,), dates],

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -726,9 +726,15 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             atr = giantTimeseries(fname).get_metadata()
         elif k == 'giantIfgramStack':
             atr = giantIfgramStack(fname).get_metadata()
+
         elif len(atr) > 0 and 'WIDTH' in atr.keys():
-            # use the attribute at root level
-            pass
+            # use the attribute at root level, which is already read from the begining
+
+            # grab attribute of dataset if specified, e.g. UNIT, no-data value, etc.
+            if datasetName and datasetName in d1_list:
+                with h5py.File(fname, 'r') as f:
+                    atr.update(dict(f[datasetName].attrs))
+
         else:
             # otherwise, grab the list of attrs in HDF5 file
             # and use the attrs with most items


### PR DESCRIPTION
**Description of proposed changes**

+ utils.readfile.read_attribute: grabbing HDF5 dataset attributes if datasetName arg is specified, to get the dataset specific attributes, e.g. unit, no-data value, fill value, etc.

+ view: better handle multi-subplots with different units, e.g. the velocity file with complex functions including periodic phase data #564
   - ignore "Std" suffix while grabbing the dataset family list, to better check whether dset list shares the same unit
   - remove "velocity" from the special file type list while checking `same_unit4all_subplot` because of the recent updates to velocity file with complex time funcs.
   - if not `same_unit4all_subplot`, printout warning message and set disp_unit to None for more accurate printout msg
   - add data unit whenever it's possible if showing colorbar for each subplot.

+ tropo_pyaps3: bugfix for potential path conflict while calling findall to grab date/hour info by use the grib file basename (user forum https://groups.google.com/g/mintpy/c/BGBotnCE1hA)

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.