### PR TITLE
tropo_pyaps3: add default value of degrees for Y_UNIT attribute

### DIFF
--- a/docs/api/colormaps.md
+++ b/docs/api/colormaps.md
@@ -2,7 +2,7 @@
 
 MintPy support the following colormaps:
 
-+ [Matplotlib colormaps](https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html)
++ [Matplotlib colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html)
 + Custom colormaps: `cmy`, `dismph`, and `romanian`
 + Custom colormaps in **.cpt** (color palette tables) format. To add your own colormap, drop the corresponding .cpt file in `$MINTPY/mintpy/data/colormaps`.
 

--- a/mintpy/prep_snap.py
+++ b/mintpy/prep_snap.py
@@ -239,6 +239,8 @@ def extract_snap_metadata(fname):
     transform = [str(float(i)) for i in transform]
     atr["X_STEP"], atr["Y_STEP"] = transform[0], transform[3]
     atr["X_FIRST"], atr["Y_FIRST"] = transform[4], transform[5]
+    atr["X_UNIT"] = "degrees"
+    atr["Y_UNIT"] = "degrees"
 
     # convert all key value in string format to ensure the --update checking in write_rsc()
     for key, value in atr.items():

--- a/mintpy/save_kmz.py
+++ b/mintpy/save_kmz.py
@@ -44,7 +44,7 @@ EXAMPLE = """example:
   save_kmz.py geo/geo_timeseries_ERA5_demErr.h5 20200505_20200517
 
   save_kmz.py geo/geo_ifgramStack.h5 20101120_20110220
-  save_kmz.py geo/geo_geometryRadar.h5 --cbar-label Elevation
+  save_kmz.py geo/geo_geometryRadar.h5 height --cbar-label Elevation
 
   # save full resolution velocity in radar-coordinates
   # for ISCE products (with lookup table in radar coordinates) ONLY

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -454,7 +454,8 @@ def get_bounding_box(meta, geom_file=None):
 
         # 'Y_FIRST' not in 'degree'
         # e.g. meters for UTM projection from ASF HyP3
-        if not meta['Y_UNIT'].lower().startswith('deg'):
+        y_unit = meta.get('Y_UNIT', 'degrees').lower()
+        if not y_unit.startswith('deg'):
             lat0, lon0 = ut.to_latlon(meta['OG_FILE_PATH'], lon0, lat0)
             lat1, lon1 = ut.to_latlon(meta['OG_FILE_PATH'], lon1, lat1)
 


### PR DESCRIPTION
**Description of proposed changes**

+ prep_snap: hardwire attributes X/Y_UNIT = 'degrees'
+ tropo_pyaps3: add default value of degrees for Y_UNIT attribute
+ save_kmz: fix typo in the examplage usagge
+ docs/api/colormaps: update to the latest link of matplotlib colormaps

**Reminders**

- [x] Fix https://github.com/insarlab/MintPy/discussions/617
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.