### PR TITLE
sbApp --plot: limit num_cores based on max memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
             git clone https://github.com/insarlab/PySolid.git ${HOME}/tools/PySolid
             # install dependencies
             source activate root
-            mamba install --verbose --yes --file ${MINTPY_HOME}/docs/requirements.txt gdal>=3 fortran-compiler
-            pip install git+https://github.com/tylere/pykml.git
+            mamba install --verbose --yes --file ${MINTPY_HOME}/docs/requirements.txt gdal">=3" fortran-compiler
+            ${CONDA_PREFIX}/bin/pip install git+https://github.com/tylere/pykml.git
             # compile pysolid Fortran code
             cd ${HOME}/tools/PySolid/pysolid
             f2py -c -m solid solid.for

--- a/docs/api/attributes.md
+++ b/docs/api/attributes.md
@@ -45,9 +45,10 @@ The following attributes vary for each interferogram:
 +  REF_DATE = reference date
 +  REF_X/Y/LAT/LON = column/row/latitude/longitude of reference point
 +  SUBSET_XMIN/XMAX/YMIN/YMAX = start/end column/row number of subset in the original coverage
-+  MODIFICATION_TIME = dataset modification time, exists in ifgramStack.h5 file for 3D dataset, used for --update option of unwrap error corrections.
++  MODIFICATION_TIME = dataset modification time, exists in ifgramStack.h5 file for 3D dataset, used for "--update" option of unwrap error corrections.
 +  NCORRLOOKS = number of independent looks, as explained in [SNAPHU](https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/snaphu.conf.full)
 +  UTM_ZONE = UTM zone, e.g. 60S, for geocoded file with UTM projection only.
++  EPSG = EPSG code for coordinate systems, for geocoded files only.
 
 ### Reference ###
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,8 +68,8 @@ Run the following in your terminal to install the dependencies to your conda env
 ```
 # To create a new conda environment, e.g. named "insar", run "conda create --name insar; conda activate insar"
 
-# Add "gdal>=3" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
-# Add "isce2"   below to install extra dependencies if you use ISCE-2
+# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
+# Add "isce2"     below to install extra dependencies if you use ISCE-2
 conda install --yes -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
 
 $CONDA_PREFIX/bin/pip install git+https://github.com/insarlab/PySolid.git

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -126,6 +126,7 @@ def create_parser():
     parser = arg_group.add_gps_argument(parser)
     parser = arg_group.add_mask_argument(parser)
     parser = arg_group.add_map_argument(parser)
+    parser = arg_group.add_memory_argument(parser)
     parser = arg_group.add_point_argument(parser)
     parser = arg_group.add_reference_argument(parser)
     parser = arg_group.add_save_argument(parser)
@@ -1354,6 +1355,7 @@ def prepare4multi_subplots(inps, metadata):
         #   inps.multilook_num ==1 (no --multilook-num input)
         # inps.multilook is used for this check ONLY
         inps.multilook_num = pp.auto_multilook_num(inps.pix_box, inps.fig_row_num * inps.fig_col_num,
+                                                   max_memory=inps.maxMemory,
                                                    print_msg=inps.print_msg)
 
     # multilook mask


### PR DESCRIPTION
**Description of proposed changes**

+ smallbaselineApp.py: limit the number of parallel processes for plotting based on the max memory from the template file, to avoid exceeding the memory. Circle CI kills processes because of this. Note that matplotlib reserved much larger memory than it actually uses.

For users who want to use a lot of parallel processes for plotting, please increase your `mintpy.compute.maxMemory` setting.  @falkamelung.

+ view.py: add --memory option. Note this is NOT used in the smallbaselineApp.py

+ plot.auto_multilook_num():
   - more detailed multilook num list, for more detailed memory management.
   - add max_memory arg to adjust according. Details are in the code comments.

+ add quotes to the version control for conda/mamba install in the command line in docs/installation.md and .circleci/config.yml files
+ circleci: use pip from conda to avoid warning msg
+ docs/api/attributes.md: add EPSG (#644)

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.