### PR TITLE
simple parallel plotting support in sbApp.py via joblib

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - dask-jobqueue>=0.3
   - defusedxml
   - h5py<3
+  - joblib
   - lxml
   - matplotlib
   - numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,7 @@ dask>=1.0
 dask-jobqueue>=0.3
 defusedxml
 h5py<3
+joblib
 lxml
 matplotlib
 numpy

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -84,6 +84,7 @@ def create_parser():
                       help='end processing at the named step (default: %(default)s)')
     step.add_argument('--dostep', dest='doStep', metavar='STEP',
                       help='run processing at the named step only')
+
     return parser
 
 
@@ -135,7 +136,7 @@ def cmd_line_parse(iargs=None):
             inps.customTemplateFile = None
 
     # check --plot
-    if iargs == ['--plot']:
+    if '--plot' in iargs:
         plot_only = True
         print('plot smallbaselineApp results without run.')
     else:
@@ -1179,12 +1180,15 @@ class TimeSeriesAnalysis:
 
         # run view
         start_time = time.time()
+
+        max_workers = self.template['mintpy.compute.numWorker']
+        num_cores, enable_parallel, Parallel, delayed = ut.check_parallel(len(iargs_list), print_msg=False, maxParallelNum=int(max_workers))
         
-        num_cores, enable_parallel, Parallel, delayed = ut.check_parallel(len(iargs_list))
-        #enable_parallel=False
-        if enable_parallel:
+        if enable_parallel and self.template['mintpy.compute.cluster']:
+            print("parallel processing using {} cores ...".format(num_cores))
             Parallel(n_jobs=num_cores)(delayed(_run_view)(iargs) for iargs in iargs_list)
         else:
+            print("serial processing ...")
             for iargs in iargs_list:
                _run_view(iargs)
 

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -1173,11 +1173,20 @@ class TimeSeriesAnalysis:
         opt_common = ['--dpi', '150', '--noverbose', '--nodisplay', '--update']
         iargs_list = [opt_common + iargs for iargs in iargs_list]
 
-        # run view
-        start_time = time.time()
-        for iargs in iargs_list:
+        def _run_view(iargs):
             print('view.py', ' '.join(iargs))
             mintpy.view.main(iargs)
+
+        # run view
+        start_time = time.time()
+        
+        num_cores, enable_parallel, Parallel, delayed = ut.check_parallel(len(iargs_list))
+        #enable_parallel=False
+        if enable_parallel:
+            Parallel(n_jobs=num_cores)(delayed(_run_view)(iargs) for iargs in iargs_list)
+        else:
+            for iargs in iargs_list:
+               _run_view(iargs)
 
         # copy text files to pic
         print('copy *.txt files into ./pic directory.')

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -167,7 +167,7 @@ def cmd_line_parse(iargs=None):
     # verbose print using --noverbose option
     global vprint
     vprint = print if inps.print_msg else lambda *args, **kwargs: None
-
+    # print view.py command line if --noverbose (used in smallbaselineApp.py)
     if not inps.print_msg:
         print('view.py', ' '.join(iargs))
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -168,6 +168,9 @@ def cmd_line_parse(iargs=None):
     global vprint
     vprint = print if inps.print_msg else lambda *args, **kwargs: None
 
+    if not inps.print_msg:
+        print('view.py', ' '.join(iargs))
+
     if inps.disp_setting_file:
         inps = update_inps_with_display_setting_file(inps, inps.disp_setting_file)
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ def do_setup():
             "dask-jobqueue>=0.3",
             "defusedxml",
             "h5py",
+            "joblib",
             "lxml",
             "matplotlib",
             "numpy",


### PR DESCRIPTION
Added support for plotting MintPy figures in parallel in `smallbaselineApp.py`. Previous iterations did this using a bash script, but this is now implemented in pure python (#538) through the use of the `joblib` library. Parallel resources can be configured and set through modification of the `mintpy.compute` options in `smallbaselineApp.cfg`.

**Reminders**

- [x] Fix #607
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.