### PR TITLE
bugfix in tropo_pyaps3.check_pyaps_account_config()

### DIFF
--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -560,7 +560,7 @@ def check_pyaps_account_config(tropo_model):
 
         # check all required option values
         for opt in SECTION_OPTS[section]:
-            val = cfg.get[section, opt]
+            val = cfg.get(section, opt)
             if not val or val in default_values:
                 raise ValueError('PYAPS: No account info found for {} in {} section in file: {}'.format(tropo_model, section, cfg_file))
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -197,12 +197,13 @@ ENVI_BYTE_ORDER = {
 
 
 #########################################################################
-def read(fname, box=None, datasetName=None, print_msg=True, xstep=1, ystep=1):
+def read(fname, box=None, datasetName=None, print_msg=True, xstep=1, ystep=1, data_type=None):
     """Read one dataset and its attributes from input file.
     Parameters: fname       : str, path of file to read
                 datasetName : str or list of str, slice names
                 box         : 4-tuple of int area to read, defined in (x0, y0, x1, y1) in pixel coordinate
                 x/ystep     : int, number of pixels to pick/multilook for each output pixel
+                data_type   : numpy data type, e.g. np.float32, np.bool_, etc.
     Returns:    data        : 2/3-D matrix in numpy.array format, return None if failed
                 atr         : dictionary, attributes of data, return None if failed
     Examples:
@@ -246,6 +247,11 @@ def read(fname, box=None, datasetName=None, print_msg=True, xstep=1, ystep=1):
                                      box=box,
                                      xstep=xstep,
                                      ystep=ystep)
+
+    # customized output data type
+    if data_type:
+        data = np.array(data, dtype=data_type)
+
     return data, atr
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ `tropo_pyaps3.py`: fix a typo I introduced in `check_pyaps_account_config()` (#639). Thank you @jsb613 for finding it out.
+ utils.readfile.py: add `data_type` arg to customized output data type (turned off by default).

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.