### PR TITLE
generate_mask: mask pixel clusters by size

### DIFF
--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -25,6 +25,9 @@ EXAMPLE = """example:
   # exlcude area by min/max value and/or subset in row/col direction
   generate_mask.py  081018_090118.unw -m 3 -M 8 -y 100 700 -x 200 800 -o mask_1.h5
 
+  # exlcude pixel cluster based on minimum number of pixels
+  generate_mask.py  maskTempCoh.h5 -p 10 mask_1.h5
+
   # exclude / include an circular area
   generate_mask.py  maskTempCoh.h5 -m 0.5 --ex-circle 230 283 100 -o maskTempCoh_nonDef.h5
   generate_mask.py  maskTempCoh.h5 -m 0.5 --in-circle 230 283 100 -o maskTempCoh_Def.h5

--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -184,7 +184,7 @@ def create_threshold_mask(inps):
     if inps.vmax is not None:
         mask[nanmask] *= ~(data[nanmask] > inps.vmax)
         print('exclude pixels with value > %s' % str(inps.vmax))
-    
+
     if inps.minpixels is not None:
         from scipy import ndimage
         data_regions = data.copy()
@@ -199,7 +199,7 @@ def create_threshold_mask(inps):
             if val < inps.minpixels:
                 subset = data_labeled[loc].view()
                 subset[subset==i] = 0.
-        
+
         mask[nanmask] *= ~(data_labeled[nanmask] != 0.)
         print('exclude all pixel clusters with less than %s pixels' % str(inps.minpixels))
 

--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -186,21 +186,9 @@ def create_threshold_mask(inps):
         print('exclude pixels with value > %s' % str(inps.vmax))
 
     if inps.minpixels is not None:
-        from scipy import ndimage
-        data_regions = data.copy()
-        data_regions[~nanmask] = 1.
-
-        data_labeled, num_features = ndimage.label(data_regions)
-        index = np.arange(1,num_features+1)
-        locs = ndimage.find_objects(data_labeled)
-        sums = ndimage.sum(data_regions, labels=data_labeled, index=index)
-
-        for i, loc, val in zip(index, locs, sums):
-            if val < inps.minpixels:
-                subset = data_labeled[loc].view()
-                subset[subset==i] = 0.
-
-        mask[nanmask] *= ~(data_labeled[nanmask] != 0.)
+        from skimage.morphology import remove_small_objects
+        removed = remove_small_objects(data.astype(bool), inps.minpixels, connectivity=1)
+        mask[nanmask] *= removed[nanmask]
         print('exclude all pixel clusters with less than %s pixels' % str(inps.minpixels))
 
     # subset in Y

--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -64,6 +64,8 @@ def create_parser():
                         help='minimum value for selected pixels')
     parser.add_argument('-M', '--max', dest='vmax', type=float,
                         help='maximum value for selected pixels')
+    parser.add_argument('-c', '--clustersize', dest='csize', type=int,
+                        help='minimum cluster size when using velocity dataset clustering')
 
     aoi = parser.add_argument_group('AOI', 'define secondary area of interest')
     # AOI defined by parameters in command line
@@ -179,6 +181,16 @@ def create_threshold_mask(inps):
     if inps.vmax is not None:
         mask[nanmask] *= ~(data[nanmask] > inps.vmax)
         print('exclude pixels with value > %s' % str(inps.vmax))
+    
+    if inps.csize is not None:
+        from scipy import ndimage
+        data_regions = data.copy()
+        data_regions[~nanmask] = 1
+
+        data_labeled, num_features = ndimage.label(data)
+        index = np.arange(num_features+1)
+        sums = ndimage.sum(data_regions, labels=data_labeled, index=index)
+        # subset
 
     # subset in Y
     if inps.subset_y is not None:

--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -67,8 +67,8 @@ def create_parser():
                         help='minimum value for selected pixels')
     parser.add_argument('-M', '--max', dest='vmax', type=float,
                         help='maximum value for selected pixels')
-    parser.add_argument('-p', '--minpixels', dest='minpixels', type=int,
-                        help='minimum cluster size in pixels')
+    parser.add_argument('-p','--mp','--minpixels', dest='minpixels', type=int,
+                        help='minimum cluster size in pixels, to remove small pixel clusters.')
 
     aoi = parser.add_argument_group('AOI', 'define secondary area of interest')
     # AOI defined by parameters in command line
@@ -185,11 +185,12 @@ def create_threshold_mask(inps):
         mask[nanmask] *= ~(data[nanmask] > inps.vmax)
         print('exclude pixels with value > %s' % str(inps.vmax))
 
+    # remove small pixel clusters
     if inps.minpixels is not None:
         from skimage.morphology import remove_small_objects
-        removed = remove_small_objects(data.astype(bool), inps.minpixels, connectivity=1)
-        mask[nanmask] *= removed[nanmask]
-        print('exclude all pixel clusters with less than %s pixels' % str(inps.minpixels))
+        num_pixel = np.sum(mask)
+        mask = remove_small_objects(mask, inps.minpixels, connectivity=1)
+        print('exclude pixel clusters with size < %d pixels: remove %d pixels' % (inps.minpixels, num_pixel-np.sum(mask)))
 
     # subset in Y
     if inps.subset_y is not None:


### PR DESCRIPTION
**Description of proposed changes**
When looking for local deformation signals in MintPy results, it is useful to mask the output velocity.h5 by a quality metric (i.e. temporal coherence) then identify clusters of pixels that are larger than a certain size threshold. This pull request would add functionality to `generate_masks.py` which would enable the user to mask out pixel clusters that contain less than a given number of pixels.

**Changes**
- generate_mask
    - adds minpixels (-p) argument
    - adds pixel cluster size masking

**Reminders**
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
