### PR TITLE
limit NUM_THREADS=1 for numpy/scipy.linalg to save CPU usage

### DIFF
--- a/docs/dask.md
+++ b/docs/dask.md
@@ -26,7 +26,7 @@ Adjust options in the template file:
 
 ```cfg
 mintpy.compute.cluster    = local
-mintpy.compute.numWorkers = auto   #auto for 4 (local) or 40 (non-local), set to "all" to use all available cores.
+mintpy.compute.numWorkers = 4     #[int > 1 / all], auto for 4 (local) or 40 (slurm / pbs / lsf), set to "all" to use all available cores.
 ```
 
 and feed the template file to the script:
@@ -61,7 +61,7 @@ To show the run time improvement, we test three datasets (South Isabela, Fernand
 
 As of Jun 2020, we have tried on one HPC system where local cluster worked on the head node but not on compute nodes. We attribute this to HPC configuration but don't know what exactly is the cause.
 
-## 2. non-local cluster on HPC - work in progress ##
+## 2. non-local cluster on HPC [work in progress] ##
 
 **Note:** This has not been tested much. SlurmCluster works for us using a shared queue (on XSEDE's comet at SDSC) but not LSFCluster (on Miami's pegasus). We believe this is caused by the HPC configuration, but we don't know by what. Please tell us if you have an idea.   
 
@@ -93,9 +93,9 @@ ifgram_inversion.py inputs/ifgramStack.h5 --cluster lsf   --config lsf   --num-w
 Adjust options in the template file as below
 
 ```cfg
-mintpy.compute.cluster   = auto #[local / lsf / pbs / slurm / no], auto for no, job scheduler in your HPC system
-mintpy.compute.numWorker = auto #[int > 1], number of worker to submit and run, auto for 4 (local) or 40 (non-local)
-mintpy.compute.config    = auto #[name / no], name of the configuration section in YAML file, auto for no (to use the same name as the cluster type specified above)
+mintpy.compute.cluster   = slurm #[local / lsf / pbs / slurm / none], auto for none, job scheduler in your HPC system
+mintpy.compute.numWorker = 40    #[int > 1], auto for 4 (local) or 40 (slurm / pbs / lsf), number of workers to use
+mintpy.compute.config    = auto  #[name / no], auto for none (to use the same name as the cluster type specified above), name of the configuration section in YAML file
 ```
 
 and feed the template file to the script:

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -8,7 +8,7 @@ mintpy.compute.maxMemory = auto #[float > 0.0], auto for 4, max memory to alloca
 ## numWorker = all  to use all locally available cores (for cluster = local only)
 ## config    = none to rollback to the default name (same as the cluster type; for cluster != local)
 mintpy.compute.cluster   = auto #[local / slurm / pbs / lsf / none], auto for none, cluster type
-mintpy.compute.numWorker = auto #[int > 1 / all], auto for 4 (local) or 40 (non-local), num of workers
+mintpy.compute.numWorker = auto #[int > 1 / all], auto for 4 (local) or 40 (slurm / pbs / lsf), num of workers
 mintpy.compute.config    = auto #[none / slurm / pbs / lsf ], auto for none (same as cluster), config name
 
 
@@ -125,6 +125,7 @@ mintpy.reference.minCoherence  = auto   #[0.0-1.0], auto for 0.85, minimum coher
 
 ########## 4. correct_unwrap_error (optional)
 ## connected components (mintpy.load.connCompFile) are required for this step.
+## SNAPHU (Chem & Zebker,2001) is currently the only unwrapper that provides connected components as far as we know.
 ## reference: Yunjun et al. (2019, section 3)
 ## supported methods:
 ## a. phase_closure          - suitable for highly redundant network

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -517,6 +517,10 @@ def correct_dem_error(inps):
 
     start_time = time.time()
 
+    # limit the number of threads to 1
+    # for slight speedup and big CPU usage save
+    num_threads_dict = cluster.set_num_threads("1")
+
     ## 1. input info
 
     # 1.1 read date info
@@ -652,6 +656,9 @@ def correct_dem_error(inps):
                                    data=ts_res,
                                    datasetName='timeseries',
                                    block=block)
+
+    # roll back to the origial number of threads
+    cluster.roll_back_num_threads(num_threads_dict)
 
     # time info
     m, s = divmod(time.time()-start_time, 60)

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -67,6 +67,52 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
     return sub_boxes
 
 
+def set_num_threads(num_threads=None, print_msg=True):
+    """limit/set the number of threads for all environmental variables to the given value
+    and save/return the original value for backup purpose.
+    Link: https://stackoverflow.com/questions/30791550
+
+    Parameters: num_threads      - str, number of threads
+                                   Set to None to return without changing env variables
+    Returns:    num_threads_dict - dict, dictionary of the original number of threads
+    """
+
+    # grab the original number of threads
+    key_list = [
+        'OMP_NUM_THREADS',         # openmp
+        'OPENBLAS_NUM_THREADS',    # openblas
+        'MKL_NUM_THREADS',         # mkl
+        'VECLIB_MAXIMUM_THREADS',  # accelerate
+        'NUMEXPR_NUM_THREADS',     # numexpr
+    ]
+    key_list = [x for x in key_list if x in os.environ.keys()]
+    if print_msg:
+        print('save the original value of {}'.format(key_list))
+
+    num_threads_dict = {}
+    for key in key_list:
+        num_threads_dict[key] = os.environ[key]
+
+    # change the env variables
+    if num_threads:
+        num_threads = str(num_threads)
+        for key in key_list:
+            os.environ[key] = num_threads
+            if print_msg:
+                print('set {} = {}'.format(key, num_threads))
+
+    return num_threads_dict
+
+
+def roll_back_num_threads(num_threads_dict, print_msg=True):
+    """Set back the number of threads for all environmental variables."""
+    for key, value in num_threads_dict.items():
+        os.environ[key] = value
+        if print_msg:
+            print('set {} = {}'.format(key, value))
+    return
+
+
 
 ############################## Beginning of DaskCluster class ##############################
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -350,6 +350,7 @@ def auto_shared_lalo_location(axs, loc=(1,0,0,1), flatten=False):
 
 def auto_colormap_name(metadata, cmap_name=None, datasetName=None, print_msg=True):
     gray_dataset_key_words = ['coherence', 'temporalCoherence',
+                              'waterMask', 'shadowMask',
                               '.cor', '.mli', '.slc', '.amp', '.ramp']
     if not cmap_name:
         if any(i in gray_dataset_key_words for i in [metadata['FILE_TYPE'],

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1311,7 +1311,7 @@ def read_gdal_vrt(fname):
     # projection / coordinate unit
     srs = osr.SpatialReference(wkt=ds.GetProjection())
     srs_name = srs.GetName()
-    if 'UTM' in srs_name:
+    if srs_name and 'UTM' in srs_name:
         atr['UTM_ZONE'] = srs_name.split('UTM zone')[-1].strip()
         atr['X_UNIT'] = 'meters'
         atr['Y_UNIT'] = 'meters'

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1333,12 +1333,15 @@ def prepare4multi_subplots(inps, metadata):
     if len(inps.dsetFamilyList) == 1 and inps.atr['FILE_TYPE'] == 'ifgramStack':
         inps.date12List = sorted(list(set(x.split('-')[1] for x in inps.sliceList)))
 
-    ## calculate multilook_num
-    # ONLY IF:
-    #   inps.multilook is True (no --nomultilook input) AND
-    #   inps.multilook_num ==1 (no --multilook-num input)
-    # inps.multilook is used for this check ONLY
-    if inps.multilook and inps.multilook_num == 1:
+    if inps.multilook_num > 1 and inps.print_msg:
+        print('multilook {0} by {0} with nearest interpolation'.format(inps.multilook_num))
+
+    elif inps.multilook and inps.multilook_num == 1:
+        ## calculate multilook_num
+        # ONLY IF:
+        #   inps.multilook is True (no --nomultilook input) AND
+        #   inps.multilook_num ==1 (no --multilook-num input)
+        # inps.multilook is used for this check ONLY
         inps.multilook_num = pp.auto_multilook_num(inps.pix_box, inps.fig_row_num * inps.fig_col_num,
                                                    print_msg=inps.print_msg)
 


### PR DESCRIPTION
**Description of proposed changes**

Testing shows that numpy/scipy with OMP_NUM_THREADS > 1 does not help much on the computing time but uses significantly more CPU. The true fast way is **Dask with multiple workers + OMP_NUM_THREADS = 1**. Thus, I am setting all the relevant NUM_THREADS env variables to 1, in ifgram_inversion.py and dem_error.py, before running the big matrix inversion and roll back to the original values afterward.

Here is the test on `ifgram_inversion.py inputs/ifgramStack.h5 -t smallbaselineApp.cfg` on my laptop:
```
Dataset: SanFranSenDT42 version 1.x, patch 1 (505 x 510 x 1021) only
Machine 1: Mac (6 Intel i7 CPUs/cores with 2.6 GHz)
| dask (worker) | OMP_NUM_THREADS | Time used (sec) | CPU usage |
|   no   (0)    |        4        |      850        | 1 x 300%  |
|   no   (0)    |        1        |      930        | 1 x 100%  |
| local  (4)    |        4        |      580        | 4 x 250%  |
| local  (4)    |        1        |      420        | 4 x 100%  |

Machine 2: Linux local cluster (16 Intel E5 CPUs/cores with 2.4 GHz)
| dask (worker) | OMP_NUM_THREADS | Time used (sec) | CPU usage |
|   no   (0)    |        4        |     1400        | 1 x 400%  |
|   no   (0)    |        1        |     1250        | 1 x 100%  |
| local  (4)    |        4        |      750        | 4 x 320%  |
| local  (4)    |        1        |      500        | 4 x 100%  |
```

@falkamelung, @Ovec8hkin could you help to confirm: if this PR does give a **slight speedup and significant CPU save** on HPC? 
Update: I am merging this now, but it would still be useful if you could confirm on HPC.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.