### PR TITLE
switch pykml install from pip git+https to conda

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,12 +20,12 @@ dependencies:
   - matplotlib
   - numpy
   - pip
+  - pykml
   - pyproj
   - scikit-image
   - scipy
   - pip:
     - git+https://github.com/insarlab/PySolid.git
-    - git+https://github.com/tylere/pykml.git
   # for ARIA, FRInGE, HyP3, GMTSAR
   - gdal>=3
   # for PyAPS

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,6 @@ Run the following in your terminal to install the dependencies to your conda env
 conda install --yes -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
 
 $CONDA_PREFIX/bin/pip install git+https://github.com/insarlab/PySolid.git
-$CONDA_PREFIX/bin/pip install git+https://github.com/tylere/pykml.git
 ```
 
 Or run the following in your terminal to install the dependencies to a new environment _**mintpy**_:
@@ -164,7 +163,6 @@ git clone https://github.com/yunjunz/PyAPS.git
 # Add "isce2"     below to install extra dependencies if you use ISCE-2
 conda install --yes -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
 $CONDA_PREFIX/bin/pip install git+https://github.com/insarlab/PySolid.git
-$CONDA_PREFIX/bin/pip install git+https://github.com/tylere/pykml.git
 
 # option 2 - install dependencies to a new environment named `mintpy`
 conda env create -f MintPy/docs/environment.yml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ lxml
 matplotlib
 numpy
 pip
+pykml
 pyproj
 scikit-image
 scipy

--- a/mintpy/info.py
+++ b/mintpy/info.py
@@ -164,7 +164,7 @@ def print_timseries_date_stat(dateList):
     datevector = ptime.date_list2vector(dateList)[1]
     print('Start Date: {}'.format(dateList[0]))
     print('End   Date: {}'.format(dateList[-1]))
-    print('Number of date   : {}'.format(len(dateList)))
+    print('Number of dates  : {}'.format(len(dateList)))
     print('STD of datetimes : {:.2f} years'.format(np.std(datevector)))
     #print('----------------------')
     #print('List of dates:\n{}'.format(dateList))

--- a/mintpy/tropo_pyaps.py
+++ b/mintpy/tropo_pyaps.py
@@ -483,18 +483,17 @@ def get_delay_timeseries(inps, atr):
     return
 
 
-def correct_timeseries(timeseries_file, trop_file, out_file):
+def correct_timeseries(dis_file, tropo_file, cor_dis_file):
+    # diff.py can handle different reference in space and time
+    # between the absolute tropospheric delay and the double referenced time-series
     print('\n------------------------------------------------------------------------------')
-    print('correcting delay for input time-series by calling diff.py')
-    cmd = 'diff.py {} {} -o {} --force'.format(timeseries_file,
-                                               trop_file,
-                                               out_file)
-    print(cmd)
-    status = subprocess.Popen(cmd, shell=True).wait()
-    if status != 0:
-        raise Exception(('Error while correcting timeseries file '
-                         'using diff.py with tropospheric delay file.'))
-    return out_file
+    print('correcting relative delay for input time-series using diff.py')
+    from mintpy import diff
+
+    iargs = [dis_file, tropo_file, '-o', cor_dis_file, '--force']
+    print('diff.py', ' '.join(iargs))
+    diff.main(iargs)
+    return cor_dis_file
 
 
 ###############################################################

--- a/mintpy/tropo_pyaps3.py
+++ b/mintpy/tropo_pyaps3.py
@@ -10,7 +10,6 @@ import os
 import sys
 import re
 from configparser import ConfigParser
-import subprocess
 import argparse
 import h5py
 import numpy as np

--- a/mintpy/version.py
+++ b/mintpy/version.py
@@ -8,7 +8,7 @@ import subprocess
 
 ###########################################################################
 
-def get_release_info(version='v1.3.1', date='2021-08-02s'):
+def get_release_info(version='v1.3.1', date='2021-08-02'):
     """Grab version and date of the latest commit from a git repository"""
     # go to the repository directory
     dir_orig = os.getcwd()

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ def do_setup():
             "lxml",
             "matplotlib",
             "numpy",
+            "pykml",
             "pyproj",
             "setuptools",
             "scikit-image",
@@ -91,7 +92,6 @@ def do_setup():
         ],
         dependency_links=[
             "git+https://github.com/insarlab/PySolid.git",
-            "git+https://github.com/tylere/pykml.git",
         ],
 
         # data files


### PR DESCRIPTION
**Description of proposed changes**

+ install: Switch pykml installation to conda via conda-forge channel as it is now updated to the python2/3 version on both conda-forge channel (https://github.com/conda-forge/pykml-feedstock/pull/11; https://github.com/insarlab/MintPy/issues/648) and PyPI, same as the github repo. Thank you @jhkennedy!

+ tropo_pyaps(3).py: remove usage of subprocess

+ info/versoin: typo fix

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)