### PR TITLE
simplify generic I/O logic for cpx binary files

### DIFF
--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -322,7 +322,8 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='average', margin=
                 length=int(atr['LENGTH']),
                 bands=len(dsDict.keys()),
                 data_type=dtype_isce,
-                scheme=atr['scheme'])
+                scheme=atr['scheme'],
+                image_type=atr['FILE_TYPE'])
             print(f'write file: {outfile}.xml')
 
             # write GDAL VRT file

--- a/mintpy/objects/sensor.py
+++ b/mintpy/objects/sensor.py
@@ -199,7 +199,7 @@ def get_unavco_mission_name(meta_dict):
 TSX = {
     'carrier_frequency'          : 9.65e9,    # Hz
     'antenna_length'             : 4.8,       # m
-    'dopper_bandwidth'           : 2770,      # Hz
+    'doppler_bandwidth'          : 2770,      # Hz
     'pulse_repetition_frequency' : 3800,      # Hz
     'chirp_bandwidth'            : 100e6,     # Hz
     'sampling_frequency'         : 109.89e6,  # Hz
@@ -212,7 +212,7 @@ TSX = {
 CSK = {
     'carrier_frequency'          : 9.6e9,     # Hz
     'antenna_length'             : 5.7,       # m
-    'dopper_bandwidth'           : 2670,      # Hz
+    'doppler_bandwidth'          : 2670,      # Hz
     'pulse_repetition_frequency' : 3000,      # Hz
     'chirp_bandwidth'            : 117e6,     # Hz
     'sampling_frequency'         : 146.25e6,  # Hz
@@ -225,7 +225,7 @@ CSK = {
 KSAT5 = {
     'carrier_frequency'          : 9.66e9,    # Hz
     'antenna_length'             : 4.48,      # m
-    'dopper_bandwidth'           : 3110,      # Hz
+    'doppler_bandwidth'          : 3110,      # Hz
     'pulse_repetition_frequency' : 3530,      # Hz
     'chirp_bandwidth'            : 73.24e6,   # Hz
     'sampling_frequency'         : 88.125e6,  # Hz
@@ -241,7 +241,7 @@ KSAT5 = {
 ERS = {
     'carrier_frequency'          : 5.300e9,   # Hz
     'antenna_length'             : 10.0,      # m
-    'dopper_bandwidth'           : 1500,      # Hz
+    'doppler_bandwidth'          : 1500,      # Hz
     'pulse_repetition_frequency' : 1680,      # Hz
     'chirp_bandwidth'            : 15.55e6,   # Hz
     'sampling_frequency'         : 18.96e6,   # Hz
@@ -254,7 +254,7 @@ ERS = {
 ENV = {
     'carrier_frequency'          : 5.331e9,   # Hz
     'antenna_length'             : 10.0,      # m
-    'dopper_bandwidth'           : 1500,      # Hz
+    'doppler_bandwidth'          : 1500,      # Hz
     'pulse_repetition_frequency' : 1650,      # Hz
     'chirp_bandwidth'            : 16.00e6,   # Hz
     'sampling_frequency'         : 18.00e6,   # Hz
@@ -272,7 +272,7 @@ ENV = {
 SEN = {
     'carrier_frequency'          : 5.405e9,   # Hz
     'antenna_length'             : 45.0,      # m
-    'dopper_bandwidth'           : 380,       # Hz
+    'doppler_bandwidth'          : 380,       # Hz
     'pulse_repetition_frequency' : 522,       # Hz
     'chirp_bandwidth'            : 56.50e6,   # Hz
     'sampling_frequency'         : 64.35e6,   # Hz
@@ -289,7 +289,7 @@ SEN = {
 RSAT2 = {
     'carrier_frequency'          : 5.405e9,   # Hz
     'antenna_length'             : 6.55,      # m
-    'dopper_bandwidth'           : 2308,      # Hz
+    'doppler_bandwidth'          : 2308,      # Hz
     'pulse_repetition_frequency' : 3637,      # Hz
     'chirp_bandwidth'            : 78.16e6,   # Hz
     'sampling_frequency'         : 112.68e6,  # Hz
@@ -313,7 +313,7 @@ SEASAT = {
 JERS = {
     'carrier_frequency'          : 1.275e9,   # Hz
     'antenna_length'             : 11.92,     # m
-    'dopper_bandwidth'           : 1157,      # Hz
+    'doppler_bandwidth'          : 1157,      # Hz
     'pulse_repetition_frequency' : 1600,      # Hz
     'chirp_bandwidth'            : 15.00e6,   # Hz
     'sampling_frequency'         : 17.10e6,   # Hz
@@ -326,7 +326,7 @@ JERS = {
 ALOS = {
     'carrier_frequency'          : 1.270e9,   # Hz
     'antenna_length'             : 8.9,       # m
-    'dopper_bandwidth'           : 1700,      # Hz
+    'doppler_bandwidth'          : 1700,      # Hz
     'pulse_repetition_frequency' : 2160,      # Hz
     'chirp_bandwidth'            : 28.00e6,   # Hz
     'sampling_frequency'         : 32.00e6,   # Hz
@@ -339,7 +339,7 @@ ALOS = {
 ALOS2 = {
     'carrier_frequency'          : 1.258e9,   # Hz
     'antenna_length'             : 9.9,       # m
-    'dopper_bandwidth'           : 1515,      # Hz
+    'doppler_bandwidth'          : 1515,      # Hz
     'pulse_repetition_frequency' : 2000,      # Hz
     'chirp_bandwidth'            : 84.0e6,    # Hz
     'sampling_frequency'         : 100.0e6,   # Hz

--- a/mintpy/simulation/simulation.py
+++ b/mintpy/simulation/simulation.py
@@ -13,13 +13,17 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from mintpy.defaults.plot import *
-from mintpy.objects import timeseries
+from mintpy.objects import timeseries, sensor
 from mintpy.utils import ptime, network as pnet
 
 # load all modules in this sub-directory for easy import
 from mintpy.simulation.decorrelation import *
 from mintpy.simulation.defo_model import *
 from mintpy.simulation.fractal import *
+
+
+SPEED_OF_LIGHT = 299792458   # m/s
+
 
 
 ############################ Deformation Time-series ############################
@@ -177,11 +181,12 @@ def simulate_network(ts_sim, date12_list, decor_day, coh_resid, L=75, num_repeat
     m_dates = [i.split('_')[0] for i in date12_list]
     s_dates = [i.split('_')[1] for i in date12_list]
     date_list = sorted(list(set(m_dates + s_dates)))
-    ifgram_sim = timeseries2ifgram(ts_sim, date_list, date12_list, display=False)
+    wvl = SPEED_OF_LIGHT / sensor.SENSOR_DICT[sensor_name.lower()]['carrier_frequency']
+    ifgram_sim = timeseries2ifgram(ts_sim, date_list, date12_list, wvl=wvl, display=False)
 
     # simulated (true) coherence
     coh_sim = pnet.simulate_coherence(date12_list,
-                                      baseline_file='bl_list.txt',
+                                      baseline_file=baseline_file,
                                       sensor_name=sensor_name,
                                       inc_angle=inc_angle,
                                       decor_time=decor_day,

--- a/mintpy/subset.py
+++ b/mintpy/subset.py
@@ -53,13 +53,13 @@ def create_parser():
                                      epilog=TEMPLATE+'\n'+EXAMPLE)
     parser.add_argument('file', nargs='+', help='File(s) to subset/crop')
 
-    parser.add_argument('-x', dest='subset_x', type=int, nargs=2,
+    parser.add_argument('-x','--sub-x','--subset-x', dest='subset_x', type=int, nargs=2,
                         help='subset range in x/cross-track/column direction')
-    parser.add_argument('-y', dest='subset_y', type=int, nargs=2,
+    parser.add_argument('-y','--sub-y','--subset-y', dest='subset_y', type=int, nargs=2,
                         help='subset range in y/along-track/row direction')
-    parser.add_argument('-l', '--lat', dest='subset_lat',
+    parser.add_argument('-l', '--lat', '--sub-lat', '--subset-lat', dest='subset_lat',
                         type=float, nargs=2, help='subset range in latitude')
-    parser.add_argument('-L', '--lon', dest='subset_lon',
+    parser.add_argument('-L', '--lon', '--sub-lon', '--subset-lon', dest='subset_lon',
                         type=float, nargs=2, help='subset range in column\n\n')
 
     parser.add_argument('-t', '--template', dest='template_file',
@@ -489,7 +489,8 @@ def subset_file(fname, subset_dict_input, out_file=None):
                 length=int(atr['LENGTH']),
                 bands=len(dsDict.keys()),
                 data_type=dtype_isce,
-                scheme=atr['scheme'])
+                scheme=atr['scheme'],
+                image_type=atr['FILE_TYPE'])
             print(f'write file: {out_file}.xml')
 
             # write GDAL VRT file

--- a/mintpy/utils/arg_group.py
+++ b/mintpy/utils/arg_group.py
@@ -34,7 +34,7 @@ def add_data_disp_argument(parser):
     data.add_argument('--noflip', dest='auto_flip', action='store_false',
                       help='turn off auto flip for radar coordinate file')
 
-    data.add_argument('--multilook-num', dest='multilook_num', type=int, default=1, metavar='NUM',
+    data.add_argument('--nmli','--num-multilook','--multilook-num', dest='multilook_num', type=int, default=1, metavar='NUM',
                       help='multilook data in X and Y direction with a factor for display (default: %(default)s).')
     data.add_argument('--nomultilook', '--no-multilook', dest='multilook', action='store_false',
                       help='do not multilook, for high quality display. \n'

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -763,7 +763,7 @@ def read_input_file_info(inps):
     vprint('file size in y/x: {}'.format((inps.length, inps.width)))
 
     # File dataset List
-    inps.sliceList = readfile.get_slice_list(inps.file)
+    inps.sliceList = readfile.get_slice_list(inps.file, no_complex=True)
 
     # Read input list of dataset to display
     inps, atr = read_dataset_input(inps)


### PR DESCRIPTION
**Description of proposed changes**

This PR modifies readfile/writefile to read and write complex binary files (from isce-2) directly in complex data type by default.

For plotting in view.py, which requires real data type, I add readfile.get_slice_list(no_complex) option to translate complex into mag/phase for plotting. This option is turn off by default for generic I/O.

+ readfile:
   - read_binary_file(): for "slc", set cpx_band to "complex" unless mag/phase is clearly specified.
   - get_slice_list(): 1) ignore meaningless geo/rdr file extension; 2) add "no_complex" arg to switch between complex (for I/O) and mag/phase (for plotting)

+ writefile:
   - write(): for .slc/.int, write complex directly
   - write_isce_xml(): add "image_type" arg to initiate different ISCE-2 image objects for better compatiability
   - write_isce_file(): support file_type == 'isce_slc'
   - comment out obsolete write_complex64() as write_complex_float32() is equivalent but simpler and faster.

+ subset/multilook: update usage of writefile.write_isce_xml()

+ view: update usage of readfile.get_slice_list()

Other minor changes:
+ subset.py: add --sub-x/y/lat/lon and --subset-x/y/lat/lon to be consistent with subset option names in other scripts.
+ view.py: add --nmli / --num-multilook for --multilook-num
+ simulation.simulation.py: typo fix and add missing wvl arg while calling timeseries2ifgram()
+ objects.sensor: typo fix for doppler_bandwidth

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.