### PR TITLE
save_gdal.py: support UTM projection

### DIFF
--- a/mintpy/save_gdal.py
+++ b/mintpy/save_gdal.py
@@ -11,7 +11,7 @@ import sys
 import argparse
 import numpy as np
 from osgeo import gdal, ogr, osr
-from mintpy.utils import readfile, plot as pp
+from mintpy.utils import readfile, utils0 as ut, plot as pp
 
 
 # link: https://gdal.org/drivers/raster/index.html
@@ -123,13 +123,19 @@ def main(iargs=None):
         inps.outfile = os.path.abspath(inps.outfile)
 
     # coordinate info
-    epsg = int(attr['EPSG'])
     rasterOrigin = (float(attr['X_FIRST']),float(attr['Y_FIRST']))
     xStep = float(attr['X_STEP'])
     yStep = float(attr['Y_STEP'])
+    kwargs = dict(xStep=xStep, yStep=yStep)
+
+    epsg = attr.get('EPSG', None)
+    if not epsg and 'UTM_ZONE' in attr.keys():
+        epsg = ut.utm_zone2epsg_code(attr['UTM_ZONE'])
+    if epsg:
+        kwargs['epsg'] = int(epsg)
 
     # convert array to raster
-    array2raster(array, inps.outfile, inps.out_format, rasterOrigin, xStep, yStep, epsg)
+    array2raster(array, inps.outfile, inps.out_format, rasterOrigin, **kwargs)
 
     return
 

--- a/mintpy/save_gdal.py
+++ b/mintpy/save_gdal.py
@@ -62,7 +62,7 @@ def cmd_line_parse(iargs=None):
 
 
 ##############################################################################
-def array2raster(array, rasterName, rasterFormat, rasterOrigin, xStep, yStep):
+def array2raster(array, rasterName, rasterFormat, rasterOrigin, xStep, yStep, epsg=4326):
 
     # transform info
     cols = array.shape[1]
@@ -85,9 +85,9 @@ def array2raster(array, rasterName, rasterFormat, rasterOrigin, xStep, yStep):
     outband = outRaster.GetRasterBand(1)
     outband.WriteArray(array)
 
-    print('set projectection as: EPSG 4326')
+    print('set projection as: EPSG {}'.format(epsg))
     outRasterSRS = osr.SpatialReference()
-    outRasterSRS.ImportFromEPSG(4326)
+    outRasterSRS.ImportFromEPSG(epsg)
     outRaster.SetProjection(outRasterSRS.ExportToWkt())
     outband.FlushCache()
     print('finished writing to {}'.format(rasterName))
@@ -123,12 +123,13 @@ def main(iargs=None):
         inps.outfile = os.path.abspath(inps.outfile)
 
     # coordinate info
+    epsg = int(attr['EPSG'])
     rasterOrigin = (float(attr['X_FIRST']),float(attr['Y_FIRST']))
     xStep = float(attr['X_STEP'])
     yStep = float(attr['Y_STEP'])
 
     # convert array to raster
-    array2raster(array, inps.outfile, inps.out_format, rasterOrigin, xStep, yStep)
+    array2raster(array, inps.outfile, inps.out_format, rasterOrigin, xStep, yStep, epsg)
 
     return
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1351,6 +1351,7 @@ def read_gdal_vrt(fname):
 
     # projection / coordinate unit
     srs = osr.SpatialReference(wkt=ds.GetProjection())
+    atr['EPSG'] = srs.GetAttrValue('AUTHORITY', 1)
     srs_name = srs.GetName()
     if srs_name and 'UTM' in srs_name:
         atr['UTM_ZONE'] = srs_name.split('UTM zone')[-1].strip()

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -20,7 +20,7 @@ import h5py
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import ndimage
-from pyproj import Proj, Transformer
+from pyproj import CRS, Proj, Transformer
 
 # global variables
 SPEED_OF_LIGHT = 299792458 # m/s
@@ -232,6 +232,20 @@ def touch(fname_list, times=None):
 
 
 #################################### Geometry ##########################################
+def utm_zone2epsg_code(utm_zone):
+    """Convert UTM Zone string to EPSG code.
+    Parameters: utm_zone - str, atr['UTM_ZONE']
+    Returns:    epsg     - str, EPSG code
+    Examples:   epsg = utm_zone2epsg_code('11N')
+    """
+    crs = CRS.from_dict({'proj': 'utm',
+                         'zone': int(utm_zone[:-1]),
+                         'south': utm_zone[-1] == 'S',
+                        })
+    epsg = crs.to_authority()[1]
+    return epsg
+
+
 def to_latlon(infile, x, y):
     """Convert x, y in the projection coordinates of the file to lon/lat in degree.
 


### PR DESCRIPTION
**Description of proposed changes**

- Add EPSG to file attributes in `readfile.py`
- array2raster now accepts additional argument for EPSG code in `save_gdal.py` (default is 4326). This loads the EPSG from file attributes.
- Fix typo in `array2raster` function

**Reminders**

- [x] Fix #644
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
