### PR TITLE
generate_mask: mask velocity based on velocityStd

### DIFF
--- a/mintpy/generate_mask.py
+++ b/mintpy/generate_mask.py
@@ -28,9 +28,9 @@ EXAMPLE = """example:
   # exlcude pixel cluster based on minimum number of pixels
   generate_mask.py  maskTempCoh.h5 -p 10 mask_1.h5
 
-  # exclude pixels in velocity dataset that don't satisfy |velocity|>a*velocityStd
-  generate_mask.py  velocity.h5 --vstd (uses default value of 2 for a)
-  generate_mask.py  velocity.h5 --vstd --vstd-num 3 (sets a to 3)
+  # exclude pixels with large velocity STD: |velocity| > cutoff (2 by default) * velocityStd
+  generate_mask.py  velocity.h5 --vstd
+  generate_mask.py  velocity.h5 --vstd --vstd-num 3
 
   # exclude / include an circular area
   generate_mask.py  maskTempCoh.h5 -m 0.5 --ex-circle 230 283 100 -o maskTempCoh_nonDef.h5


### PR DESCRIPTION
References issue #613
Generate mask based on formula |velocity|>2*velocitStd

**Description of proposed changes**
- adds --vstd argument
- adds mask generation functionality in create_threshold_mask()

**Reminders**
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.