### PR TITLE
add.py: handle TS in the same way as diff.py

### DIFF
--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -10,14 +10,17 @@ import os
 import sys
 import argparse
 import numpy as np
+from mintpy.objects import timeseries
 from mintpy.utils import readfile, writefile
+from mintpy.diff import check_reference
 
 
 ################################################################################
 EXAMPLE = """example:
-  add.py mask_1.h5 mask_2.h5 mask_3.h5 -o mask_all.h5
-  add.py 081008_100220.unw 100220_110417.unw -o 081008_110417.unw
-  add.py timeseries_ERA5.h5 inputs/ERA5.h5 -o timeseries.h5
+  add.py mask_1.h5 mask_2.h5 mask_3.h5        -o mask_all.h5
+  add.py 081008_100220.unw  100220_110417.unw -o 081008_110417.unw
+  add.py timeseries_ERA5.h5 inputs/ERA5.h5    -o timeseries.h5
+  add.py timeseriesRg.h5    inputs/TECsub.h5  -o timeseriesRg_TECsub.h5 --force
 """
 
 
@@ -29,6 +32,8 @@ def create_parser():
 
     parser.add_argument('file', nargs='+', help='files (2 or more) to be added')
     parser.add_argument('-o', '--output', dest='outfile', help='output file name')
+    parser.add_argument('--force', action='store_true',
+                        help='Enforce the adding for the shared dates only for time-series files')
     return parser
 
 
@@ -38,6 +43,12 @@ def cmd_line_parse(iargs=None):
     if len(inps.file) < 2:
         parser.print_usage()
         sys.exit('ERROR: At least 2 input files needed!')
+
+    # only two input files are supported for time-series type
+    atr = readfile.read_attribute(inps.file[0])
+    if atr['FILE_TYPE'] == 'timeseries' and len(inps.file) != 2:
+        raise ValueError('Only TWO files are supported for time-series, input has {}'.format(len(inps.file)))
+
     return inps
 
 
@@ -52,7 +63,7 @@ def add_matrix(data1, data2):
     return data
 
 
-def add_file(fnames, out_file=None):
+def add_file(fnames, out_file=None, force=False):
     """Generate sum of all input files
     Parameters: fnames : list of str, path/name of input files to be added
                 out_file : str, optional, path/name of output file
@@ -67,26 +78,76 @@ def add_file(fnames, out_file=None):
             out_file += '_plus_' + os.path.splitext(os.path.basename(fnames[i]))[0]
         out_file += ext
 
-    dsDict = {}
-    dsNames = readfile.get_dataset_list(fnames[0])
-    for dsName in dsNames:
-        # ignore dsName if input file has single dataset
-        if len(dsNames) == 1:
-            dsName2read = None
-        else:
-            dsName2read = dsName
+    atr1 = readfile.read_attribute(fnames[0])
+    atr2 = readfile.read_attribute(fnames[1])
 
-        print('adding {} ...'.format(dsName))
-        data = readfile.read(fnames[0], datasetName=dsName2read)[0]
-        for i in range(1, len(fnames)):
-            data2 = readfile.read(fnames[i], datasetName=dsName2read)[0]
-            data = add_matrix(data, data2)
-        dsDict[dsName] = data
+    if atr1['FILE_TYPE'] == 'timeseries':
+        file1, file2 = fnames[0], fnames[1]
 
-    # output
-    atr = readfile.read_attribute(fnames[0])
-    print('use metadata from the 1st file: {}'.format(fnames[0]))
-    writefile.write(dsDict, out_file=out_file, metadata=atr, ref_file=fnames[0])
+        # check dates shared by two timeseries files
+        dateList1 = timeseries(file1).get_date_list()
+        dateList2 = timeseries(file2).get_date_list()
+        dateListShared = [i for i in dateList1 if i in dateList2]
+        dateShared = np.ones((len(dateList1)), dtype=np.bool_)
+        if dateListShared != dateList1:
+            print('WARNING: {} does not contain all dates in {}'.format(file2, file1))
+            if force:
+                dateListEx = list(set(dateList1) - set(dateListShared))
+                print('Continue and enforce the differencing for their shared dates only.')
+                print('\twith following dates are ignored for differencing:\n{}'.format(dateListEx))
+                dateShared[np.array([dateList1.index(i) for i in dateListEx])] = 0
+            else:
+                raise Exception('To enforce the differencing anyway, use --force option.')
+
+        # check reference point
+        ref_date, ref_y, ref_x = check_reference(atr1, atr2)
+
+        # read data2 (consider different reference_date/pixel)
+        print('read from file: {}'.format(file2))
+        data2 = readfile.read(file2, datasetName=dateListShared)[0]
+
+        if ref_y and ref_x:
+            print('* referencing data from {} to y/x: {}/{}'.format(os.path.basename(file2), ref_y, ref_x))
+            ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
+            ref_val = readfile.read(file2, datasetName=dateListShared, box=ref_box)[0]
+            data2 -= np.tile(ref_val.reshape(-1, 1, 1), (1, data2.shape[1], data2.shape[2]))
+
+        if ref_date:
+            print('* referencing data from {} to date: {}'.format(os.path.basename(file2), ref_date))
+            ref_ind = dateListShared.index(ref_date)
+            data2 -= np.tile(data2[ref_ind, :, :], (data2.shape[0], 1, 1))
+
+        # read data1
+        print('read from file: {}'.format(file1))
+        data = readfile.read(file1)[0]
+
+        # apply adding
+        mask = data == 0.
+        data[dateShared] += data2
+        data[mask] = 0.               # Do not change zero phase value
+        del data2
+
+        # write file
+        writefile.write(data, out_file=out_file, metadata=atr1, ref_file=file1)
+
+    else:
+        dsDict = {}
+        dsNames = readfile.get_dataset_list(fnames[0])
+        for dsName in dsNames:
+            # ignore dsName if input file has single dataset
+            dsName2read = None if len(dsNames) == 1 else dsName
+
+            print('adding {} ...'.format(dsName))
+            data = readfile.read(fnames[0], datasetName=dsName2read)[0]
+            for i in range(1, len(fnames)):
+                data2 = readfile.read(fnames[i], datasetName=dsName2read)[0]
+                data = add_matrix(data, data2)
+            dsDict[dsName] = data
+
+        # output
+        print('use metadata from the 1st file: {}'.format(fnames[0]))
+        writefile.write(dsDict, out_file=out_file, metadata=atr1, ref_file=fnames[0])
+
     return out_file
 
 
@@ -95,7 +156,7 @@ def main(iargs=None):
     inps = cmd_line_parse(iargs)
     print('input files to be added: ({})\n{}'.format(len(inps.file), inps.file))
 
-    inps.outfile = add_file(inps.file, inps.outfile)
+    inps.outfile = add_file(inps.file, inps.outfile, force=inps.force)
 
     print('Done.')
     return inps.outfile

--- a/mintpy/diff.py
+++ b/mintpy/diff.py
@@ -62,20 +62,23 @@ def cmd_line_parse(iargs=None):
 
 
 #####################################################################################
-def _check_reference(atr1, atr2):
+def check_reference(atr1, atr2):
     """Check reference date and point
     Parameters: atr1/2   - dict, metadata of file1/2
     Returns:    ref_date - str, None for re-referencing in time  is NOT needed
                 ref_y/x  - int, None for re-referencing in space is NOT needed
     """
-    # reference date
+    # 1. reference date
+    # if same, do nothing
+    # if different, use the 1st one as the reference
     if atr1['REF_DATE'] == atr2.get('REF_DATE', None):
         ref_date = None
     else:
         ref_date = atr1['REF_DATE']
-        #print('consider different reference date')
 
-    # reference point
+    # 2. reference point
+    # if same, do nothing
+    # if different, use the 1st one as the reference
     ref_y = atr1.get('REF_Y', None)
     ref_x = atr1.get('REF_X', None)
     if ref_x == atr2.get('REF_X', None) or ref_y == atr2.get('REF_Y', None):
@@ -84,7 +87,6 @@ def _check_reference(atr1, atr2):
     else:
         ref_y = ref_y
         ref_x = ref_x
-        #print('consider different reference pixel')
 
     if ref_y is not None:
         ref_y = int(ref_y)
@@ -136,7 +138,7 @@ def diff_file(file1, file2, out_file=None, force=False, max_num_pixel=2e8):
             unit_fac = 0.001
 
         # check reference point
-        ref_date, ref_y, ref_x = _check_reference(atr1, atr2)
+        ref_date, ref_y, ref_x = check_reference(atr1, atr2)
 
         # check dates shared by two timeseries files
         dateListShared = [i for i in dateList1 if i in dateList2]
@@ -144,10 +146,10 @@ def diff_file(file1, file2, out_file=None, force=False, max_num_pixel=2e8):
         if dateListShared != dateList1:
             print('WARNING: {} does not contain all dates in {}'.format(file2, file1))
             if force:
-                dateExcluded = list(set(dateList1) - set(dateListShared))
+                dateListEx = list(set(dateList1) - set(dateListShared))
                 print('Continue and enforce the differencing for their shared dates only.')
-                print('\twith following dates are ignored for differencing:\n{}'.format(dateExcluded))
-                dateShared[np.array([dateList1.index(i) for i in dateExcluded])] = 0
+                print('\twith following dates are ignored for differencing:\n{}'.format(dateListEx))
+                dateShared[np.array([dateList1.index(i) for i in dateListEx])] = 0
             else:
                 raise Exception('To enforce the differencing anyway, use --force option.')
 

--- a/mintpy/save_gdal.py
+++ b/mintpy/save_gdal.py
@@ -78,7 +78,7 @@ def array2raster(array, rasterName, rasterFormat, rasterOrigin, xStep, yStep):
     print('create raster band')
     print('raster row / column number: {}, {}'.format(rows, cols))
     print('raster transform info: {}'.format(transform))
-    outRaster = driver.Create(rasterName, cols, rows, 1, gdal.GDT_Float64)
+    outRaster = driver.Create(rasterName, cols, rows, 1, gdal.GDT_Float32)
     outRaster.SetGeoTransform(transform)
 
     print('write data to raster band')

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -1135,6 +1135,7 @@ class TimeSeriesAnalysis:
             # files from geocoding
             [os.path.join(geo_dir, 'geo_maskTempCoh.h5'),       '-c', 'gray'],
             [os.path.join(geo_dir, 'geo_temporalCoherence.h5'), '-c', 'gray'],
+            [os.path.join(geo_dir, 'geo_avgSpatialCoh.h5'),     '-c', 'gray'],
             [os.path.join(geo_dir, 'geo_velocity.h5'),          'velocity'],
             [os.path.join(geo_dir, 'geo_timeseries*.h5')] + opt4ts,
 

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -330,15 +330,19 @@ def date_list2vector(date_list):
 
 
 ################################################################
-def get_date_range(dmin, dmax):
-    """Make a list of dates with one-day interval [dmin, dmax]
+def get_date_range(dmin, dmax, dstep=1):
+    """Make a list of dates with one-day (or given days) interval for [dmin, dmax]
     Parameters: dmin      : str in YYYYMMDD format
                 dmax      : str in YYYYMMDD format
+                dstep     : int, interval in number of days
     Returns:    date_list : list of str in YYYYMMDD format
     """
+    # read inputs
     t1 = '{}-{}-{}'.format(dmin[:4], dmin[4:6], dmin[6:])
     t2 = '{}-{}-{}'.format(dmax[:4], dmax[4:6], dmax[6:])
-    date_objs = np.arange(t1, t2, dtype='datetime64[D]').astype('M8[D]').astype('O')
+    dt = np.timedelta64(dstep, 'D')
+    # prepare date range
+    date_objs = np.arange(t1, t2, dt, dtype='datetime64[D]').astype('M8[D]').astype('O')
     date_list = [obj.strftime('%Y%m%d') for obj in date_objs] + [dmax]
     return date_list
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -643,10 +643,10 @@ def get_slice_list(fname):
             # mag / pha / cpx reading like "multiple bands"
             slice_list = ['magnitude', 'phase']
 
-        elif fbase.startswith('offset') and fext in ['.bip'] and num_band == 2:
+        elif fbase.startswith('off') and fext in ['.bip'] and num_band == 2:
             slice_list = ['azimuthOffset', 'rangeOffset']
 
-        elif fbase.startswith('offset') and fname.endswith('cov.bip') and num_band == 3:
+        elif fbase.startswith('off') and fname.endswith('cov.bip') and num_band == 3:
             slice_list = ['azimuthOffsetVar', 'rangeOffsetVar', 'offsetCovar']
 
         else:

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -435,7 +435,19 @@ def update_data_with_plot_inps(data, metadata, inps):
     if inps.wrap:
         inps.vlim = inps.wrap_range
 
-    # 3. update display min/max
+    # math operation
+    if inps.math_operation:
+        vprint('Apply math operation: {}'.format(inps.math_operation))
+        if inps.math_operation == 'square':
+            data = np.square(data)
+        elif inps.math_operation == 'sqrt':
+            data = np.sqrt(data)
+        elif inps.math_operation == 'reverse':
+            data *= -1
+        elif inps.math_operation == 'inverse':
+            data = 1. / data
+
+    # 4. update display min/max
     inps.dlim = [np.nanmin(data), np.nanmax(data)]
     if not inps.vlim: # and data.ndim < 3:
         inps.cmap_lut, inps.vlim = pp.auto_adjust_colormap_lut_and_disp_limit(data, print_msg=inps.print_msg)
@@ -1546,18 +1558,6 @@ class viewer():
                                          box=(ref_x, ref_y, ref_x+1, ref_y+1),
                                          print_msg=False)[0]
                 data[data != 0.] -= ref_data
-
-            # math operation
-            if self.math_operation:
-                vprint('Apply math operation: {}'.format(self.math_operation))
-                if self.math_operation == 'square':
-                    data = np.square(data)
-                elif self.math_operation == 'sqrt':
-                    data = np.sqrt(data)
-                elif self.math_operation == 'reverse':
-                    data *= -1
-                elif self.math_operation == 'inverse':
-                    data = 1. / data
 
             # masking
             if self.zero_mask:


### PR DESCRIPTION
**Description of proposed changes**

+ `add.py`:
   - check num of files == 2 for TS file only
   - support two TS file with different reference point, different reference date, different date list; to be consistent with diff.py.
+ `diff.py`: `_check_reference()` -> `check_reference()` with more comments
+ `view`: expand --math to multi-subplots
+ `save_gdal`: use float32 as default to save disk
+ `smallbaselineApp`: plot geo_avgSpatialCoh.h5 file
+ `utils.readfile`: more relaxed wildcard filename for offset file from ampcor
+ `utils.ptime.get_date_range()`: add 'dstep' option for coarser list to speedup matrix operation laterward

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.