### PR TITLE
hyp3: fix incAngle/slantRangeDist + add more attributes (pass full test)

### DIFF
--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -380,33 +380,33 @@ mintpy.load.waterMaskFile    = $DATA_DIR/SanFranSenDT42/mask/watermask.msk
 
 ### [ASF HyP3](https://hyp3-docs.asf.alaska.edu/)
 
-**WARNING: The current incidence angle file offered by HyP3 is not compatible with MintPy and should not be used!**
-
 1. Search, request and download GUNW products using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb).
 
     + For at least one GUNW product, download the accompanying DEM.
 
 2. Clip DEM and all interferograms to the same area using hyp3lib/[cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
 
-Here is an example workflow: [prep_TS_hyp3](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/prep_TS_hyp3.ipynb).
+Here is an example workflow: [smallbaselineApp_hyp3](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/smallbaselineApp_hyp3.ipynb).
 
 ```
-$DATA_DIR/TongariroSenA
+$DATA_DIR/RidgecrestSenDT71
 ├── hyp3
-|   ├── S1BA_20161229T070618_20170116T070658_VVP018_INT80_G_ueF_8108
-│   │   ├── S1BA_20161229T070618_20170116T070658_VVP018_INT80_G_ueF_8108_unw_phase_clip.tif
-│   │   ├── S1BA_20161229T070618_20170116T070658_VVP018_INT80_G_ueF_8108_corr_clip.tif
-│   │   ├── S1BA_20161229T070618_20170116T070658_VVP018_INT80_G_ueF_8108_dem_clip.tif
-│   │   ├── S1BA_20161229T070618_20170116T070658_VVP018_INT80_G_ueF_8108.txt
+|   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_corr_clip.tif
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_dem_clip.tif
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_lv_theta_clip.tif
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_unw_phase_clip.tif
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_water_mask_clip.tif
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43.txt
 │   │   └── ...
-│   ├── S1AB_20170116T070658_20170122T070616_VVP006_INT80_G_ueF_0209
-│   │   ├── S1AB_20170116T070658_20170122T070616_VVP006_INT80_G_ueF_0209_unw_phase_clip.tif
-│   │   ├── S1AB_20170116T070658_20170122T070616_VVP006_INT80_G_ueF_0209_corr_clip.tif
-│   │   ├── S1AB_20170116T070658_20170122T070616_VVP006_INT80_G_ueF_0209.txt
+│   ├── S1AA_20190622T135157_20190716T135159_VVP024_INT80_G_ueF_BA28
+│   │   ├── S1AA_20190622T135157_20190716T135159_VVP024_INT80_G_ueF_BA28_corr_clip.tif
+│   │   ├── S1AA_20190622T135157_20190716T135159_VVP024_INT80_G_ueF_BA28_unw_phase_clip.tif
+│   │   ├── S1AA_20190622T135157_20190716T135159_VVP024_INT80_G_ueF_BA28.txt
 │   │   └── ...
 │   └── ...
 └── mintpy
-    └── TongariroSenA.txt
+    └── RidgecrestSenDT71.txt
 ```
 
 The corresponding template options for `load_data`:
@@ -414,10 +414,12 @@ The corresponding template options for `load_data`:
 ```cfg
 mintpy.load.processor        = hyp3
 ##---------interferogram datasets:
-mintpy.load.unwFile          = $DATA_DIR/TongariroSenA/hyp3/*/*unw_phase_clip.tif
-mintpy.load.corFile          = $DATA_DIR/TongariroSenA/hyp3/*/*corr_clip.tif
+mintpy.load.unwFile          = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*unw_phase_clip.tif
+mintpy.load.corFile          = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*corr_clip.tif
 ##---------geometry datasets:
-mintpy.load.demFile          = $DATA_DIR/TongariroSenA/hyp3/*/*dem_clip.tif
+mintpy.load.demFile          = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*dem_clip.tif
+mintpy.load.incAngleFile     = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*lv_theta_clip.tif
+mintpy.load.waterMaskFile    = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*water_mask_clip.tif
 ```
 
 ### [GMTSAR](https://github.com/gmtsar/gmtsar) ###

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -103,8 +103,8 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
     '''
 
     # determine interferogram pair info and hyp3 metadata file name
-    sat, date1_string, date2_string, pol, res, soft, proc, ids, *_ = os.path.basename(fname).split('_')
-    job_id = '_'.join([sat, date1_string, date2_string, pol, res, soft, proc, ids])
+    sat, date1_str, date2_str, pol, res, soft, proc, ids, *_ = os.path.basename(fname).split('_')
+    job_id = '_'.join([sat, date1_str, date2_str, pol, res, soft, proc, ids])
     directory = os.path.dirname(fname)
     meta_file = f'{os.path.join(directory,job_id)}.txt'
 
@@ -117,16 +117,17 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
 
     # add universal hyp3 metadata
     meta['PROCESSOR'] = 'hyp3'
-    meta['HEADING'] = hyp3_meta['Heading']
+    meta['CENTER_LINE_UTC'] = hyp3_meta['UTCtime']
     meta['ALOOKS'] = hyp3_meta['Azimuth looks']
     meta['RLOOKS'] = hyp3_meta['Range looks']
-    meta['P_BASELINE_TOP_HDR'] = hyp3_meta['Baseline']
-    meta['P_BASELINE_BOTTOM_HDR'] = hyp3_meta['Baseline']
     meta['EARTH_RADIUS'] = hyp3_meta['Earth radius at nadir']
     meta['HEIGHT'] = hyp3_meta['Spacecraft height']
+    meta['STARTING_RANGE'] = hyp3_meta['Slant range near']
+    # ensure negative value for the heading angle
+    meta['HEADING'] = float(hyp3_meta['Heading']) % 360. - 360.
 
     # add LAT/LON_REF1/2/3/4 based on whether satellite ascending or descending
-    meta['ORBIT_DIRECTION'] = 'ASCENDING' if float(meta['HEADING']) > -90 else 'DESCENDING'
+    meta['ORBIT_DIRECTION'] = 'ASCENDING' if abs(meta['HEADING']) > 90 else 'DESCENDING'
     N = float(meta['Y_FIRST'])
     W = float(meta['X_FIRST'])
     S = N + float(meta['Y_STEP']) * int(meta['LENGTH'])
@@ -153,24 +154,28 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
 
     # note: HyP3 currently only supports Sentinel-1 data, so Sentinel-1
     #       configuration is hard-coded.
-    meta['PLATFORM'] = 'Sen'
-    meta['ANTENNA_SIDE'] = -1
-    meta['WAVELENGTH'] = SPEED_OF_LIGHT / sensor.SEN['carrier_frequency']
+    if hyp3_meta['Reference Granule'].startswith('S1'):
+        meta['PLATFORM'] = 'Sen'
+        meta['ANTENNA_SIDE'] = -1
+        meta['WAVELENGTH'] = SPEED_OF_LIGHT / sensor.SEN['carrier_frequency']
+        meta['RANGE_PIXEL_SIZE'] = sensor.SEN['range_pixel_size'] * int(meta['RLOOKS'])
+        meta['AZIMUTH_PIXEL_SIZE'] = sensor.SEN['azimuth_pixel_size'] * int(meta['ALOOKS'])
 
     # note: HyP3 (incidence) angle datasets are in the unit of radian
     # which is different from the isce-2 convention of degree
-    if 'inc_map' in os.path.basename(fname):
+    if 'lv_theta' in os.path.basename(fname):
         meta['UNIT'] = 'radian'
 
     # add metadata that is only relevant to interferogram files
     if is_ifg:
-        date1 = datetime.strptime(date1_string,'%Y%m%dT%H%M%S')
-        date2 = datetime.strptime(date2_string,'%Y%m%dT%H%M%S')
-        date_avg = date1 + (date2 - date1) / 2
-        date_avg_seconds = (date_avg - date_avg.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
-
-        meta['CENTER_LINE_UTC'] = date_avg_seconds
+        date1 = datetime.strptime(date1_str,'%Y%m%dT%H%M%S')
+        date2 = datetime.strptime(date2_str,'%Y%m%dT%H%M%S')
+        #date_avg = date1 + (date2 - date1) / 2
+        #date_avg_seconds = (date_avg - date_avg.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()
+        #meta['CENTER_LINE_UTC'] = date_avg_seconds
         meta['DATE12'] = f'{date1.strftime("%y%m%d")}-{date2.strftime("%y%m%d")}'
+        meta['P_BASELINE_TOP_HDR'] = hyp3_meta['Baseline']
+        meta['P_BASELINE_BOTTOM_HDR'] = hyp3_meta['Baseline']
 
     return(meta)
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the following changes for `hyp3` related data loading process/documentation. With the example dataset on Ridgecrest that @cirrusasf provided (https://jzhu-hyp3-dev.s3.us-west-2.amazonaws.com/hyp3-mintpy/Ridgecrest.zip), I have been able to use tropospheric correction and dem error correction as expected, so the `hyp3 + mintpy` workflow is fully functioning in my opinion (#540).

One small issue is the DEM error correction for the specific Ridgecrest EQ, when we specify a step function on July 4, but the current code could not distinguish if the step func (EQ) happens before or after the SAR acquisition on the same day. This should be an easy fix, will do it in another PR since it's not really related to hyp3.

+ prep_hyp3:
   - ensure negative HEADING value (https://github.com/ASFHyP3/hyp3-gamma/issues/306)
   - grab CENTER_LINE_UTC from UTCtime directly
   - put P_BASELINE_* to the ifgram specific metadata
   - add STARTING_RANGE from "Slant range near"
   - add RANGE/AZIMUTH_PIXEL_SIZE from hardwired Sentinel-1 info
   - adjust to the new incidence angle file name 'lv_theta'

+ stackDict: convert Gamma inc angle to isce/mintpy inc angle convention while loading the data

+ docs/dir_structure.hyp3: 
   - remove warning for inc angle as the latest HyP3 is producing the correct one now
   - add geometry file path in the template for incidence angle and water mask
   - use Ridgecrest SenT71 dataset for the example in the directory structure

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.