### PR TITLE
readfile: default UNIT as "degrees" for geocoded isce xml

### DIFF
--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1225,6 +1225,7 @@ def read_isce_xml(fname):
             if abs(v_step) < 1. and abs(v_step) > 1e-7:
                 xmlDict['{}_STEP'.format(prefix)] = v_step
                 xmlDict['{}_FIRST'.format(prefix)] = v_first - v_step / 2.
+                xmlDict['{}_UNIT'.format(prefix)] = 'degrees'
 
     # PAMDataset, e.g. hgt.rdr.aux.xml
     elif root.tag == 'PAMDataset':


### PR DESCRIPTION
**Description of proposed changes**

This is related to loading datasets from the ISCE processor.

When reading files in geo-coordinates, the unit of the coordinates should be read from the XML file directly. For XML files from ISCE without this information, we set the default UNIT as "degrees".

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.