### PR TITLE
view: bugfix in search_dataset_input()

### DIFF
--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -32,8 +32,8 @@ REFERENCE = """references:
   Parameters and Uncertainties: A Bayesian Approach, Geochemistry, Geophysics, Geosystems, 19, 
   doi:10.1029/2018GC007585.
 
-  Yunjun, Z., F. Amelung, Y. Aoki, (2021), Imaging the Hydrothermal System of Kirishima Volcanic Complex, 
-  Japan from ALOS-1/2 InSAR time-series, (in prep.).
+  Yunjun, Z., Amelung, F., & Aoki, Y. (2021), Imaging the hydrothermal system of Kirishima volcanic complex 
+  with L-band InSAR time series, Geophysical Research Letters, 48(11), e2021GL092879. doi:10.1029/2021GL092879
 """
 
 def create_parser():
@@ -55,9 +55,9 @@ def create_parser():
     parser.add_argument('--out-dir', dest='outdir',
                         help='custom output directory, ONLY IF --output is not specified.')
     parser.add_argument('--ellipsoid2geoid', action='store_true',
-                        help='Convert the height of ellipsoid to geoid using geoidheight module\n'+
-                             'Download/install geoidheight as below:\n'+
-                             'https://github.com/geodesymiami/Yunjun_et_al-2019-Kirishima/GBIS')
+                        help='Convert the height of ellipsoid to geoid using "geoidheight" module\n'+
+                             'Download & install geoidheight as below:\n'+
+                             'https://github.com/geodesymiami/2021_Kirishima')
     return parser
 
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -761,6 +761,9 @@ def read_input_file_info(inps):
 
 def search_dataset_input(allList, inList=[], inNumList=[], search_dset=True):
     """Get dataset(es) from input dataset / dataset_num"""
+    # make a copy to avoid weird variable behavior
+    inNumList = [x for x in inNumList]
+
     # inList --> inNumList --> outNumList --> outList
     if inList:
         if isinstance(inList, str):

--- a/test/configs/SanFranSenDT42.txt
+++ b/test/configs/SanFranSenDT42.txt
@@ -1,8 +1,9 @@
 # vim: set filetype=cfg:
-mintpy.load.processor       = aria  #[isce, aria, snap, gamma, roipac], auto for isce
-mintpy.load.autoPath        = yes
-mintpy.load.xstep           = 2
-mintpy.load.ystep           = 2
+mintpy.compute.cluster  = local
+mintpy.load.processor   = aria  #[isce, aria, snap, gamma, roipac], auto for isce
+mintpy.load.autoPath    = yes
+mintpy.load.xstep       = 2
+mintpy.load.ystep       = 2
 
 mintpy.reference.lalo       = 37.69, -122.07
 mintpy.unwrapError.method   = bridging

--- a/test/configs/WCapeSenAT29.txt
+++ b/test/configs/WCapeSenAT29.txt
@@ -1,5 +1,6 @@
 # vim: set filetype=cfg:
 ##-------------------------------- MintPy -----------------------------##
+mintpy.compute.cluster  = local
 ########## 1. Load Data (--load to exit after this step)
 ## load_data.py -H to check more details and example inputs.
 mintpy.load.processor   = snap


### PR DESCRIPTION
**Description of proposed changes**

+ view: bugfix in search_dataset_input() by making a local copy of the input inNumList arg, to avoid weird initiation behavior during multiple calls from save_roipac.py, as reported in https://groups.google.com/g/mintpy/c/fL5PUB0kMdU

+ utils.read_timeseries_lalo/yx():
   - add method arg to switch between mean and median
   - return the dispersity time-series if win_size > 1, STD for mean, MAD for median.

+ test/config: turn on dask parallel for SanFran & WCape datasets

+ save_gbis: update reference of Yunjun et al. (2021)

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.