### PR TITLE
__init__: rm `sys.path.insert()` and force internal imports

### DIFF
--- a/mintpy/__init__.py
+++ b/mintpy/__init__.py
@@ -7,10 +7,11 @@ from mintpy.version import release_version, logo
 __version__ = release_version
 __logo__ = logo
 
-# check environment variable
-mintpy_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(1, mintpy_path)
-sys.path.insert(1, os.path.join(mintpy_path, 'defaults'))
-sys.path.insert(1, os.path.join(mintpy_path, 'objects'))
-sys.path.insert(1, os.path.join(mintpy_path, 'simulation'))
-sys.path.insert(1, os.path.join(mintpy_path, 'utils'))
+## check environment variable
+#mintpy_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+#sys.path.insert(1, mintpy_path)
+#sys.path.insert(1, os.path.join(mintpy_path, 'defaults'))
+#sys.path.insert(1, os.path.join(mintpy_path, 'objects'))
+#sys.path.insert(1, os.path.join(mintpy_path, 'simulation'))
+#sys.path.insert(1, os.path.join(mintpy_path, 'utils'))
+

--- a/mintpy/__init__.py
+++ b/mintpy/__init__.py
@@ -14,9 +14,3 @@ sys.path.insert(1, os.path.join(mintpy_path, 'defaults'))
 sys.path.insert(1, os.path.join(mintpy_path, 'objects'))
 sys.path.insert(1, os.path.join(mintpy_path, 'simulation'))
 sys.path.insert(1, os.path.join(mintpy_path, 'utils'))
-
-try:
-    os.environ['MINTPY_HOME']
-except KeyError:
-    print('Using default MintPy Path: %s' % (mintpy_path))
-    os.environ['MINTPY_HOME'] = mintpy_path

--- a/mintpy/__init__.py
+++ b/mintpy/__init__.py
@@ -1,13 +1,11 @@
-from __future__ import print_function
-import sys
-import os
-
 # get version info
 from mintpy.version import release_version, logo
 __version__ = release_version
 __logo__ = logo
 
 ## check environment variable
+#import os
+#import sys
 #mintpy_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 #sys.path.insert(1, mintpy_path)
 #sys.path.insert(1, os.path.join(mintpy_path, 'defaults'))

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -15,8 +15,6 @@ import shutil
 import argparse
 import subprocess
 import tarfile
-
-import mintpy
 from mintpy import view
 
 
@@ -34,7 +32,9 @@ URL_LIST = [
     'https://zenodo.org/record/3952917/files/KujuAlosAT422F650.tar.xz',
 ]
 
-PROJ_NAME_LIST = [os.path.basename(url).split('.tar.xz')[0] for url in URL_LIST]
+PROJ_NAMES = [os.path.basename(url).split('.tar.xz')[0] for url in URL_LIST]
+TEMPLATE_FILES = [os.path.join(os.path.dirname(__file__), 'configs/{}.txt'.format(proj_name))
+                  for proj_name in PROJ_NAMES]
 
 
 #####################################################################################
@@ -47,10 +47,10 @@ DSET_INFO = """
 """
 
 EXAMPLE = """example:
-  $MINTPY_HOME/test/test_smallbaselineApp.py
-  $MINTPY_HOME/test/test_smallbaselineApp.py  --dir ~/test
-  $MINTPY_HOME/test/test_smallbaselineApp.py  --dset KujuAlosAT422F650
-  $MINTPY_HOME/test/test_smallbaselineApp.py  --nofresh
+  test_smallbaselineApp.py
+  test_smallbaselineApp.py  --dir ~/test
+  test_smallbaselineApp.py  --dset KujuAlosAT422F650
+  test_smallbaselineApp.py  --nofresh
 """
 
 def create_parser():
@@ -58,9 +58,9 @@ def create_parser():
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=EXAMPLE)
 
-    parser.add_argument('--dset', dest='dset_name', nargs='+', metavar='DSET', choices=PROJ_NAME_LIST, default=PROJ_NAME_LIST,
+    parser.add_argument('--dset', dest='dset_name', nargs='+', metavar='DSET', choices=PROJ_NAMES, default=PROJ_NAMES,
                         help='name(s) of datasets to be tested.\n'+
-                             'Available datasets: {}\n'.format(PROJ_NAME_LIST) +
+                             'Available datasets: {}\n'.format(PROJ_NAMES) +
                              '(default: all)')
 
     parser.add_argument('--test-pyaps', dest='test_pyaps', action='store_true',
@@ -95,10 +95,9 @@ def test_dataset(dset_name, test_dir, fresh_start=True, test_pyaps=False, test_i
     print('Go to test directory:', test_dir)
     os.chdir(test_dir)
 
-    dset_idx = PROJ_NAME_LIST.index(dset_name)
+    dset_idx = PROJ_NAMES.index(dset_name)
     dset_url = URL_LIST[dset_idx]
-    mintpy_dir = os.path.dirname(mintpy.__file__)
-    template_file = os.path.join(Path(mintpy_dir).parent, 'test/configs/{}.txt'.format(dset_name))
+    template_file = TEMPLATE_FILES[dset_idx]
 
     # download tar file
     tar_file = os.path.basename(dset_url)
@@ -159,7 +158,6 @@ def test_dataset(dset_name, test_dir, fresh_start=True, test_pyaps=False, test_i
     iargs = [vel_file, 'velocity', '--nodisplay', '--noverbose', '-o', png_file]
     if dset_name in CMAP_DICT.keys():
         iargs += ['-c', CMAP_DICT[dset_name]]
-    print('view.py', ' '.join(iargs))
     view.main(iargs)
 
     # open final velocity map if on mac
@@ -194,7 +192,7 @@ def main(iargs=None):
         print('#'*100+'\n'*3)
 
     # print message
-    if num_dset == len(PROJ_NAME_LIST):
+    if num_dset == len(PROJ_NAMES):
         m, s = divmod(time.time()-start_time, 60)
         msg  = '#'*50
         msg += '\n    PASS ALL testings without running errors.\n'

--- a/test/test_smallbaselineApp.py
+++ b/test/test_smallbaselineApp.py
@@ -33,8 +33,7 @@ URL_LIST = [
 ]
 
 PROJ_NAMES = [os.path.basename(url).split('.tar.xz')[0] for url in URL_LIST]
-TEMPLATE_FILES = [os.path.join(os.path.dirname(__file__), 'configs/{}.txt'.format(proj_name))
-                  for proj_name in PROJ_NAMES]
+TEMPLATE_FILES = [Path(__file__).resolve().parent / 'configs' / f'{proj_name}.txt' for proj_name in PROJ_NAMES]
 
 
 #####################################################################################


### PR DESCRIPTION
**Description of proposed changes**

This PR address the 1st and 2nd issues in #652.

+ `mintpy/__inti__.py`: 
   - remove try/except for print and MINTPY_HOME as it's not really used anywhere, and their corresponding module imports.
   - remove `sys.path.insert()` calls. These were replicates from the isce-2 style (isceobj, iscesys, etc.), but they are not really applicable to and used in mintpy, nor had we encouraged in any other files besides this one.

**NOTE**: however, this might still potentially impact downstream workflows, thus, should be noted in the release notes/changelog.

+ test_smallbaselineApp.py:
   - use the relative path to locate config file, instead of using mintpy module
   - remove the occurrence of MINTPY_HOME

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.