### PR TITLE
tropo_pyaps3: check GAM account info in pyaps3/model.cfg file

### DIFF
--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -6,6 +6,7 @@
 ############################################################
 
 
+from configparser import ConfigParser
 import os
 import sys
 import re

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -524,7 +524,7 @@ def check_exist_grib_file(gfile_list, print_msg=True):
 
 
 def check_pyaps_config(tropo_model):
-    """Check for input in PyAPS config file. If there is no input an error will be raised.
+    """Check for input in PyAPS config file. If they are default values or are empty then raise error
     Parameters: tropo_model : String of tropo model being used to calculate tropospheric delay
     Returns:    None
     """
@@ -537,6 +537,13 @@ def check_pyaps_config(tropo_model):
         'NARR': 'NARR'
     }
 
+    # Default values in cfg file
+    default_values = ['the-email-address-used-as-login@ecmwf-website.org',
+                      'the-user-name-used-as-login@earthdata.nasa.gov',
+                      'the-password-used-as-login@earthdata.nasa.gov',
+                      'the-email-adress-used-as-login@ucar-website.org',
+                      'your-uid:your-api-key']
+
     # Load API keys
     cfg_path = os.path.join(os.path.dirname(pa.__file__), 'model.cfg')
     cfg = ConfigParser()
@@ -544,15 +551,22 @@ def check_pyaps_config(tropo_model):
 
     if tropo_model == 'ERA5':
         key = cfg.get(pyaps_models[tropo_model], 'key')
-        if not key:
+        if key in default_values or not key:
             raise ValueError('pyaps config for CDS not detected!')
 
-    elif tropo_model in ['MERRA', 'ERAI']:
+    elif tropo_model == 'ERAI':
         user = cfg.get(pyaps_models[tropo_model], 'email')
         key = cfg.get(pyaps_models[tropo_model], 'key')
-        if not user or not key:
-            raise ValueError('pyaps config for {} not detected!'.format(pyaps_models[tropo_model]))
+        if (user in default_values or not user) or (key in default_values or not key):
+            raise ValueError('pyaps config for ECMWF not detected!')
+
+    elif tropo_model == 'MERRA':
+        user = cfg.get(pyaps_models[tropo_model], 'user')
+        key = cfg.get(pyaps_models[tropo_model], 'password')
+        if (user in default_values or not user) or (key in default_values or not key):
+            raise ValueError('pyaps config for MERRA not detected!')
     return
+
 
 def dload_grib_files(grib_files, tropo_model='ERA5', snwe=None):
     """Download weather re-analysis grib files using PyAPS

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -6,10 +6,10 @@
 ############################################################
 
 
-from configparser import ConfigParser
 import os
 import sys
 import re
+from configparser import ConfigParser
 import subprocess
 import argparse
 import h5py
@@ -538,7 +538,7 @@ def check_pyaps_account_config(tropo_model):
     }
     SECTION_OPTS = {
         'CDS'  : ['key'],
-        'ECMWF': ['email', 'key']',
+        'ECMWF': ['email', 'key'],
         'MERRA': ['user', 'password'],
     }
 

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -542,6 +542,29 @@ def dload_grib_files(grib_files, tropo_model='ERA5', snwe=None):
         hour = re.findall('\d{8}[-_]\d{2}', os.path.basename(grib_files2dload[0]))[0].replace('-', '_').split('_')[1]
         grib_dir = os.path.dirname(grib_files2dload[0])
 
+        # Load API keys
+        cfg_path = os.path.join(os.path.dirname(pa.__file__), 'model.cfg')
+        cfg = ConfigParser()
+        cfg.read(cfg_path)
+        if tropo_model in ['ECMWF', 'ERA', 'ECMWF_old']:
+            username = cfg.get(tropo_model, 'email')
+            key = cfg.get(tropo_model, 'key')
+        elif tropo_model == 'MERRA':
+            username = cfg.get(tropo_model, 'user')
+            key = cfg.get(tropo_model, 'password')
+        else:
+            # ERA5
+            key = cfg.get('CDS', 'key')
+
+        # Check if API config is missing
+        if tropo_model in ['ECMWF', 'ERA', 'ECMWF_old', 'MERRA']:
+            if not username or not key:
+                raise ValueError('Missing API config in PyAPS cfg file')
+        else:
+            # ERA5
+            if not key:
+                raise ValueError('Missing API config in PyAPS cfg file')
+
         # try 3 times to download, then use whatever downloaded to calculate delay
         i = 0
         while i < 3:


### PR DESCRIPTION
**Description of proposed changes**

This addresses the error of missing API config for PyAPS. If the user did not input their API credentials in `model.cfg` in the `pyaps3` directory it raised a vague `ZeroDivisionError: float division by zero` error.

This revision will now raise a `ValueError` with a more appropriate error message telling users that the API config is missing.

Related to #226.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.