### PR TITLE
read_attr(): UNIT bugfix for dsName with date info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ jobs:
             mkdir -p ${HOME}/tools
             cd ${HOME}/tools
             wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            chmod +x Miniconda3-latest-Linux-x86_64.sh
-            ./Miniconda3-latest-Linux-x86_64.sh -b -p ${HOME}/tools/miniconda3
+            bash Miniconda3-latest-Linux-x86_64.sh -b -p ${HOME}/tools/miniconda3
             ${HOME}/tools/miniconda3/bin/conda init bash
             ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
             ${HOME}/tools/miniconda3/bin/conda install -c conda-forge --yes mamba

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,8 +59,7 @@ Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) if you have 
 # use wget or curl to download in command line or click from the web brower
 # curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o Miniconda3-latest-MacOSX-x86_64.sh
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-chmod +x Miniconda3-latest-MacOSX-x86_64.sh
-./Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/tools/miniconda3
+bash Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/tools/miniconda3
 ~/tools/miniconda3/bin/conda init bash
 ```
 

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -303,6 +303,10 @@ def main(iargs=None):
     if inps.disp_fig:
         print('showing ...')
         plt.show()
+    else:
+        plt.close()
+
+    return
 
 
 ############################################################

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -750,10 +750,11 @@ class timeseriesViewer():
         self.ts_data, self.mask = read_timeseries_data(self)[0:2]
 
         # Figure 1 - Cumulative Displacement Map
-        self.figsize_img = pp.auto_figure_size(ds_shape=self.ts_data[0].shape[-2:],
-                                               disp_cbar=True,
-                                               disp_slider=True,
-                                               print_msg=self.print_msg)
+        if not self.figsize_img:
+            self.figsize_img = pp.auto_figure_size(ds_shape=self.ts_data[0].shape[-2:],
+                                                   disp_cbar=True,
+                                                   disp_slider=True,
+                                                   print_msg=self.print_msg)
         self.fig_img = plt.figure(self.figname_img, figsize=self.figsize_img)
 
         # Figure 1 - Axes 1 - Displacement Map

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -715,6 +715,10 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
 
     # HDF5 files
     if fext in ['.h5', '.he5']:
+        if datasetName:
+            # get rid of potential date info
+            datasetName = datasetName.split('-')[0]
+
         with h5py.File(fname, 'r') as f:
             atr = dict(f.attrs)
             g1_list = [i for i in f.keys() if isinstance(f[i], h5py.Group)]

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -84,7 +84,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
     # Read residual std text file
     print('read timeseries RMS from file: '+std_file)
     fc = np.loadtxt(std_file, dtype=bytes).astype(str)
-    std_list = fc[:, 1].astype(np.float).tolist()
+    std_list = fc[:, 1].astype(np.float32).tolist()
     date_list = list(fc[:, 0])
     return std_list, date_list
 
@@ -135,7 +135,7 @@ def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
     # Read residual RMS text file
     print('read timeseries residual RMS from file: '+rms_file)
     fc = np.loadtxt(rms_file, dtype=bytes).astype(str)
-    rms_list = fc[:, 1].astype(np.float).tolist()
+    rms_list = fc[:, 1].astype(np.float32).tolist()
     date_list = list(fc[:, 0])
     return rms_list, date_list, rms_file
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -330,8 +330,8 @@ def update_inps_with_file_metadata(inps, metadata):
                     raise ValueError('--lalo-label is NOT supported for projection: UTM')
 
             else:
-                vprint('WARNING: Un-recognized coordinate unit: {}'.format(inps.coord_unit))
-                vprint('    Switch to the native Y/X and continue to plot')
+                print('WARNING: Un-recognized coordinate unit: {}'.format(inps.coord_unit))
+                print('    Switch to the native Y/X and continue to plot')
                 inps.fig_coord = 'radar'
 
 
@@ -396,7 +396,7 @@ def update_data_with_plot_inps(data, metadata, inps):
             else:
                 msg = 'WARNING: input reference pixel ({}, {}) has either masked or NaN value!'.format(ref_y, ref_x)
                 msg += ' -> skip re-referencing.'
-                vprint(msg)
+                print(msg)
                 inps.ref_yx = None
 
         elif len(data.shape) == 3:
@@ -417,7 +417,7 @@ def update_data_with_plot_inps(data, metadata, inps):
             else:
                 msg = 'WARNING: input reference pixel ({}, {}) has either masked or NaN value!'.format(ref_y, ref_x)
                 msg += ' -> skip re-referencing.'
-                vprint(msg)
+                print(msg)
                 inps.ref_yx = None
     else:
         inps.ref_yx = None
@@ -658,8 +658,8 @@ def plot_slice(ax, data, metadata, inps=None):
                 lats = readfile.read(geom_file, datasetName='latitude',  box=inps.pix_box, print_msg=False)[0]
                 lons = readfile.read(geom_file, datasetName='longitude', box=inps.pix_box, print_msg=False)[0]
             except:
-                msg = 'WARNING: no latitude / longitude found in file: {}'.format(os.path.basename(geom_file))
-                msg += ', skip showing lat/lon in the status bar.'
+                msg = 'WARNING: no latitude / longitude found in file: {}, '.format(os.path.basename(geom_file))
+                msg += 'skip showing lat/lon in the status bar.'
                 vprint(msg)
                 geom_file = None
         else:
@@ -875,8 +875,7 @@ def read_dataset_input(inps):
                                         inps.search_dset)[0][0]
 
         if not ref_date:
-            vprint('WARNING: input reference date is not included in input file!')
-            vprint('input reference date: '+inps.ref_date)
+            print('WARNING: input reference date {} is not included in input file! Ignore it and continue'.format(inps.ref_date))
             inps.ref_date = None
         else:
             inps.ref_date = ref_date
@@ -1395,7 +1394,10 @@ def prepare4multi_subplots(inps, metadata):
         else:
             inps.dem_file = None
             inps.transparency = 1.0
-            vprint('Input DEM file has different size than data file, ignore it.')
+            msg = 'WARNING: DEM file has a different size from the data file. '
+            msg += 'This feature is only supported for single subplot, and not for multi-subplots.'
+            msg += '\n    --> Ignore it and continue.'
+            print(msg)
     return inps
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ utils.readfile.read_attribute(): fix a bug of grabbing the UNIT for HDF5 dataset, if `datasetName` is specified with date info as suffix. This only affects the unit display in the colorbar during plot.
+ utils.utils1.get_residual_std/rms(): use np.float32 to replace np.float to avoid numpy deprecation warning
+ view: print WARNING msg regardless of --verbose setting
+ tsview: more friendly figsize_img API for the interactive tsview.ipynb in MintPy-tutorial repo
+ plot_network: fix --nodisplay bug while calling from jupyter notebook
+ install: use bash *.sh to replace chmod +x cmd in docs/installation.md and .circleci/config.yml files

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.