### PR TITLE
resample: support using isce-2 lat/lon.rdr file

### DIFF
--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -41,6 +41,8 @@ EXAMPLE = """example:
   # interative polygon selection of region of interest
   # useful for custom mask generation in unwrap error correction with bridging
   generate_mask.py  waterMask.h5 -m 0.5 --roipoly
+  generate_mask.py  azOff.h5 --roipoly --view-cmd "-v -0.1 0.1"
+  generate_mask.py  velocity.h5 --roipoly --view-cmd "--dem ./inputs/geometryGeo.h5 --contour-step 100 --contour-smooth 0.0"
 """
 
 
@@ -73,6 +75,7 @@ def create_parser():
                      help='exclude area defined by an circle (x, y, radius) in pixel number')
     aoi.add_argument('--in-circle', dest='in_circle', nargs=3, type=int, metavar=('X', 'Y', 'RADIUS'),
                      help='include area defined by an circle (x, y, radius) in pixel number')
+
     # AOI defined by file
     aoi.add_argument('--base', dest='base_file', type=str,
                      help='exclude pixels == base_value\n'
@@ -82,9 +85,13 @@ def create_parser():
                           'i.e.: --base inputs/geometryRadar.h5 --base-dset shadow --base-value 1')
     aoi.add_argument('--base-value', dest='base_value', type=float, default=0,
                      help='value of pixels in base_file to be excluded.\nDefault: 0')
+
     # AOI manual selected
     aoi.add_argument('--roipoly', action='store_true',
                      help='Interactive polygonal region of interest (ROI) selection.')
+    aoi.add_argument('--view-cmd', dest='view_cmd', type=str,
+                     help='view.py command to facilitate the AOI selection.'
+                          'E.g. "-v -0.1 0.1"')
 
     # special type of mask
     parser.add_argument('--nonzero', dest='nonzero', action='store_true',
@@ -204,7 +211,7 @@ def create_threshold_mask(inps):
     # interactively select polygonal region of interest (ROI)
     if inps.roipoly:
         from mintpy.utils import plot_ext
-        poly_mask = plot_ext.get_poly_mask(inps.file, datasetName=inps.dset)
+        poly_mask = plot_ext.get_poly_mask(inps.file, datasetName=inps.dset, view_cmd=inps.view_cmd)
         if poly_mask is not None:
             mask *= poly_mask
 

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -297,7 +297,7 @@ def estimate_timeseries(A, B, tbase_diff, ifgram, weight_sqrt=None, min_norm_vel
 
     opt 1: X = np.dot(np.dot(numpy.linalg.inv(np.dot(B.T, B)), B.T), ifgram)
     opt 2: X = np.dot(numpy.linalg.pinv(B), ifgram)
-    opt 3: X = np.dot(scipy.linalg.pinv2(B), ifgram)
+    opt 3: X = np.dot(scipy.linalg.pinv(B), ifgram)
     opt 4: X = scipy.linalg.lstsq(B, ifgram)[0] [recommend and used]
 
     opt 4 supports weight.

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -85,7 +85,7 @@ def create_parser():
     fig.add_argument('--mc', '--markercolor', dest='markercolor',
                      default='orange', help='marker color')
     fig.add_argument('--ms', '--markersize', dest='markersize',
-                     type=int, default=16, help='marker size in points')
+                     type=int, default=12, help='marker size in points')
     fig.add_argument('--every-year', dest='every_year', type=int,
                      default=1, help='number of years per major tick on x-axis')
 

--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -78,7 +78,7 @@ def filter_data(data, filter_type, filter_par=None):
     Inputs:
         data        : 2D np.array, matrix to be filtered
         filter_type : string, filter type
-        filter_par  : string, optional, parameter for low/high pass filter
+        filter_par  : (list of) int/float, optional, parameter for low/high pass filter
                       for low/highpass_avg, it's kernel size in int
                       for low/highpass_gaussain, it's sigma in float
                       for double_difference, it's local and regional kernel sizes in int
@@ -88,8 +88,10 @@ def filter_data(data, filter_type, filter_par=None):
 
     if filter_type == "sobel":
         data_filt = filters.sobel(data)
+
     elif filter_type == "roberts":
         data_filt = filters.roberts(data)
+
     elif filter_type == "canny":
         data_filt = feature.canny(data)
 
@@ -97,6 +99,7 @@ def filter_data(data, filter_type, filter_par=None):
         p = int(filter_par)
         kernel = np.ones((p, p), np.float32)/(p*p)
         data_filt = ndimage.convolve(data, kernel)
+
     elif filter_type == "highpass_avg":
         p = int(filter_par)
         kernel = np.ones((p, p), np.float32)/(p*p)
@@ -105,6 +108,7 @@ def filter_data(data, filter_type, filter_par=None):
 
     elif filter_type == "lowpass_gaussian":
         data_filt = filters.gaussian(data, sigma=filter_par)
+
     elif filter_type == "highpass_gaussian":
         lp_data = filters.gaussian(data, sigma=filter_par)
         data_filt = data - lp_data
@@ -144,7 +148,7 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
         fname       : string, name/path of file to be filtered
         ds_names    : list of string, datasets of interest
         filter_type : string, filter type
-        filter_par  : string, optional, parameter for low/high pass filter
+        filter_par  : (list of) int/float, optional, parameter for low/high pass filter
                       for low/highpass_avg, it's kernel size in int
                       for low/highpass_gaussain, it's sigma in float
                       for double_difference, it's local and regional kernel sizes in int
@@ -156,22 +160,27 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
     atr = readfile.read_attribute(fname)
     k = atr['FILE_TYPE']
     msg = 'filtering {} file: {} using {} filter'.format(k, fname, filter_type)
+
     if filter_type.endswith('avg'):
         if not filter_par:
             filter_par = 5
-        else:
+        elif isinstance(filter_par, list):
             filter_par = filter_par[0]
+        filter_par = int(filter_par)
         msg += ' with kernel size of {}'.format(filter_par)
+
     elif filter_type.endswith('gaussian'):
         if not filter_par:
             filter_par = 3.0
-        else:
+        elif isinstance(filter_par, list):
             filter_par = filter_par[0]
+        filter_par = float(filter_par)
         msg += ' with sigma of {:.1f}'.format(filter_par)
+
     elif filter_type == 'double_difference':
         if not filter_par:
-            filter_par = [1,10]
-        local, regional = filter_par
+            filter_par = [1, 10]
+        local, regional = int(filter_par[0]), int(filter_par[1])
         msg += ' with local/regional kernel sizes of {}/{}'.format(local, regional)
     print(msg)
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -331,7 +331,7 @@ def auto_shared_lalo_location(axs, loc=(1,0,0,1), flatten=False):
 
 
 def auto_colormap_name(metadata, cmap_name=None, datasetName=None, print_msg=True):
-    gray_dataset_key_words = ['coherence', 'temporal_coherence',
+    gray_dataset_key_words = ['coherence', 'temporalCoherence',
                               '.cor', '.mli', '.slc', '.amp', '.ramp']
     if not cmap_name:
         if any(i in gray_dataset_key_words for i in [metadata['FILE_TYPE'],
@@ -460,7 +460,7 @@ def plot_coherence_history(ax, date12List, cohList, p_dict={}):
     if 'fontsize'    not in p_dict.keys():   p_dict['fontsize']    = 12
     if 'linewidth'   not in p_dict.keys():   p_dict['linewidth']   = 2
     if 'markercolor' not in p_dict.keys():   p_dict['markercolor'] = 'orange'
-    if 'markersize'  not in p_dict.keys():   p_dict['markersize']  = 16
+    if 'markersize'  not in p_dict.keys():   p_dict['markersize']  = 12
     if 'disp_title'  not in p_dict.keys():   p_dict['disp_title']  = True
     if 'every_year'  not in p_dict.keys():   p_dict['every_year']  = 1
     if 'vlim'        not in p_dict.keys():   p_dict['vlim']        = [0.2, 1.0]
@@ -519,7 +519,7 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     if 'fontsize'    not in p_dict.keys():  p_dict['fontsize']    = 12
     if 'linewidth'   not in p_dict.keys():  p_dict['linewidth']   = 2
     if 'markercolor' not in p_dict.keys():  p_dict['markercolor'] = 'orange'
-    if 'markersize'  not in p_dict.keys():  p_dict['markersize']  = 16
+    if 'markersize'  not in p_dict.keys():  p_dict['markersize']  = 12
 
     # For colorful display of coherence
     if 'cohList'     not in p_dict.keys():  p_dict['cohList']     = None
@@ -691,7 +691,7 @@ def plot_perp_baseline_hist(ax, dateList, pbaseList, p_dict={}, dateList_drop=[]
     if 'fontsize'    not in p_dict.keys():   p_dict['fontsize']    = 12
     if 'linewidth'   not in p_dict.keys():   p_dict['linewidth']   = 2
     if 'markercolor' not in p_dict.keys():   p_dict['markercolor'] = 'orange'
-    if 'markersize'  not in p_dict.keys():   p_dict['markersize']  = 16
+    if 'markersize'  not in p_dict.keys():   p_dict['markersize']  = 12
     if 'disp_title'  not in p_dict.keys():   p_dict['disp_title']  = True
     if 'every_year'  not in p_dict.keys():   p_dict['every_year']  = 1
     transparency = 0.7
@@ -805,7 +805,7 @@ def plot_coherence_matrix(ax, date12List, cohList, date12List_drop=[], p_dict={}
     if 'fontsize'    not in p_dict.keys():   p_dict['fontsize']    = 12
     if 'linewidth'   not in p_dict.keys():   p_dict['linewidth']   = 2
     if 'markercolor' not in p_dict.keys():   p_dict['markercolor'] = 'orange'
-    if 'markersize'  not in p_dict.keys():   p_dict['markersize']  = 16
+    if 'markersize'  not in p_dict.keys():   p_dict['markersize']  = 12
     if 'disp_title'  not in p_dict.keys():   p_dict['disp_title']  = True
     if 'fig_title'   not in p_dict.keys():   p_dict['fig_title']   = '{} Matrix'.format(p_dict['ds_name'])
     if 'colormap'    not in p_dict.keys():   p_dict['colormap']    = 'jet'

--- a/mintpy/utils/plot_ext.py
+++ b/mintpy/utils/plot_ext.py
@@ -80,7 +80,7 @@ class SelectFromCollection(object):
         self.canvas.draw_idle()
 
 ## Utility script
-def get_poly_mask(fname, datasetName, print_msg=True):
+def get_poly_mask(fname, datasetName, print_msg=True, view_cmd=''):
     """Get mask of pixels within polygon from interactive selection
     Parameters: data : 2D np.array in size of (length, width)
     Returns:    mask : 2D np.arrat in size of (length, width) in np.bool_ format
@@ -89,9 +89,8 @@ def get_poly_mask(fname, datasetName, print_msg=True):
     cmd = 'view.py {} '.format(fname)
     if datasetName:
         cmd += ' {} '.format(datasetName)
-    ## Customized setting for plotting (temporarily for advanced users)
-    #cmd += ' --dem ./inputs/geometryGeo.h5 --contour-step 100 --contour-smooth 0.0 '
-    #cmd += ' -u cm -v -6 6 '
+    if view_cmd:
+        cmd += view_cmd
 
     d_v, atr ,inps = view.prep_slice(cmd)
     ax = plt.subplots(figsize=inps.fig_size)[1]


### PR DESCRIPTION
**Description of proposed changes**

+ objects.resample: Support geocoding using ISCE-2 lat/lon.rdr file directly, as an alternative of using mintpy geometry file in HDF5 format, to facilitate post-processing of single interferogram from isce. An example usage is shown in the function comment.

+ objects.ramp: add ignore_zero_value argument, to better handle offset field because zero value is common as no-data for phase but valid for offset.

+ generate_mask: add --view-cmd option for --roipoly to customize view.py display to facilitate the interactive polygon selection

+ ifgram_inversion: in the comment, replace pinv2 with pinv since scipy v1.7.0 has merged pinv2 into pinv and will deprecate pinv2, for notes in the future

+ spatial_filter: fix typo in the comments of filter_par with more tolerant handling of input filter_par var type: string or (list of) int/float

+ plot_network & utils.plot: reduce markersize for less crowd view

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.