### PR TITLE
utils: refactor time_func.py and add s1_utils.py 

### DIFF
--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -26,6 +26,8 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
     /objects
         conncomp      (objects/ramp)
         stack         (utils/ptime)
+    /utils
+        time_func     (utils/ptime)
     /simulation
         decorrelation (utils/ptime)
         defo_model    (utils/utils0)
@@ -33,6 +35,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
 ------------------ level 2 --------------------
     /utils
         readfile      (objects/{stack, giant})
+        s1_utils      (utils/{ptime, time_func})
 ------------------ level 3 --------------------
     /objects
         resample      (utils/{readfile, utils0, ptime})

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -1,6 +1,6 @@
 Here are example interferogram stacks pre-processed using different InSAR processors.
 
-#### Sentinel-1 on Fernandina with ISCE ####
+### Sentinel-1 on Fernandina with ISCE ###
 
 Area: Fernandina volcano at Galápagos Islands, Ecuador     
 Data: Sentinel-1 A/B descending track 128 during Dec 2014 - June 2018 (98 acquisitions; [Zenodo](https://zenodo.org/record/3952953))      
@@ -21,7 +21,7 @@ Relevant literature:
 
 + Yunjun, Z., H. Fattahi, and F. Amelung (2019), Small baseline InSAR time series analysis: Unwrapping error correction and noise reduction, _Computers & Geosciences, 133,_ 104331, doi:10.1016/j.cageo.2019.104331.
 
-#### Sentinel-1 on San Francisco Bay with ARIA ####
+### Sentinel-1 on San Francisco Bay with ARIA ###
 
 Area: San Francisco Bay, California, USA     
 Data: Sentinel-1 A/B descending track 42 during May 2015 - March 2020 (114 acquisitoins; [Zenodo](https://zenodo.org/record/4265413))    
@@ -42,7 +42,7 @@ Relevant literature:
 
 + Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct connection between the Hayward and Calaveras Faults, _Geophysical Research Letters,_ 42(8), 2734-2741, doi:10.1002/2015GL063575.
 
-#### Envisat of the 2008 Wells earthquake with Gamma ####
+### Envisat of the 2008 Wells, Nevada earthquake with Gamma ###
 
 Area: Wells, Nevada, USA ([USGS event page](https://earthquake.usgs.gov/earthquakes/eventpage/nn00234425/executive))       
 Data: Envisat ASAR descending track 399 during July 2007 - September 2008 (11 acquisitions; [Zenodo](https://zenodo.org/record/3952950))      
@@ -63,7 +63,20 @@ Relevant literature:
 
 + Nealy, J. L., H. M. Benz, G. P. Hayes, E. A. Bergman, and W. D. Barnhart (2017), The 2008 Wells, Nevada, Earthquake Sequence: Source Constraints Using Calibrated Multiple‐Event Relocation and InSAR, _Bulletin of the Seismological Society of America_, 107(3), 1107-1117, doi:10.1785/0120160298.
 
-#### Sentinel-1 on Western Cape, South Africa with SNAP ####
+### Sentinel-1 of the 2019 Ridgecrest, California earthquake sequence with HyP3 ###
+
+Area: Owens Valley, California, USA ([USGS event page](https://earthquake.usgs.gov/earthquakes/eventpage/ci38457511/executive))        
+Data: Sentinel-1 descending track 71 during June - August 2019 (7 acquisitions; [Zenodo](https://zenodo.org/record/5502403))       
+Size: ~480 MB
+
+```bash
+wget https://zenodo.org/record/5502403/files/RidgecrestSenDT71.tar.xz
+tar -xvJf RidgecrestSenDT71.tar.xz
+cd RidgecrestSenDT71
+smallbaselineApp.py ${MINTPY_HOME}/mintpy/data/input_files/RidgecrestSenDT71.txt
+```
+
+### Sentinel-1 on Western Cape, South Africa with SNAP ###
 
 Area: West coast of Western Cape province, South Africa        
 Data: Sentinel-1 ascending track 29 during March - June 2019 (10 acquisitions; [Zenodo](https://zenodo.org/record/4318134))       
@@ -76,7 +89,7 @@ cd WCapeSenAT29
 smallbaselineApp.py ${MINTPY_HOME}/mintpy/data/input_files/WCapeSenAT29.txt
 ```
 
-#### ALOS on Kuju with ROI_PAC ####
+### ALOS on Kuju with ROI_PAC ###
 
 Area: Kuju volcano at Kyushu island, SW Japan     
 Data: ALOS PALSAR ascending track 422 during January 2007 - January 2011 (24 acquisitions; [Zenodo](https://zenodo.org/record/3952917))     

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -98,9 +98,3 @@ Relevant literature:
 + Nakaboh, M., H. Ono, M. Sako, Y. Sudo, T. Hashimoto, and A. W. Hurst (2003), Continuing deflation by fumaroles at Kuju Volcano, Japan, _Geophysical Research Letters_, 30(7), doi:10.1029/2002gl016047.
 + Ishitsuka, K., T. Tsuji, T. Matsuoka, J. Nishijima, and Y. Fujimitsu (2016), Heterogeneous surface displacement pattern at the Hatchobaru geothermal field inferred from SAR interferometry time-series, _International Journal of Applied Earth Observation and Geoinformation_, 44, 95-103, doi:10.1016/j.jag.2015.07.006.
 
-<br><br>
-Check the auto plotted figures in **mintpy/pic** folder, and modify the plotting parameters to adjust your plotting, and re-run the plotting script to update your plotting result:   
-
-```
-./plot_smallbaselineApp.sh
-```

--- a/mintpy/data/input_files/RidgecrestSenDT71.txt
+++ b/mintpy/data/input_files/RidgecrestSenDT71.txt
@@ -8,15 +8,11 @@ mintpy.load.corFile         = ../hyp3/*/*corr_clip.tif
 mintpy.load.demFile         = ../hyp3/*/*dem_clip.tif
 mintpy.load.incAngleFile    = ../hyp3/*/*lv_theta_clip.tif
 mintpy.load.waterMaskFile   = ../hyp3/*/*water_mask_clip.tif
-##---------subset (optional):
-## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
-mintpy.subset.yx            = auto    #[y0:y1,x0:x1 / no], auto for no
-mintpy.subset.lalo          = 391e4:400e4,39e4:51e4    #[S:N,W:E / no], auto for no
 
 mintpy.reference.lalo       = 391.5e4,45e4
-mintpy.networkInversion.weightFunc  = no
+mintpy.networkInversion.weightFunc  = var
 mintpy.troposphericDelay.method     = pyaps
 mintpy.topographicResidual          = yes
 mintpy.topographicResidual.stepFuncDate         = 20190706T0320
-mintpy.topographicResidual.pixelwiseGeometry    = no
+mintpy.topographicResidual.pixelwiseGeometry    = yes
 

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -248,7 +248,7 @@ mintpy.deramp.maskFile = auto  #[filename / no], auto for maskTempCoh.h5, mask f
 mintpy.topographicResidual                   = auto  #[yes / no], auto for yes
 mintpy.topographicResidual.polyOrder         = auto  #[1-inf], auto for 2, poly order of temporal deformation model
 mintpy.topographicResidual.phaseVelocity     = auto  #[yes / no], auto for no - phase, use phase velocity for minimization
-mintpy.topographicResidual.stepFuncDate      = auto  #[20080529,20100611 / no], auto for no, date of step jump
+mintpy.topographicResidual.stepFuncDate      = auto  #[20080529,20190704T1733 / no], auto for no, date of step jump
 mintpy.topographicResidual.excludeDate       = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
 mintpy.topographicResidual.pixelwiseGeometry = auto  #[yes / no], auto for yes, use pixel-wise geometry info
 

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -247,13 +247,19 @@ def get_design_matrix4defo(inps):
     msg += '\n'+'-'*80
     print(msg)
 
-    # get design matrix for temporal deformation model
+    # prepare temporal deformation model
     model = dict()
     model['polynomial'] = inps.polyOrder
     model['step'] = inps.stepFuncDate
     model['periodic'] = inps.periodic
-    date_list = timeseries(inps.timeseries_file).get_date_list()
-    G_defo = time_func.get_design_matrix4time_func(date_list, model)
+
+    # prepare SAR info
+    ts_obj = timeseries(inps.timeseries_file)
+    date_list = ts_obj.get_date_list()
+    seconds = ts_obj.get_metadata().get('CENTER_LINE_UTC', 0)
+
+    # compose design matrix
+    G_defo = time_func.get_design_matrix4time_func(date_list, model, seconds=seconds)
 
     return G_defo
 

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -15,7 +15,7 @@ import numpy as np
 from scipy import linalg
 from mintpy.objects import timeseries, geometry, cluster
 from mintpy.defaults.template import get_template_content
-from mintpy.utils import arg_group, ptime, readfile, writefile, utils as ut
+from mintpy.utils import arg_group, ptime, time_func, readfile, writefile, utils as ut
 
 
 # key configuration parameter name
@@ -253,7 +253,7 @@ def get_design_matrix4defo(inps):
     model['step'] = inps.stepFuncDate
     model['periodic'] = inps.periodic
     date_list = timeseries(inps.timeseries_file).get_date_list()
-    G_defo = timeseries.get_design_matrix4time_func(date_list, model)
+    G_defo = time_func.get_design_matrix4time_func(date_list, model)
 
     return G_defo
 

--- a/mintpy/objects/sensor.py
+++ b/mintpy/objects/sensor.py
@@ -262,6 +262,19 @@ ENV = {
     'ground_range_pixel_size'    : 21.3,      # m
 }
 
+# Radarsat-2 stripmap ultra-fine mode
+# from Table 2 in Jung et al. (2014)
+RSAT2 = {
+    'carrier_frequency'          : 5.405e9,   # Hz
+    'antenna_length'             : 6.55,      # m
+    'doppler_bandwidth'          : 2308,      # Hz
+    'pulse_repetition_frequency' : 3637,      # Hz
+    'chirp_bandwidth'            : 78.16e6,   # Hz
+    'sampling_frequency'         : 112.68e6,  # Hz
+    'azimuth_pixel_size'         : 2.2,       # m
+    'ground_range_pixel_size'    : 2.1,       # m
+}
+
 # Sentinel-1 Interferometric Wide (IW / TOPS) swath mode
 # Typical value:
 # azfact = azResolution / azPixelSize = 1.46
@@ -282,19 +295,6 @@ SEN = {
     'IW1' : {'range_resolution' : 2.7, 'azimuth_resolution': 22.5},
     'IW2' : {'range_resolution' : 3.1, 'azimuth_resolution': 22.7},
     'IW3' : {'range_resolution' : 3.5, 'azimuth_resolution': 22.6},
-}
-
-# Radarsat-2 stripmap ultra-fine mode
-# from Table 2 in Jung et al. (2014)
-RSAT2 = {
-    'carrier_frequency'          : 5.405e9,   # Hz
-    'antenna_length'             : 6.55,      # m
-    'doppler_bandwidth'          : 2308,      # Hz
-    'pulse_repetition_frequency' : 3637,      # Hz
-    'chirp_bandwidth'            : 78.16e6,   # Hz
-    'sampling_frequency'         : 112.68e6,  # Hz
-    'azimuth_pixel_size'         : 2.2,       # m
-    'ground_range_pixel_size'    : 2.1,       # m
 }
 
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -13,10 +13,10 @@ import sys
 import re
 import time
 import itertools
-from datetime import datetime as dt, timedelta
+import datetime as dt
 import h5py
 import numpy as np
-from mintpy.utils import ptime
+from mintpy.utils import ptime, time_func
 
 
 ##------------------ Global Variables ---------------------##
@@ -153,6 +153,8 @@ class timeseries:
 
     File structure: https://mintpy.readthedocs.io/en/latest/api/data_structure/#timeseries
     """
+    # point get_design_matrix4time_func() to utils.time_func for backward compatibility
+    get_design_matrix4time_func = time_func.get_design_matrix4time_func
 
     def __init__(self, file=None):
         self.file = file
@@ -184,11 +186,11 @@ class timeseries:
 
         # time info
         self.dateFormat = ptime.get_date_str_format(self.dateList[0])
-        self.times = np.array([dt.strptime(i, self.dateFormat) for i in self.dateList])
+        self.times = np.array([dt.datetime.strptime(i, self.dateFormat) for i in self.dateList])
         # add hh/mm/ss info to the datetime objects
         if 'T' not in self.dateFormat or all(i.hour==0 and i.minute==0 for i in self.times):
             utc_sec = float(self.metadata['CENTER_LINE_UTC'])
-            self.times = np.array([i + timedelta(seconds=utc_sec) for i in self.times])
+            self.times = np.array([i + dt.timedelta(seconds=utc_sec) for i in self.times])
         self.tbase = np.array([(i.days + i.seconds / (24 * 60 * 60))
                                for i in (self.times - self.times[self.refIndex])],
                               dtype=np.float32)
@@ -450,243 +452,6 @@ class timeseries:
                 f.write('{}\t{}\n'.format(d, pbase))
         return out_file
 
-
-    #####---------- time functions
-    @staticmethod
-    def get_design_matrix4time_func(date_list, model=None, refDate=None):
-        """design matrix/function model of linear velocity estimation
-        Parameters: date_list : list of str in YYYYMMDD format, size=num_date
-                    model     : dict of time functions, e.g.:
-                                {'polynomial' : 2,                    # int, polynomial degree with 1 (linear), 2 (quadratic), 3 (cubic), etc.
-                                 'periodic'   : [1.0, 0.5],           # list of float, period(s) in years. 1.0 (annual), 0.5 (semiannual), etc.
-                                 'step'       : ['20061014'],         # list of str, date(s) in YYYYMMDD.
-                                 'exp'        : {'20181026': [60],    # dict, key for onset time in YYYYMMDD and value for char. times in days.
-                                                 ...
-                                                 },
-                                 'log'        : {'20161231': [80.5],  # dict, key for onset time in YYYYMMDD and value for char. times in days.
-                                                 '20190125': [100, 200],
-                                                 ...
-                                                 },
-                                 ...
-                                 }
-        Returns:    A         : 2D array of design matrix in size of (num_date, num_param)
-                                num_param = (poly_deg + 1) + 2*len(periodic) + len(steps) + len(exp_taus) + len(log_taus)
-        """
-
-        def get_design_matrix4polynomial_func(yr_diff, degree):
-            """design matrix/function model of linear/polynomial velocity estimation
-
-            The k! denominator makes the estimated polynomial coefficient (c_k) physically meaningful:
-                k=1 makes c_1 the velocity;
-                k=2 makes c_2 the acceleration;
-                k=3 makes c_3 the acceleration rate;
-
-            Parameters: yr_diff: time difference from refDate in decimal years
-                        degree : polynomial models: 1=linear, 2=quadratic, 3=cubic, etc.
-            Returns:    A      : 2D array of poly-coeff. in size of (num_date, degree+1)
-            """
-            A = np.zeros([len(yr_diff), degree + 1], dtype=np.float32)
-            for i in range(degree+1):
-                A[:,i] = (yr_diff**i) / np.math.factorial(i)
-
-            return A
-
-
-        def get_design_matrix4periodic_func(yr_diff, periods):
-            """design matrix/function model of periodic velocity estimation
-            Parameters: yr_diff : 1D array of time difference from refDate in decimal years
-                        periods : list of period in years: 1=annual, 0.5=semiannual, etc.
-            Returns:    A       : 2D array of periodic sine & cosine coeff. in size of (num_date, 2*num_period)
-            """
-            num_date = len(yr_diff)
-            num_period = len(periods)
-            A = np.zeros((num_date, 2*num_period), dtype=np.float32)
-
-            for i, period in enumerate(periods):
-                c0, c1 = 2*i, 2*i+1
-                A[:, c0] = np.cos(2*np.pi/period * yr_diff)
-                A[:, c1] = np.sin(2*np.pi/period * yr_diff)
-
-            return A
-
-
-        def get_design_matrix4step_func(date_list, step_date_list):
-            """design matrix/function model of coseismic velocity estimation
-            Parameters: date_list      : list of dates in YYYYMMDD format
-                        step_date_list : Heaviside step function(s) with date in YYYYMMDD
-            Returns:    A              : 2D array of zeros & ones in size of (num_date, num_step)
-            """
-            num_date = len(date_list)
-            num_step = len(step_date_list)
-            A = np.zeros((num_date, num_step), dtype=np.float32)
-
-            t = np.array(ptime.yyyymmdd2years(date_list))
-            t_steps = ptime.yyyymmdd2years(step_date_list)
-            for i, t_step in enumerate(t_steps):
-                A[:, i] = np.array(t > t_step).flatten()
-
-            return A
-
-
-        def get_design_matrix4exp_func(date_list, exp_dict):
-            """design matrix/function model of exponential postseismic relaxation estimation
-
-            Reference: Eq. (5) in Hetland et al. (2012, JGR).
-            Note that there is a typo in the paper for this equation, based on the MInTS code, it should be:
-                Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t-T_i)/tau_i)] }
-            instead of the one below shown in the paper:
-                Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t)/tau_i)] }
-            where:
-                a_i         amplitude      of i-th exp term
-                T_i         onset time     of i-th exp term
-                tau_i       char time      of i-th exp term (relaxation time)
-                H(t-T_i)    Heaviside func of i-th exp term (ensuring the exp func is one-sided)
-
-            Parameters: date_list      : list of dates in YYYYMMDD format
-                        exp_dict       : dict of exp func(s) info as:
-                                         {{onset_time1} : [{char_time11,...,char_time1N}],
-                                          {onset_time2} : [{char_time21,...,char_time2N}],
-                                          ...
-                                          }
-                                         where onset_time is string  in YYYYMMDD format and
-                                               char_time  is float32 in decimal days
-            Returns:    A              : 2D array of zeros & ones in size of (num_date, num_exp)
-            """
-            num_date = len(date_list)
-            num_exp  = sum([len(val) for key, val in exp_dict.items()])
-            A = np.zeros((num_date, num_exp), dtype=np.float32)
-
-            t = np.array(ptime.yyyymmdd2years(date_list))
-            # loop for onset time(s)
-            i = 0
-            for exp_onset in exp_dict.keys():
-                # convert string to float in years
-                exp_T = ptime.yyyymmdd2years(exp_onset)
-
-                # loop for charateristic time(s)
-                for exp_tau in exp_dict[exp_onset]:
-                    # convert time from days to years
-                    exp_tau /= 365.25
-                    A[:, i] = np.array(t > exp_T).flatten() * (1 - np.exp(-1 * (t - exp_T) / exp_tau))
-                    i += 1
-
-            return A
-
-
-        def get_design_matrix4log_func(date_list, log_dict):
-            """design matrix/function model of logarithmic postseismic relaxation estimation
-
-            Reference: Eq. (4) in Hetland et al. (2012, JGR)
-            Note that there is a typo in the paper for this equation, based on the MInTS code, it should be:
-                Sum_i{ a_i * H(t-Ti) * [1 + log((t-T_i)/tau_i)] }
-            instead of the one below shown in the paper:
-                Sum_i{ a_i * H(t-Ti) * [1 + log((t)/tau_i)] }
-            where:
-                a_i         amplitude      of i-th log term
-                T_i         onset time     of i-th log term
-                tau_i       char time      of i-th log term (relaxation time)
-                H(t-T_i)    Heaviside func of i-th log term (ensuring the log func is one-sided)
-
-            Parameters: date_list      : list of dates in YYYYMMDD format
-                        log_dict       : dict of log func(s) info as:
-                                         {{onset_time1} : [{char_time11,...,char_time1N}],
-                                          {onset_time2} : [{char_time21,...,char_time2N}],
-                                          ...
-                                          }
-                                         where onset_time is string  in YYYYMMDD format and
-                                               char_time  is float32 in decimal days
-            Returns:    A              : 2D array of zeros & ones in size of (num_date, num_log)
-            """
-            num_date = len(date_list)
-            num_log  = sum([len(log_dict[x]) for x in log_dict])
-            A = np.zeros((num_date, num_log), dtype=np.float32)
-
-            t = np.array(ptime.yyyymmdd2years(date_list))
-            # loop for onset time(s)
-            i = 0
-            for log_onset in log_dict.keys():
-                # convert string to float in years
-                log_T = ptime.yyyymmdd2years(log_onset)
-
-                # loop for charateristic time(s)
-                for log_tau in log_dict[log_onset]:
-                    # convert time from days to years
-                    log_tau /= 365.25
-
-                    olderr = np.seterr(invalid='ignore', divide='ignore')
-                    A[:, i] = np.array(t > log_T).flatten() * np.nan_to_num(np.log(1 + (t - log_T) / log_tau), nan=0, neginf=0)
-                    np.seterr(**olderr)
-                    i += 1
-
-            return A
-
-
-        ## prepare time info
-        # convert list of date into array of years in float
-        yr_diff = np.array(ptime.yyyymmdd2years(date_list))
-
-        # reference date
-        if refDate is None:
-            refDate = date_list[0]
-        yr_diff -= yr_diff[date_list.index(refDate)]
-
-        ## construct design matrix A
-        # default model value
-        if not model:
-            model = {'polynomial' : 1}
-
-        # read the models
-        poly_deg   = model.get('polynomial', 0)
-        periods    = model.get('periodic', [])
-        steps      = model.get('step', [])
-        exps       = model.get('exp', dict())
-        logs       = model.get('log', dict())
-        num_period = len(periods)
-        num_step   = len(steps)
-        num_exp    = sum([len(val) for key, val in exps.items()])
-        num_log    = sum([len(val) for key, val in logs.items()])
-
-        num_param = (poly_deg + 1) + (2 * num_period) + num_step + num_exp + num_log
-        if num_param <= 1:
-            raise ValueError('NO time functions specified!')
-
-        # initialize the design matrix
-        num_date = len(yr_diff)
-        A = np.zeros((num_date, num_param), dtype=np.float32)
-        c0 = 0
-
-        # update linear/polynomial term(s)
-        if poly_deg > 0:
-            c1 = c0 + poly_deg + 1
-            A[:, c0:c1] = get_design_matrix4polynomial_func(yr_diff, poly_deg)
-            c0 = c1
-
-        # update periodic term(s)
-        if num_period > 0:
-            c1 = c0 + 2 * num_period
-            A[:, c0:c1] = get_design_matrix4periodic_func(yr_diff, periods)
-            c0 = c1
-
-        # update coseismic/step term(s)
-        if num_step > 0:
-            c1 = c0 + num_step
-            A[:, c0:c1] = get_design_matrix4step_func(date_list, steps)
-            c0 = c1
-
-        # update exponential term(s)
-        if num_exp > 0:
-            c1 = c0 + num_exp
-            A[:, c0:c1] = get_design_matrix4exp_func(date_list, exps)
-            c0 = c1
-
-        # update logarithmic term(s)
-        if num_log > 0:
-            c1 = c0 + num_log
-            A[:, c0:c1] = get_design_matrix4log_func(date_list, logs)
-            c0 = c1
-
-        return A
-
 ################################ timeseries class end ##################################
 
 
@@ -935,8 +700,8 @@ class ifgramStack:
         # convert date from str to datetime.datetime objects
         self.mDates = np.array([i.decode('utf8') for i in dates[:, 0]])
         self.sDates = np.array([i.decode('utf8') for i in dates[:, 1]])
-        self.mTimes = np.array([dt.strptime(i, self.dateFormat) for i in self.mDates])
-        self.sTimes = np.array([dt.strptime(i, self.dateFormat) for i in self.sDates])
+        self.mTimes = np.array([dt.datetime.strptime(i, self.dateFormat) for i in self.mDates])
+        self.sTimes = np.array([dt.datetime.strptime(i, self.dateFormat) for i in self.sDates])
 
     def read(self, datasetName='unwrapPhase', box=None, print_msg=True, dropIfgram=False):
         """Read 3D dataset with bounding box in space
@@ -1289,7 +1054,7 @@ class ifgramStack:
 
         # tbase in the unit of years
         date_format = ptime.get_date_str_format(date_list[0])
-        dates = np.array([dt.strptime(i, date_format) for i in date_list])
+        dates = np.array([dt.datetime.strptime(i, date_format) for i in date_list])
         tbase = [i.days + i.seconds / (24 * 60 * 60) for i in (dates - dates[0])]
         tbase = np.array(tbase, dtype=np.float32) / 365.25
 

--- a/mintpy/simulation/simulation.py
+++ b/mintpy/simulation/simulation.py
@@ -13,8 +13,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from mintpy.defaults.plot import *
-from mintpy.objects import timeseries, sensor
-from mintpy.utils import ptime, network as pnet
+from mintpy.objects import sensor
+from mintpy.utils import ptime, time_func, network as pnet
 
 # load all modules in this sub-directory for easy import
 from mintpy.simulation.decorrelation import *
@@ -222,7 +222,7 @@ def estimate_coherence(ifgram, L=20, win_size=25):
 
 def timeseries2velocity(date_list, defo_list):
     # date_list --> design_matrix
-    A = timeseries.get_design_matrix4time_func(date_list)
+    A = time_func.get_design_matrix4time_func(date_list)
     A_inv = np.linalg.pinv(A)
 
     # least square inversion

--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -424,6 +424,7 @@ def run_timeseries2time_func(inps):
     length, width = int(atr['LENGTH']), int(atr['WIDTH'])
     num_date = inps.numDate
     dates = np.array(inps.dateList)
+    seconds = atr.get('CENTER_LINE_UTC', 0)
 
     # use the 1st date as reference if not found, e.g. timeseriesResidual.h5 file
     if "REF_DATE" not in atr.keys() and not inps.ref_date:
@@ -573,7 +574,8 @@ def run_timeseries2time_func(inps):
                 m_boot[i] = time_func.estimate_time_func(
                     model=model,
                     date_list=dates[boot_ind].tolist(),
-                    dis_ts=ts_data[boot_ind])[1]
+                    dis_ts=ts_data[boot_ind],
+                    seconds=seconds)[1]
 
                 prog_bar.update(i+1, suffix='iteration {} / {}'.format(i+1, inps.bootstrapCount))
             prog_bar.close()
@@ -590,7 +592,8 @@ def run_timeseries2time_func(inps):
             G, m[:, mask], e2 = time_func.estimate_time_func(
                 model=model,
                 date_list=inps.dateList,
-                dis_ts=ts_data)
+                dis_ts=ts_data,
+                seconds=seconds)
             #del ts_data
 
             ## Compute the covariance matrix for model parameters: Gm = d

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -15,7 +15,7 @@ from scipy import linalg, stats
 from matplotlib import pyplot as plt, ticker, widgets, patches
 
 from mintpy.objects import timeseries, giantTimeseries, HDFEOS
-from mintpy.utils import arg_group, readfile, ptime, plot as pp, utils as ut
+from mintpy.utils import arg_group, ptime, time_func, readfile, utils as ut, plot as pp
 from mintpy.multilook import multilook_data
 from mintpy import subset, view, timeseries2velocity as ts2vel
 
@@ -331,8 +331,7 @@ def read_init_info(inps):
     # dense TS for plotting
     inps.date_list_fit = ptime.get_date_range(inps.date_list[0], inps.date_list[-1])
     inps.dates_fit = ptime.date_list2vector(inps.date_list_fit)[0]
-    inps.G_fit = timeseries.get_design_matrix4time_func(date_list=inps.date_list_fit,
-                                                        model=inps.model)
+    inps.G_fit = time_func.get_design_matrix4time_func(inps.date_list_fit, inps.model)
     return inps, atr
 
 
@@ -586,7 +585,7 @@ def get_model_param_str(model, ds_dict, unit_fac=100):
 def fit_time_func(model, date_list, ts_dis, unit_fac=100, G_fit=None, conf_level=0.95):
     """Fit a suite of fime functions to the time series.
     Equations:  Gm = d
-    Parameters: model      - dict of time functions, check timeseries2velocity.estimate_time_func() for details.
+    Parameters: model      - dict of time functions, check utils.time_func.estimate_time_func() for details.
                 date_list  - list of dates in YYYYMMDD format
                 ts_dis     - 1D np.ndarray, displacement time series
                 unit_fac   - float, scaling factor due to different data and display units
@@ -606,9 +605,10 @@ def fit_time_func(model, date_list, ts_dis, unit_fac=100, G_fit=None, conf_level
         return m_strs, ts_fit, ts_fit_lim
 
     # 1.1 estimate time func parameter via least squares (OLS)
-    G, m, e2 = ts2vel.estimate_time_func(model=model,
-                                         date_list=date_list,
-                                         dis_ts=ts_dis)
+    G, m, e2 = time_func.estimate_time_func(
+        model=model,
+        date_list=date_list,
+        dis_ts=ts_dis)
 
     # 1.2 calc the precision of time func parameters
     # using the OLS estimation residues e2 = sum((d - Gm) ** 2)

--- a/mintpy/utils/arg_group.py
+++ b/mintpy/utils/arg_group.py
@@ -347,18 +347,18 @@ def add_timefunc_argument(parser):
                            '--periodic 1.0 0.5                        # an annual cycle plus a semi-annual cycle\n')
     model.add_argument('--step', dest='step', type=str, nargs='+', default=[],
                       help='step function(s) at YYYYMMDD (default: %(default)s). E.g.:\n' +
-                           '--step 20061014                           # coseismic step  at 2006-10-14\n' +
-                           '--step 20110311 20120928                  # coseismic steps at 2011-03-11 and 2012-09-28\n')
+                           '--step 20061014                           # coseismic step  at 2006-10-14T00:00\n' +
+                           '--step 20110311 20120928T1733             # coseismic steps at 2011-03-11T00:00 and 2012-09-28T17:33\n')
     model.add_argument('--exp', '--exponential', dest='exp', type=str, nargs='+', action='append', default=[],
                       help='exponential function(s) at YYYYMMDD with characteristic time(s) tau in decimal days (default: %(default)s). E.g.:\n' +
-                           '--exp  20181026 60                        # exp onset at 2006-10-14 with tau=60 days\n' +
-                           '--exp  20181026 60 120                    # exp onset at 2006-10-14 with tau=60 days overlayed by a tau=145 days\n' +
+                           '--exp  20181026 60                        # exp onset at 2006-10-14T00:00 with tau=60 days\n' +
+                           '--exp  20181026T1355 60 120               # exp onset at 2006-10-14T13:55 with tau=60 days overlayed by a tau=145 days\n' +
                            '--exp  20161231 80.5 --exp 20190125 100   # 1st exp onset at 2011-03-11 with tau=80.5 days and\n' +
                            '                                          # 2nd exp onset at 2012-09-28 with tau=100  days')
     model.add_argument('--log', '--logarithmic', dest='log', type=str, nargs='+', action='append', default=[],
                       help='logarithmic function(s) at YYYYMMDD with characteristic time(s) tau in decimal days (default: %(default)s). E.g.:\n' +
-                           '--log  20181016 90.4                      # log onset at 2006-10-14 with tau=90.4 days\n' +
-                           '--log  20181016 90.4 240                  # log onset at 2006-10-14 with tau=90.4 days overlayed by a tau=240 days\n' +
+                           '--log  20181016 90.4                      # log onset at 2006-10-14T00:00 with tau=90.4 days\n' +
+                           '--log  20181016T1733 90.4 240             # log onset at 2006-10-14T17:33 with tau=90.4 days overlayed by a tau=240 days\n' +
                            '--log  20161231 60 --log 20190125 180.2   # 1st log onset at 2011-03-11 with tau=60 days and\n' +
                            '                                          # 2nd log onset at 2012-09-28 with tau=180.2 days\n')
     return parser

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -212,7 +212,10 @@ def auto_figure_title(fname, datasetNames=[], inps_dict=None):
             fig_title = fbase
 
     elif fext in ['.h5','.he5']:
-        fig_title = fbase
+        if len(datasetNames) == 1:
+            fig_title = datasetNames[0]
+        else:
+            fig_title = fbase
 
     else:
         fig_title = os.path.basename(fname)

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -139,11 +139,11 @@ def decimal_year2datetime(years):
     return years_dt
 
 
-def yyyymmdd2years(dates):
+def yyyymmdd2years(dates, seconds=0):
     """Convert date(s) string into float number in the unit of year
-
-    Parameters: dates - (list of) str, date in YYYYMMDD format
-    Returns:    years - (list of) float, years including the date and time info
+    Parameters: dates   - (list of) str, date in YYYYMMDD format
+                seconds - float or str, time of the day info in seconds
+    Returns:    years   - (list of) float, years including the date and time info
     """
 
     # make a copy in list of input arg
@@ -161,6 +161,13 @@ def yyyymmdd2years(dates):
              d.hour / (365.25 * 24) +
              d.minute / (365.25 * 24 * 60) +
              d.second / (365.25 * 24 * 60 * 60))
+
+        # add time of the day info if:
+        # 1) seconds arg is valid AND
+        # 2) no time info from dates arg
+        if seconds and 'T' not in date_format:
+            y += float(seconds) / (365.25 * 24 * 60 * 60)
+
         years.append(y)
 
     if isinstance(dates, str):

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1566,12 +1566,12 @@ def read_gdal(fname, box=None, band=1, cpx_band='phase', xstep=1, ystep=1):
         box = (0, 0, ds.RasterXSize, ds.RasterYSize)
 
     # read
-    # link: https://gdal.org/python/osgeo.gdal.Band-class.html#ReadAsArray
-    kwargs = dict(xoff=box[0],
-                  yoff=box[1],
-                  win_xsize=box[2]-box[0],
-                  win_ysize=box[3]-box[1])
-    data = bnd.ReadAsArray(**kwargs)
+    # Note: do not use gdal python kwargs because of error: 'BandRasterIONumPy', argument 3 of type 'double'
+    # Recommendation: use rasterio instead of gdal pytho
+    # Link: https://gdal.org/python/osgeo.gdal.Band-class.html#ReadAsArray
+    #kwargs = dict(xoff=box[0], win_xsize=box[2]-box[0],
+    #              yoff=box[1], win_ysize=box[3]-box[1])
+    data = bnd.ReadAsArray()[box[1]:box[3], box[0]:box[2]]
 
     # adjust output band for complex data
     data_type = GDAL2ISCE_DATATYPE[bnd.DataType]

--- a/mintpy/utils/s1_utils.py
+++ b/mintpy/utils/s1_utils.py
@@ -1,0 +1,114 @@
+############################################################
+# Program is part of MintPy                                #
+# Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
+# Author: Zhang Yunjun, Aug 2021                           #
+############################################################
+# Recommand import:
+#   from mintpy.utils import s1_utils
+
+
+import os
+import numpy as np
+from mintpy.utils import ptime, time_func
+
+
+def estimate_S1AB_bias(mintpy_dir, dates, ts_dis):
+    """Estimate the bias between Sentinel-1 A and B.
+    Parameters: mintpy_dir - str, path of the mintpy working directory
+                dates      - list of datetime.datetime objects
+                ts_dis     - 2D np.ndarray in size of (num_date, num_pixel) in float32
+    Returns:    bias       - 1D np.ndarray in size of (num_pixel) in float32
+                flagA/B    - 1D np.ndarray in size of (num_date) in bool
+                dates_fit  - list of datetime.datetime objects
+                ts_fitA/B  - 1D np.ndarray in size of (num_date_fit) in float32
+    """
+    num_date = len(dates)
+    ts_dis = ts_dis.reshape(num_date, -1)
+
+    # dates/flags for S1A/B
+    date_listA = np.loadtxt(os.path.join(mintpy_dir, 'S1A_date.txt'), dtype=str).tolist()
+    date_listB = np.loadtxt(os.path.join(mintpy_dir, 'S1B_date.txt'), dtype=str).tolist()
+    date_list = sorted(date_listA + date_listB)
+    min_date = date_listB[0]
+    flagA = np.array([x in date_listA and x >= min_date for x in date_list], dtype=np.bool_)
+    flagB = np.array([x in date_listB and x >= min_date for x in date_list], dtype=np.bool_)
+    # update date_list to the shared time period only
+    date_listA = np.array(date_list)[flagA].tolist()
+    date_listB = np.array(date_list)[flagB].tolist()
+
+    # fit
+    model = dict(polynomial=1)
+    mA = time_func.estimate_time_func(model, date_listA, ts_dis[flagA, :], ref_date=date_listA[0])[1]
+    mB = time_func.estimate_time_func(model, date_listB, ts_dis[flagB, :], ref_date=date_listB[0])[1]
+
+    # grab bias/offset from the fitting time-series
+    date_list_fit = ptime.get_date_range(min_date, date_list[-1], dstep=10)
+    dates_fit = ptime.date_list2vector(date_list_fit)[0]
+    GA_fit = time_func.get_design_matrix4time_func(date_list_fit, model, ref_date=date_listA[0])
+    GB_fit = time_func.get_design_matrix4time_func(date_list_fit, model, ref_date=date_listB[0])
+    ts_fitA = np.matmul(GA_fit, mA)
+    ts_fitB = np.matmul(GB_fit, mB)
+    bias = np.median(ts_fitB - ts_fitA, axis=0)
+
+    return bias, flagA, flagB, dates_fit, ts_fitA, ts_fitB
+
+
+def get_subswath_masks(flag, cut_overlap_in_half=False):
+    """Get the 3 masks for each of the Sentinel-1 subswath.
+    Parameters: flag                - 2D np.ndarray in size of (length, width) in bool for valid observations
+                cut_overlap_in_half - bool, turn on for offset estimated with very large chip size
+    Returns:    mask1/2/3           - 2D np.ndarray in size of (length, width) in bool
+                box1/2/3            - list of (x0, y0, x1, y1) in int
+    Examples:   flag = readfile.read('inputs/geometryRadar.h5', datasetName='height')[0] != 0
+                mask1, mask2, mask3 = s1_utils.get_subswath_masks(flag)[:3]
+    """
+    length, width = flag.shape
+    iw1_x0 = 0
+    iw3_x1 = width
+
+    # get ymin/max based on the rough center colomn number for each subswath
+    x1, x2, x3 = int(width/6), int(width*3/6), int(width*5/6)
+    yind = np.where(flag[:, x1])[0];  iw1_y0, iw1_y1 = yind[0], yind[-1]
+    yind = np.where(flag[:, x2])[0];  iw2_y0, iw2_y1 = yind[0], yind[-1]
+    yind = np.where(flag[:, x3])[0];  iw3_y0, iw3_y1 = yind[0], yind[-1]
+
+    # get xmin/max based on the non-overlap rows
+    y0 = int((iw1_y0 + iw2_y0) / 2)
+    y1 = int((iw1_y1 + iw2_y1) / 2)
+    xs = [np.where(np.diff(flag[y0, :]))[0][0],
+          np.where(np.diff(flag[y1, :]))[0][0]]
+    iw2_x0, iw1_x1 = min(xs), max(xs)
+
+    y0 = int((iw2_y0 + iw3_y0) / 2)
+    y1 = int((iw2_y1 + iw3_y1) / 2)
+    xs = [np.where(np.diff(flag[y0, :]))[0][-1],
+          np.where(np.diff(flag[y1, :]))[0][-1]]
+    iw3_x0, iw2_x1 = min(xs), max(xs)
+
+    # iw1/2/3_x0/y0/x1/y1 --> box1/2/3
+    box1 = [iw1_x0, iw1_y0, iw1_x1, iw1_y1]
+    box2 = [iw2_x0, iw2_y0, iw2_x1, iw2_y1]
+    box3 = [iw3_x0, iw3_y0, iw3_x1, iw3_y1]
+
+    # adjust subswath overlap in X
+    if cut_overlap_in_half:
+        box2[0] += int((box1[2] - box2[0]) / 2)
+        box3[0] += int((box2[2] - box3[0]) / 2)
+
+    # initiate mask
+    mask1 = np.zeros((length, width), dtype=np.bool_)
+    mask2 = np.zeros((length, width), dtype=np.bool_)
+    mask3 = np.zeros((length, width), dtype=np.bool_)
+
+    # assign mask for each subswath
+    mask1[box1[1]:box1[3], box1[0]:box1[2]] = 1
+    mask2[box2[1]:box2[3], box2[0]:box2[2]] = 1
+    mask3[box3[1]:box3[3], box3[0]:box3[2]] = 1
+    mask1[mask2==1] = 0
+    mask2[mask3==1] = 0
+
+    return mask1, mask2, mask3, box1, box2, box3
+
+
+
+

--- a/mintpy/utils/time_func.py
+++ b/mintpy/utils/time_func.py
@@ -1,0 +1,301 @@
+############################################################
+# Program is part of MintPy                                #
+# Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
+# Author: Zhang Yunjun, Yuan-Kai Liu, Aug 2021             #
+############################################################
+# Recommend import:
+#   from mintpy.utils import time_func
+
+
+import numpy as np
+from scipy import linalg
+from mintpy.utils import ptime
+
+
+def estimate_time_func(model, date_list, dis_ts, ref_date=None):
+    """Deformation model estimator, using a suite of linear, periodic, step, exponential, and logarithmic function(s).
+
+    Problem setup:
+        Gm = d
+
+    Parameters: date_list - list of str, dates in YYYYMMDD format
+                dis_ts    - 2D np.ndarray, displacement observation in size of (num_date, num_pixel)
+                model     - dict of time functions, e.g.:
+                            {'polynomial' : 2,                    # int, polynomial degree with 1 (linear), 2 (quadratic), 3 (cubic), etc.
+                             'periodic'   : [1.0, 0.5],           # list of float, period(s) in years. 1.0 (annual), 0.5 (semiannual), etc.
+                             'step'       : ['20061014'],         # list of str, date(s) in YYYYMMDD.
+                             'exp'        : {'20181026': [60],    # dict, key for onset time in YYYYMMDD and value for char times in days.
+                                             ...
+                                            },
+                             'log'        : {'20161231': [80.5],  # dict, key for onset time in YYYYMMDD and value for char times in days.
+                                             '20190125': [100, 200],
+                                             ...
+                                            },
+                             ...
+                             }
+    Returns:    G         - 2D np.ndarray, design matrix           in size of (num_date, num_param)
+                m         - 2D np.ndarray, parameter solution      in size of (num_param, num_pixel)
+                e2        - 1D np.ndarray, sum of squared residual in size of (num_pixel,)
+    """
+
+    G = get_design_matrix4time_func(date_list, model, ref_date=ref_date)
+
+    # least squares solver
+    # Opt. 1: m = np.linalg.pinv(G).dot(dis_ts)
+    # Opt. 2: m = scipy.linalg.lstsq(G, dis_ts, cond=1e-15)[0]
+    # Numpy is not used because it can not handle NaN value in dis_ts
+    m, e2 = linalg.lstsq(G, dis_ts, cond=None)[:2]
+
+    # check empty e2 due to the rank-deficient G matrix for sigularities.
+    e2 = np.array(e2)
+    if e2.size == 0:
+        print('\nWarning: empty e2 residues array due to a redundant or rank-deficient G matrix. This can cause sigularities.')
+        print('Please check: https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.lstsq.html#scipy.linalg.lstsq')
+        print('The issue may be due to:')
+        print('\t1) very small char time(s) or tau(s) of the exp/log function(s)')
+        print('\t2) the onset time(s) of exp/log are far earlier than the minimum date of the time series.')
+        print('Try a different char time, onset time.')
+        print('Your G matrix of the temporal model: \n', G)
+        raise ValueError('G matrix is redundant/rank-deficient!')
+
+    return G, m, e2
+
+
+
+#################################### Design Matrices ##########################################
+
+def get_design_matrix4time_func(date_list, model=None, ref_date=None):
+    """Design matrix (function model) for time functions parameter estimation.
+    Parameters: date_list : list of str in YYYYMMDD format, size=num_date
+                model     : dict of time functions, e.g.:
+                            {'polynomial' : 2,                    # int, polynomial degree with 1 (linear), 2 (quadratic), 3 (cubic), etc.
+                             'periodic'   : [1.0, 0.5],           # list of float, period(s) in years. 1.0 (annual), 0.5 (semiannual), etc.
+                             'step'       : ['20061014'],         # list of str, date(s) in YYYYMMDD.
+                             'exp'        : {'20181026': [60],    # dict, key for onset time in YYYYMMDD and value for char. times in days.
+                                             ...
+                                             },
+                             'log'        : {'20161231': [80.5],  # dict, key for onset time in YYYYMMDD and value for char. times in days.
+                                             '20190125': [100, 200],
+                                             ...
+                                             },
+                             ...
+                             }
+    Returns:    A         : 2D array of design matrix in size of (num_date, num_param)
+                            num_param = (poly_deg + 1) + 2*len(periodic) + len(steps) + len(exp_taus) + len(log_taus)
+    """
+
+    ## prepare time info
+    # convert list of date into array of years in float
+    yr_diff = np.array(ptime.yyyymmdd2years(date_list))
+
+    # reference date
+    if ref_date is None:
+        ref_date = date_list[0]
+    yr_diff -= yr_diff[date_list.index(ref_date)]
+
+    ## construct design matrix A
+    # default model value
+    if not model:
+        model = {'polynomial' : 1}
+
+    # read the models
+    poly_deg   = model.get('polynomial', 0)
+    periods    = model.get('periodic', [])
+    steps      = model.get('step', [])
+    exps       = model.get('exp', dict())
+    logs       = model.get('log', dict())
+    num_period = len(periods)
+    num_step   = len(steps)
+    num_exp    = sum([len(val) for key, val in exps.items()])
+    num_log    = sum([len(val) for key, val in logs.items()])
+
+    num_param = (poly_deg + 1) + (2 * num_period) + num_step + num_exp + num_log
+    if num_param <= 1:
+        raise ValueError('NO time functions specified!')
+
+    # initialize the design matrix
+    num_date = len(yr_diff)
+    A = np.zeros((num_date, num_param), dtype=np.float32)
+    c0 = 0
+
+    # update linear/polynomial term(s)
+    if poly_deg > 0:
+        c1 = c0 + poly_deg + 1
+        A[:, c0:c1] = get_design_matrix4polynomial_func(yr_diff, poly_deg)
+        c0 = c1
+
+    # update periodic term(s)
+    if num_period > 0:
+        c1 = c0 + 2 * num_period
+        A[:, c0:c1] = get_design_matrix4periodic_func(yr_diff, periods)
+        c0 = c1
+
+    # update coseismic/step term(s)
+    if num_step > 0:
+        c1 = c0 + num_step
+        A[:, c0:c1] = get_design_matrix4step_func(date_list, steps)
+        c0 = c1
+
+    # update exponential term(s)
+    if num_exp > 0:
+        c1 = c0 + num_exp
+        A[:, c0:c1] = get_design_matrix4exp_func(date_list, exps)
+        c0 = c1
+
+    # update logarithmic term(s)
+    if num_log > 0:
+        c1 = c0 + num_log
+        A[:, c0:c1] = get_design_matrix4log_func(date_list, logs)
+        c0 = c1
+
+    return A
+
+
+
+def get_design_matrix4polynomial_func(yr_diff, degree):
+    """design matrix/function model of linear/polynomial velocity estimation
+
+    The k! denominator makes the estimated polynomial coefficient (c_k) physically meaningful:
+        k=1 makes c_1 the velocity;
+        k=2 makes c_2 the acceleration;
+        k=3 makes c_3 the acceleration rate;
+
+    Parameters: yr_diff: time difference from ref_date in decimal years
+                degree : polynomial models: 1=linear, 2=quadratic, 3=cubic, etc.
+    Returns:    A      : 2D array of poly-coeff. in size of (num_date, degree+1)
+    """
+    A = np.zeros([len(yr_diff), degree + 1], dtype=np.float32)
+    for i in range(degree+1):
+        A[:,i] = (yr_diff**i) / np.math.factorial(i)
+
+    return A
+
+
+def get_design_matrix4periodic_func(yr_diff, periods):
+    """design matrix/function model of periodic velocity estimation
+    Parameters: yr_diff : 1D array of time difference from ref_date in decimal years
+                periods : list of period in years: 1=annual, 0.5=semiannual, etc.
+    Returns:    A       : 2D array of periodic sine & cosine coeff. in size of (num_date, 2*num_period)
+    """
+    num_date = len(yr_diff)
+    num_period = len(periods)
+    A = np.zeros((num_date, 2*num_period), dtype=np.float32)
+
+    for i, period in enumerate(periods):
+        c0, c1 = 2*i, 2*i+1
+        A[:, c0] = np.cos(2*np.pi/period * yr_diff)
+        A[:, c1] = np.sin(2*np.pi/period * yr_diff)
+
+    return A
+
+
+def get_design_matrix4step_func(date_list, step_date_list):
+    """design matrix/function model of coseismic velocity estimation
+    Parameters: date_list      : list of dates in YYYYMMDD format
+                step_date_list : Heaviside step function(s) with date in YYYYMMDD
+    Returns:    A              : 2D array of zeros & ones in size of (num_date, num_step)
+    """
+    num_date = len(date_list)
+    num_step = len(step_date_list)
+    A = np.zeros((num_date, num_step), dtype=np.float32)
+
+    t = np.array(ptime.yyyymmdd2years(date_list))
+    t_steps = ptime.yyyymmdd2years(step_date_list)
+    for i, t_step in enumerate(t_steps):
+        A[:, i] = np.array(t > t_step).flatten()
+
+    return A
+
+
+def get_design_matrix4exp_func(date_list, exp_dict):
+    """design matrix/function model of exponential postseismic relaxation estimation
+
+    Reference: Eq. (5) in Hetland et al. (2012, JGR).
+    Note that there is a typo in the paper for this equation, based on the MInTS code, it should be:
+        Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t-T_i)/tau_i)] }
+    instead of the one below shown in the paper:
+        Sum_i{ a_i * H(t-Ti) * [1 - e^(-(t)/tau_i)] }
+    where:
+        a_i         amplitude      of i-th exp term
+        T_i         onset time     of i-th exp term
+        tau_i       char time      of i-th exp term (relaxation time)
+        H(t-T_i)    Heaviside func of i-th exp term (ensuring the exp func is one-sided)
+
+    Parameters: date_list      : list of dates in YYYYMMDD format
+                exp_dict       : dict of exp func(s) info as:
+                                 {{onset_time1} : [{char_time11,...,char_time1N}],
+                                  {onset_time2} : [{char_time21,...,char_time2N}],
+                                  ...
+                                  }
+                                 where onset_time is string  in YYYYMMDD format and
+                                       char_time  is float32 in decimal days
+    Returns:    A              : 2D array of zeros & ones in size of (num_date, num_exp)
+    """
+    num_date = len(date_list)
+    num_exp  = sum([len(val) for key, val in exp_dict.items()])
+    A = np.zeros((num_date, num_exp), dtype=np.float32)
+
+    t = np.array(ptime.yyyymmdd2years(date_list))
+    # loop for onset time(s)
+    i = 0
+    for exp_onset in exp_dict.keys():
+        # convert string to float in years
+        exp_T = ptime.yyyymmdd2years(exp_onset)
+
+        # loop for charateristic time(s)
+        for exp_tau in exp_dict[exp_onset]:
+            # convert time from days to years
+            exp_tau /= 365.25
+            A[:, i] = np.array(t > exp_T).flatten() * (1 - np.exp(-1 * (t - exp_T) / exp_tau))
+            i += 1
+
+    return A
+
+
+def get_design_matrix4log_func(date_list, log_dict):
+    """design matrix/function model of logarithmic postseismic relaxation estimation
+
+    Reference: Eq. (4) in Hetland et al. (2012, JGR)
+    Note that there is a typo in the paper for this equation, based on the MInTS code, it should be:
+        Sum_i{ a_i * H(t-Ti) * [1 + log((t-T_i)/tau_i)] }
+    instead of the one below shown in the paper:
+        Sum_i{ a_i * H(t-Ti) * [1 + log((t)/tau_i)] }
+    where:
+        a_i         amplitude      of i-th log term
+        T_i         onset time     of i-th log term
+        tau_i       char time      of i-th log term (relaxation time)
+        H(t-T_i)    Heaviside func of i-th log term (ensuring the log func is one-sided)
+
+    Parameters: date_list      : list of dates in YYYYMMDD format
+                log_dict       : dict of log func(s) info as:
+                                 {{onset_time1} : [{char_time11,...,char_time1N}],
+                                  {onset_time2} : [{char_time21,...,char_time2N}],
+                                  ...
+                                  }
+                                 where onset_time is string  in YYYYMMDD format and
+                                       char_time  is float32 in decimal days
+    Returns:    A              : 2D array of zeros & ones in size of (num_date, num_log)
+    """
+    num_date = len(date_list)
+    num_log  = sum([len(log_dict[x]) for x in log_dict])
+    A = np.zeros((num_date, num_log), dtype=np.float32)
+
+    t = np.array(ptime.yyyymmdd2years(date_list))
+    # loop for onset time(s)
+    i = 0
+    for log_onset in log_dict.keys():
+        # convert string to float in years
+        log_T = ptime.yyyymmdd2years(log_onset)
+
+        # loop for charateristic time(s)
+        for log_tau in log_dict[log_onset]:
+            # convert time from days to years
+            log_tau /= 365.25
+
+            olderr = np.seterr(invalid='ignore', divide='ignore')
+            A[:, i] = np.array(t > log_T).flatten() * np.nan_to_num(np.log(1 + (t - log_T) / log_tau), nan=0, neginf=0)
+            np.seterr(**olderr)
+            i += 1
+
+    return A
+

--- a/tests/test_smallbaselineApp.py
+++ b/tests/test_smallbaselineApp.py
@@ -28,6 +28,7 @@ URL_LIST = [
     'https://zenodo.org/record/5498198/files/FernandinaSenDT128.tar.xz',
     'https://zenodo.org/record/4320005/files/SanFranSenDT42.tar.xz',
     'https://zenodo.org/record/3952950/files/WellsEnvD2T399.tar.xz',
+    'https://zenodo.org/record/5502403/files/RidgecrestSenDT71.tar.xz',
     'https://zenodo.org/record/4318134/files/WCapeSenAT29.tar.xz',
     'https://zenodo.org/record/3952917/files/KujuAlosAT422F650.tar.xz',
 ]
@@ -41,6 +42,7 @@ DSET_INFO = """
   FernandinaSenDT128 for ISCE/topsStack
   SanFranSenDT42     for ARIA
   WellsEnvD2T399     for GAMMA
+  RidgecrestSenDT71  for HyP3
   WCapeSenAT29       for SNAP
   KujuAlosAT422F650  for ROI_PAC
 """


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the following new features:
1. add a new dedicated utility script `utils/time_func.py` for `estimate_time_func()` (from timeseries2velocity.py) and `get_design_matrix4time_func()` (from objects/stack.py and all its sub-functions).
2. support accurate time of the day info in `THH(:)MM` style for relevant time functions (step/exp/log) for #640.
3. add a new utility script `utils/s1_utils.py` dedicated for Sentinel-1 specific functionalities, with initial content from Yunjun et al. [in prep]
4. add new example dataset `RidgecrestSenDT71` for `hyp3` from @cirrusasf (https://github.com/insarlab/MintPy-tutorial/pull/26).

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.