### PR TITLE
read_attr: check existing FILE_TYPE for HDF5 file

### DIFF
--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -709,9 +709,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
 
         # FILE_TYPE - k
         py2_mintpy_stack_files = ['interferograms', 'coherence', 'wrapped'] #obsolete mintpy format
-        if 'FILE_TYPE' in atr:
-            k = atr['FILE_TYPE']
-        elif any(i in d1_list for i in ['unwrapPhase', 'azimuthOffset']):
+        if any(i in d1_list for i in ['unwrapPhase', 'azimuthOffset']):
             k = 'ifgramStack'
         elif any(i in d1_list for i in ['height', 'latitude', 'azimuthCoord']):
             k = 'geometry'
@@ -727,6 +725,8 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             k = 'giantIfgramStack'
         elif any(i in g1_list for i in py2_mintpy_stack_files):
             k = list(set(g1_list) & set(py2_mintpy_stack_files))[0]
+        elif 'FILE_TYPE' in atr:
+            k = atr['FILE_TYPE']
         elif len(d1_list) > 0:
             k = d1_list[0]
         elif len(g1_list) > 0:

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -708,6 +708,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             d1_list = [i for i in f.keys() if isinstance(f[i], h5py.Dataset) and f[i].ndim >= 2]
 
         # FILE_TYPE - k
+        # pre-defined/known dataset/group names > existing FILE_TYPE > exsiting dataset/group names
         py2_mintpy_stack_files = ['interferograms', 'coherence', 'wrapped'] #obsolete mintpy format
         if any(i in d1_list for i in ['unwrapPhase', 'azimuthOffset']):
             k = 'ifgramStack'

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -709,7 +709,9 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
 
         # FILE_TYPE - k
         py2_mintpy_stack_files = ['interferograms', 'coherence', 'wrapped'] #obsolete mintpy format
-        if any(i in d1_list for i in ['unwrapPhase', 'azimuthOffset']):
+        if 'FILE_TYPE' in atr:
+            k = atr['FILE_TYPE']
+        elif any(i in d1_list for i in ['unwrapPhase', 'azimuthOffset']):
             k = 'ifgramStack'
         elif any(i in d1_list for i in ['height', 'latitude', 'azimuthCoord']):
             k = 'geometry'


### PR DESCRIPTION
**Description of proposed changes**

When I run info.py, the "FILE_TYPE" is guessed based on dataset name and if a stack with different naming is called, some options like --date do not work. 
This change proposes to read 'FILT_TYPE' from the stack attributes if exists.

**Reminders**

- [x] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.