### PR TITLE
ts2vel: save residual displacement TS via --save-res

### DIFF
--- a/mintpy/info.py
+++ b/mintpy/info.py
@@ -164,12 +164,12 @@ def print_timseries_date_stat(dateList):
     datevector = ptime.date_list2vector(dateList)[1]
     print('Start Date: {}'.format(dateList[0]))
     print('End   Date: {}'.format(dateList[-1]))
-    print('Number of acquisitions    : {}'.format(len(dateList)))
-    print('Std. of acquisition times : {:.2f} yeras'.format(np.std(datevector)))
-    print('----------------------')
-    print('List of dates:\n{}'.format(dateList))
-    print('----------------------')
-    print('List of dates in years:\n{}'.format(datevector))
+    print('Number of date   : {}'.format(len(dateList)))
+    print('STD of datetimes : {:.2f} years'.format(np.std(datevector)))
+    #print('----------------------')
+    #print('List of dates:\n{}'.format(dateList))
+    #print('----------------------')
+    #print('List of dates in years:\n{}'.format(datevector))
     return
 
 

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -7,8 +7,8 @@
 
 
 import os
-import sys
 import re
+import sys
 import argparse
 import numpy as np
 from scipy import linalg, stats

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1321,6 +1321,7 @@ def scale_data2disp_unit(data=None, metadata=dict(), disp_unit=None):
                 print('Un-scalable display unit:', disp_unit[0])
     else:
         print('Un-scalable data unit:', data_unit)
+        disp_unit = [metadata['UNIT']]
 
     # Calculate scaling factor  - 2
     if len(data_unit) == 2:
@@ -1598,8 +1599,13 @@ def draw_scalebar(ax, geo_box, unit='degrees', loc=[0.2, 0.2, 0.1], labelpad=0.0
     ## length
     # 1. calc scene width in meters
     if unit.startswith('deg'):
-        scene_width = geod.inv(geo_box[0], geo_box[3],
-                               geo_box[2], geo_box[3])[2]
+        if (geo_box[2] - geo_box[0]) > 30:
+            # do not plot scalebar if the longitude span > 30 deg
+            scene_width = None
+            return ax
+        else:
+            scene_width = geod.inv(geo_box[0], geo_box[3],
+                                   geo_box[2], geo_box[3])[2]
     elif unit.startswith('meter'):
         scene_width = geo_box[2] - geo_box[0]
 

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -7,7 +7,6 @@
 #   from mintpy.utils import ptime
 
 import os
-import sys
 import re
 import time
 import datetime as dt
@@ -35,7 +34,19 @@ def get_date_str_format(date_str):
         pass
 
     date_str_format = None
-    if len(re.findall('\d{8}T\d{6}', date_str)) > 0:
+    if len(re.findall('\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}', date_str)) > 0:
+        date_str_format = '%Y-%m-%dT%H:%M:%S'
+
+    elif len(re.findall('\d{4}-\d{2}-\d{2}T\d{2}:\d{2}', date_str)) > 0:
+        date_str_format = '%Y-%m-%dT%H:%M'
+
+    elif len(re.findall('\d{4}-\d{2}-\d{2}T\d{2}', date_str)) > 0:
+        date_str_format = '%Y-%m-%dT%H'
+
+    elif len(re.findall('\d{4}-\d{2}-\d{2}T', date_str)) > 0:
+        date_str_format = '%Y-%m-%d'
+
+    elif len(re.findall('\d{8}T\d{6}', date_str)) > 0:
         date_str_format = '%Y%m%dT%H%M%S'
 
     elif len(re.findall('\d{8}T\d{4}', date_str)) > 0:
@@ -173,7 +184,7 @@ def yy2yyyy(year):
         year = '19'+year
     else:
         year = '20'+year
-    return datyeare
+    return year
 
 
 def yyyymmdd(dates):
@@ -301,8 +312,8 @@ def date_list2tbase(date_list):
 
     # Dictionary: key - date, value - temporal baseline
     dateDict = {}
-    for i in range(len(date_list)):
-        dateDict[date_list[i]] = tbase[i]
+    for i, date_str in enumerate(date_list):
+        dateDict[date_str] = tbase[i]
     return tbase, dateDict
 
 
@@ -332,20 +343,23 @@ def date_list2vector(date_list):
 ################################################################
 def get_date_range(dmin, dmax, dstep=1, dunit='D', out_fmt='%Y%m%d'):
     """Make a list of dates with one-day (or given days) interval for [dmin, dmax]
-    Parameters: dmin    - str in YYYYMMDD format
-                dmax    - str in YYYYMMDD format
+    Parameters: dmin    - str in format supported by get_date_str_format()
+                dmax    - str in format supported by get_date_str_format()
                 dstep   - int, interval in number of dunit
                 dunit   - str, unit of interval, e.g. Y, M, W, D, h, m, s
                 out_fmt - str, output datetime string format
     Returns:    dt_list - list of str in YYYYMMDD format
     """
     # read inputs
-    t1 = np.datetime64('{}-{}-{}'.format(dmin[:4], dmin[4:6], dmin[6:]))
-    t2 = np.datetime64('{}-{}-{}'.format(dmax[:4], dmax[4:6], dmax[6:]))
-    dt = np.timedelta64(dstep, dunit)
+    date_str_format = get_date_str_format(dmin)
+    t1 = np.datetime64(dt.datetime.strptime(dmin, date_str_format).isoformat())
+    t2 = np.datetime64(dt.datetime.strptime(dmax, date_str_format).isoformat())
+    tstep = np.timedelta64(dstep, dunit)
+
     # prepare date range
-    dt_objs = np.arange(t1, t2+dt, dt, dtype='datetime64').astype('O')
+    dt_objs = np.arange(t1, t2+tstep, tstep, dtype='datetime64').astype('O')
     dt_list = [obj.strftime(out_fmt) for obj in dt_objs]
+
     return dt_list
 
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -292,13 +292,16 @@ def read_hdf5_file(fname, datasetName=None, box=None, xstep=1, ystep=1, print_ms
     elif isinstance(datasetName, str):
         datasetName = [datasetName]
 
-    # if datasetName is all numerical (or include only T), add dsFamily as prefix
-    if all(i.replace('T','').isdigit() for i in datasetName):
-        datasetName = ['{}-{}'.format(ds_3d_list[0], i) for i in datasetName]
+    # if datasetName is all date info, add dsFamily as prefix
+    # a) if all digit, e.g. YYYYMMDD
+    # b) if in isoformat(), YYYY-MM-DDTHH:MM, etc.
+    if all(x.isdigit() or x[:4].isdigit() for x in datasetName):
+        datasetName = ['{}-{}'.format(ds_3d_list[0], x) for x in datasetName]
 
     # Input Argument: decompose slice list into dsFamily and inputDateList
     dsFamily = datasetName[0].split('-')[0]
-    inputDateList = [i.replace(dsFamily,'').replace('-','') for i in datasetName]
+    inputDateList = [x.replace(dsFamily,'') for x in datasetName]
+    inputDateList = [x[1:] for x in inputDateList if x.startswith('-')]
 
     # read hdf5
     with h5py.File(fname, 'r') as f:
@@ -336,7 +339,7 @@ def read_hdf5_file(fname, datasetName=None, box=None, xstep=1, ystep=1, print_ms
             if not inputDateList or inputDateList == ['']:
                 slice_flag[:] = True
             else:
-                date_list = [i.split('-')[1] for i in
+                date_list = [i.split('-', 1)[1] for i in
                              [j for j in slice_list if j.startswith(dsFamily)]]
                 for d in inputDateList:
                     slice_flag[date_list.index(d)] = True

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -540,6 +540,10 @@ def plot_slice(ax, data, metadata, inps=None):
                        alpha=inps.transparency, animated=inps.animation, zorder=1)
 
         # Scale Bar
+        if inps.coord_unit.startswith('deg') and (inps.geo_box[2] - inps.geo_box[0]) > 30:
+            # do not plot scalebar if the longitude span > 30 deg
+            inps.disp_scalebar = False
+
         if inps.disp_scalebar:
             vprint('plot scale bar: {}'.format(inps.scalebar))
             pp.draw_scalebar(ax,

--- a/test/configs/RidgecrestSenDT71.txt
+++ b/test/configs/RidgecrestSenDT71.txt
@@ -1,0 +1,15 @@
+# vim: set filetype=cfg:
+mintpy.compute.cluster      = local
+mintpy.load.processor       = hyp3
+##---------interferogram datasets:
+mintpy.load.unwFile         = ../hyp3/*/*unw_phase_clip.tif
+mintpy.load.corFile         = ../hyp3/*/*corr_clip.tif
+##---------geometry datasets:
+mintpy.load.demFile         = ../hyp3/*/*dem_clip.tif
+mintpy.load.incAngleFile    = ../hyp3/*/*lv_theta_clip.tif
+mintpy.load.waterMaskFile   = ../hyp3/*/*water_mask_clip.tif
+
+mintpy.networkInversion.weightFunc  = no
+mintpy.troposphericDelay.method     = pyaps
+mintpy.topographicResidual          = no
+


### PR DESCRIPTION
**Description of proposed changes**

+ `timeseries2velocity.py`: save residual displacement time-series via `--save-res` and `--res-file` options (#588)
+ support very long time-series file with date in `isoformat`. e.g YYYY-MM-DDTHH:MM for reading and plotting.
+ initial test config file for hyp3 `test/configs/RidgecrestSenDT71.txt`

**Reminders**

- [x] Fix #588
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.