### PR TITLE
Plotting flexibility and support for GNSS component plotting

### DIFF
--- a/mintpy/objects/coord.py
+++ b/mintpy/objects/coord.py
@@ -450,6 +450,26 @@ class coordinate:
             msg += '\tsubset range in (W, N, E, S): {}\n'.format(self.box_pixel2geo(pixel_box))
             raise ValueError(msg)
 
+        # Check Y/Azimuth/Latitude subset range
+        if sub_y[0] < 0:
+            sub_y[0] = 0
+            if print_msg:
+                print('WARNING: input y < min (0)! Set it to min.')
+        if sub_y[1] > length:
+            sub_y[1] = length
+            if print_msg:
+                print('WARNING: input y > max ({})! Set it to max.'.format(length))
+
+        # Check X/Range/Longitude subset range
+        if sub_x[0] < 0:
+            sub_x[0] = 0
+            if print_msg:
+                print('WARNING: input x < min (0)! Set it to min.')
+        if sub_x[1] > width:
+            sub_x[1] = width
+            if print_msg:
+                print('WARNING: input x > max ({})! Set it to max.'.format(width))
+
         out_box = (sub_x[0], sub_y[0], sub_x[1], sub_y[1])
         return out_box
 

--- a/mintpy/objects/coord.py
+++ b/mintpy/objects/coord.py
@@ -450,26 +450,6 @@ class coordinate:
             msg += '\tsubset range in (W, N, E, S): {}\n'.format(self.box_pixel2geo(pixel_box))
             raise ValueError(msg)
 
-        # Check Y/Azimuth/Latitude subset range
-        if sub_y[0] < 0:
-            sub_y[0] = 0
-            if print_msg:
-                print('WARNING: input y < min (0)! Set it to min.')
-        if sub_y[1] > length:
-            sub_y[1] = length
-            if print_msg:
-                print('WARNING: input y > max ({})! Set it to max.'.format(length))
-
-        # Check X/Range/Longitude subset range
-        if sub_x[0] < 0:
-            sub_x[0] = 0
-            if print_msg:
-                print('WARNING: input x < min (0)! Set it to min.')
-        if sub_x[1] > width:
-            sub_x[1] = width
-            if print_msg:
-                print('WARNING: input x > max ({})! Set it to max.'.format(width))
-
         out_box = (sub_x[0], sub_y[0], sub_x[1], sub_y[1])
         return out_box
 

--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -16,7 +16,7 @@ from pyproj import Geod
 from urllib.request import urlretrieve
 
 from mintpy.objects.coord import coordinate
-from mintpy.utils import ptime, time_func, readfile, utils1 as ut, utils as ut0
+from mintpy.utils import ptime, time_func, readfile, utils1 as ut
 
 
 unr_site_list_file = 'http://geodesy.unr.edu/NGLStationPages/DataHoldings.txt'
@@ -164,7 +164,7 @@ def get_gps_los_obs(insar_file, site_names, start_date, end_date, msk,
             geom_obj = meta
             vprint('use incidence / azimuth angle from metadata')
         cropped_metadata = get_plot_extent(metadata, msk, geo_box)
-        coord = ut0.coordinate(cropped_metadata)
+        coord = coordinate(cropped_metadata)
 
         # loop for calculation
         prog_bar = ptime.progressBar(maxValue=num_site, print_msg=print_msg)
@@ -209,8 +209,6 @@ def get_gps_los_obs(insar_file, site_names, start_date, end_date, msk,
             fcw.writerows(data_list_tocsv)
 
     return site_obs
-
-
 
 
 #################################### Beginning of GPS-GSI utility functions ########################
@@ -562,24 +560,20 @@ class GPS:
     def get_gps_los_velocity(self, geom_obj, start_date=None, end_date=None, ref_site=None,
                              gps_comp='enu2los', az_angle=0.):
 
-        try:
-            dates, dis = self.read_gps_los_displacement(geom_obj,
-                                                        start_date=start_date,
-                                                        end_date=end_date,
-                                                        ref_site=ref_site,
-                                                        gps_comp=gps_comp,
-                                                        az_angle=az_angle)[:2]
+        dates, dis = self.read_gps_los_displacement(geom_obj,
+                                                    start_date=start_date,
+                                                    end_date=end_date,
+                                                    ref_site=ref_site,
+                                                    gps_comp=gps_comp,
+                                                    az_angle=az_angle)[:2]
 
-            # displacement -> velocity
-            date_list = [dt.strftime(i, '%Y%m%d') for i in dates]
-            if len(date_list) >= 2:
-                A = time_func.get_design_matrix4time_func(date_list)
-                self.velocity = np.dot(np.linalg.pinv(A), dis)[1]
-            else:
-                self.velocity = np.nan
-        except:
+        # displacement -> velocity
+        date_list = [dt.strftime(i, '%Y%m%d') for i in dates]
+        if len(date_list) >= 2:
+            A = time_func.get_design_matrix4time_func(date_list)
+            self.velocity = np.dot(np.linalg.pinv(A), dis)[1]
+        else:
             self.velocity = np.nan
-            dis = np.nan
 
         return self.velocity, dis
 

--- a/mintpy/utils/arg_group.py
+++ b/mintpy/utils/arg_group.py
@@ -51,6 +51,8 @@ def add_dem_argument(parser):
     dem = parser.add_argument_group('DEM', 'display topography in the background')
     dem.add_argument('-d', '--dem', dest='dem_file', metavar='DEM_FILE',
                      help='DEM file to show topography as background')
+    dem.add_argument('--dem-mask', dest='dem_mask', action='store_true',
+                     help='Mask all DEM values not coincident with valid data pixels')
     dem.add_argument('--dem-noshade', dest='disp_dem_shade', action='store_false',
                      help='do not show DEM shaded relief')
     dem.add_argument('--dem-nocontour', dest='disp_dem_contour', action='store_false',
@@ -163,6 +165,8 @@ def add_gps_argument(parser):
     gps = parser.add_argument_group('GPS', 'GPS data to display')
     gps.add_argument('--show-gps', dest='disp_gps', action='store_true',
                      help='Show UNR GPS location within the coverage.')
+    gps.add_argument('--gps-mask', dest='gps_mask', action='store_true',
+                     help='Mask all GPS stations not coincident with valid data pixels')
     gps.add_argument('--gps-label', dest='disp_gps_label', action='store_true',
                      help='Show GPS site name')
     gps.add_argument('--gps-comp', dest='gps_component', choices={'enu2los', 'hz2los', 'up2los', 'horizontal', 'vertical'},
@@ -176,7 +180,8 @@ def add_gps_argument(parser):
     gps.add_argument('--gps-end-date', dest='gps_end_date', type=str, metavar='YYYYMMDD',
                      help='start date of GPS data, default is date of the last SAR acquisition')
     gps.add_argument('--azimuth', '--az', dest='az_angle', type=float, default=0.,
-                     help='azimuth angle in degree (clockwise) of the direction of the horizontal movement\n' +
+                     help='azimuth angle in degrees in the direction of the horizontal movement\n'
+                             'with anti-clockwise direction as positive\n' +
                              'default is 0., assuming no projection needed and magnitude of horizontal vectors passed.\n' +
                              'i.e. azimuth angle of strike-slip fault\n\n' +
                              'Note:\n' +

--- a/mintpy/utils/arg_group.py
+++ b/mintpy/utils/arg_group.py
@@ -165,16 +165,24 @@ def add_gps_argument(parser):
                      help='Show UNR GPS location within the coverage.')
     gps.add_argument('--gps-label', dest='disp_gps_label', action='store_true',
                      help='Show GPS site name')
-    gps.add_argument('--gps-comp', dest='gps_component', choices={'enu2los', 'hz2los', 'up2los'},
+    gps.add_argument('--gps-comp', dest='gps_component', choices={'enu2los', 'hz2los', 'up2los', 'horizontal', 'vertical'},
                      help='Plot GPS in color indicating deformation velocity direction')
     gps.add_argument('--gps-redo', dest='gps_redo', action='store_true',
                      help='Re-calculate GPS observations in LOS direction, instead of read from existing CSV file.')
     gps.add_argument('--ref-gps', dest='ref_gps_site', type=str, help='Reference GPS site')
 
     gps.add_argument('--gps-start-date', dest='gps_start_date', type=str, metavar='YYYYMMDD',
-                     help='start date of GPS data, default is date of the 1st SAR acquisiton')
+                     help='start date of GPS data, default is date of the 1st SAR acquisition')
     gps.add_argument('--gps-end-date', dest='gps_end_date', type=str, metavar='YYYYMMDD',
-                     help='start date of GPS data, default is date of the last SAR acquisiton')
+                     help='start date of GPS data, default is date of the last SAR acquisition')
+    gps.add_argument('--azimuth', '--az', dest='az_angle', type=float, default=0.,
+                     help='azimuth angle in degree (clockwise) of the direction of the horizontal movement\n' +
+                             'default is 0., assuming no projection needed and magnitude of horizontal vectors passed.\n' +
+                             'i.e. azimuth angle of strike-slip fault\n\n' +
+                             'Note:\n' +
+                             'a. Near north direction can not be well resolved due to the lack of\n' +
+                             '   diversity in viewing geometry. Check exact dilution of precision for \n' +
+                             '   each component in Wright et al., 2004, GRL')
     return parser
 
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1010,10 +1010,15 @@ def read_dem(dem_file, pix_box=None, geo_box=None, print_msg=True, multilook_num
         if print_msg:
             print('align DEM to the input data file')
         dem_tmp = np.zeros((dem_pix_box[3] - dem_pix_box[1],
-                            dem_pix_box[2] - dem_pix_box[0]), dtype=dem.dtype) * np.nan
-        dem_tmp[box2read[1]-dem_pix_box[1]:box2read[3]-dem_pix_box[1],
-                box2read[0]-dem_pix_box[0]:box2read[2]-dem_pix_box[0]] = dem
-        dem = np.array(dem_tmp)
+                            dem_pix_box[2] - dem_pix_box[0]),
+                            dtype=dem.dtype) * np.nan
+        # Only file if bounds have already not been expanded
+        if dem_tmp[box2read[1]-dem_pix_box[1]:box2read[3]-dem_pix_box[1],
+                box2read[0]-dem_pix_box[0]:box2read[2]-dem_pix_box[0]].shape \
+                == dem.shape:
+            dem_tmp[box2read[1]-dem_pix_box[1]:box2read[3]-dem_pix_box[1],
+                    box2read[0]-dem_pix_box[0]:box2read[2]-dem_pix_box[0]] = dem
+            dem = np.array(dem_tmp)
 
     # adjust DEM bounds according to user input
     dem = extendbox(dem, pix_box, xstep=multilook_num, ystep=multilook_num)

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1177,15 +1177,11 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         raise ValueError('input reference GPS site "{}" not available!'.format(inps.ref_gps_site))
 
     k = metadata['FILE_TYPE']
-    print('inps.gps_component,k!!!',inps.gps_component,k)
     if inps.gps_component and k not in ['velocity', 'timeseries', 'SenD']:
         inps.gps_component = None
         vprint('WARNING: --gps-comp is not implemented for {} file yet, set --gps-comp = None and continue'.format(k))
 
     if inps.gps_component:
-        # check input azimuth angle
-        if inps.az_angle < 0.:
-            inps.az_angle += 360.
         # plot GPS velocity/displacement along LOS direction
         vprint('-'*30)
         msg = 'plotting GPS '
@@ -1231,10 +1227,16 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
 
         # plot
         for lat, lon, obs in zip(site_lats, site_lons, site_obs):
-            color = cmap( (obs - vmin) / (vmax - vmin) ) if obs else 'none'
-            # only plot valid GNSS stations
-            if color != 'none':
-                ax.scatter(lon, lat, color=color, s=marker_size**2, edgecolors='k', zorder=10)
+            color = cmap( (obs - vmin) / (vmax - vmin) ) \
+                    if not np.isnan(obs) else 'none'
+            # Mask GNSS stations if outside of data range
+            if inps.gps_mask:
+                if not np.isnan(obs):
+                    ax.scatter(lon, lat, color=color, s=marker_size**2,
+                               edgecolors='k', zorder=10)
+            else:
+                ax.scatter(lon, lat, color=color, s=marker_size**2,
+                               edgecolors='k', zorder=10)
 
     else:
         # plot GPS locations only

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -113,6 +113,7 @@ def extendbox(data, pix_box, xstep=1, ystep=1):
     """Adjust bbox to reflect user-specified plotting extents"""
 
     #if multilooking, adjust pix_box
+    pix_box = list(pix_box)
     if xstep * ystep > 1:
         # adjust X-dim
         pix_box[0] /= xstep

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -109,6 +109,65 @@ def read_pts2inps(inps, coord_obj):
 
 
 ############################################ Plot Utilities #############################################
+def extendbox(data, pix_box, xstep=1, ystep=1):
+    """Adjust bbox to reflect user-specified plotting extents"""
+
+    #if multilooking, adjust pix_box
+    if xstep * ystep > 1:
+        # adjust X-dim
+        pix_box[0] /= xstep
+        pix_box[2] /= xstep
+        # adjust Y-dim
+        pix_box[1] /= ystep
+        pix_box[3] /= ystep
+
+    orig_datashape = data.shape
+    orig_datatype = data.dtype
+    offsetarr = [0, 0, 0, 0]
+    ###extend
+    # Check Y/Azimuth/Latitude subset range
+    if pix_box[1] < 0:
+        delta = int(abs(pix_box[1]))
+        offsetarr[1] = int(pix_box[1])
+        append_arr = np.ma.masked_values(np.zeros((delta,data.shape[1])),0)
+        data = np.ma.append(append_arr, data, axis=0)
+    if pix_box[3] > orig_datashape[0]:
+        delta = int(pix_box[3] - orig_datashape[0])
+        offsetarr[3] = delta
+        append_arr = np.ma.masked_values(np.zeros((delta,data.shape[1])),0)
+        data = np.ma.append(data, append_arr, axis=0)
+    if pix_box[3] < orig_datashape[0]:
+        delta = int(orig_datashape[0] - pix_box[3])
+        offsetarr[3] = delta
+        data = data[:-1*delta]
+    # Check X/Range/Longitude subset range
+    if pix_box[0] < 0:
+        delta = int(abs(pix_box[0]))
+        offsetarr[0] = int(pix_box[0])
+        append_arr = np.ma.masked_values(np.zeros((data.shape[0],delta)),0)
+        data = np.ma.append(append_arr, data, axis=1)
+    if pix_box[2] > orig_datashape[1]:
+        delta = int(pix_box[2] - orig_datashape[1])
+        offsetarr[2] = delta
+        append_arr = np.ma.masked_values(np.zeros((data.shape[0],delta)),0)
+        data = np.ma.append(data, append_arr, axis=1)
+    if pix_box[2] < orig_datashape[1]:
+        delta = int(orig_datashape[1] - pix_box[2])
+        offsetarr[2] = delta
+        data = data[:, :-1*delta]
+
+    ###crop
+    # Check Y/Azimuth/Latitude subset range
+    if pix_box[1] > 0:
+        data = data[pix_box[1]:]
+    # Check X/Range/Longitude subset range
+    if pix_box[0] > 0:
+        data = data[:, pix_box[0]:]
+
+    data = data.astype(str(orig_datatype))
+    return data, offsetarr
+
+
 def add_inner_title(ax, title, loc, prop=None, **kwargs):
     from matplotlib.offsetbox import AnchoredText
     from matplotlib.patheffects import withStroke
@@ -917,7 +976,7 @@ def plot_coherence_matrix(ax, date12List, cohList, date12List_drop=[], p_dict={}
     return ax, coh_mat, im
 
 
-def read_dem(dem_file, pix_box=None, geo_box=None, print_msg=True):
+def read_dem(dem_file, pix_box=None, geo_box=None, print_msg=True, multilook_num=1):
     if print_msg:
         print('reading DEM: {} ...'.format(os.path.basename(dem_file)))
 
@@ -942,7 +1001,7 @@ def read_dem(dem_file, pix_box=None, geo_box=None, print_msg=True):
 
     dem, dem_metadata = readfile.read(dem_file,
                                       datasetName=dsName,
-                                      box=box2read,
+                                      box=(0, 0, int(dem_metadata['WIDTH']), int(dem_metadata['LENGTH'])),
                                       print_msg=print_msg)
 
     # if input DEM does not cover the entire AOI, fill with NaN
@@ -954,6 +1013,14 @@ def read_dem(dem_file, pix_box=None, geo_box=None, print_msg=True):
         dem_tmp[box2read[1]-dem_pix_box[1]:box2read[3]-dem_pix_box[1],
                 box2read[0]-dem_pix_box[0]:box2read[2]-dem_pix_box[0]] = dem
         dem = np.array(dem_tmp)
+
+    # adjust DEM bounds according to user input
+    dem = extendbox(dem, pix_box, xstep=multilook_num, ystep=multilook_num)
+    np.ma.set_fill_value(dem, np.nan)
+    try:
+        dem = dem.filled()
+    except:
+        pass
     return dem, dem_metadata, dem_pix_box
 
 
@@ -1110,16 +1177,21 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         raise ValueError('input reference GPS site "{}" not available!'.format(inps.ref_gps_site))
 
     k = metadata['FILE_TYPE']
-    if inps.gps_component and k not in ['velocity', 'timeseries']:
+    print('inps.gps_component,k!!!',inps.gps_component,k)
+    if inps.gps_component and k not in ['velocity', 'timeseries', 'SenD']:
         inps.gps_component = None
         vprint('WARNING: --gps-comp is not implemented for {} file yet, set --gps-comp = None and continue'.format(k))
 
     if inps.gps_component:
+        # check input azimuth angle
+        if inps.az_angle < 0.:
+            inps.az_angle += 360.
         # plot GPS velocity/displacement along LOS direction
         vprint('-'*30)
         msg = 'plotting GPS '
         msg += 'velocity' if k == 'velocity' else 'displacement'
-        msg += ' in LOS direction'
+        msg += ' with respect to {} in {} direction ...'.format(
+            inps.ref_gps_site, inps.gps_component)
         vprint(msg)
         vprint('number of available GPS stations: {}'.format(len(site_names)))
         vprint('start date: {}'.format(inps.gps_start_date))
@@ -1132,9 +1204,14 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
             site_names=site_names,
             start_date=inps.gps_start_date,
             end_date=inps.gps_end_date,
+            msk=inps.msk,
+            geo_box=inps.geo_box,
+            metadata=metadata,
             gps_comp=inps.gps_component,
             print_msg=print_msg,
             redo=inps.gps_redo,
+            ref_site=inps.ref_gps_site,
+            az_angle=inps.az_angle
         )
 
         # reference GPS
@@ -1155,7 +1232,9 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         # plot
         for lat, lon, obs in zip(site_lats, site_lons, site_obs):
             color = cmap( (obs - vmin) / (vmax - vmin) ) if obs else 'none'
-            ax.scatter(lon, lat, color=color, s=marker_size**2, edgecolors='k', zorder=10)
+            # only plot valid GNSS stations
+            if color != 'none':
+                ax.scatter(lon, lat, color=color, s=marker_size**2, edgecolors='k', zorder=10)
 
     else:
         # plot GPS locations only
@@ -1279,6 +1358,9 @@ def scale_data2disp_unit(data=None, metadata=dict(), disp_unit=None):
         elif disp_unit[0] == 'dm': scale *= 10.0
         elif disp_unit[0] == 'm' : scale *= 1.0
         elif disp_unit[0] == 'km': scale *= 1/1000.0
+        elif disp_unit[0] == 'in': scale *= 39.3701
+        elif disp_unit[0] == 'ft': scale *= 3.28084
+        elif disp_unit[0] == 'mi': scale *= 0.000621371
         elif disp_unit[0] in ['radians','radian','rad','r']:
             range2phase = -(4*np.pi) / float(metadata['WAVELENGTH'])
             scale *= range2phase
@@ -1290,6 +1372,9 @@ def scale_data2disp_unit(data=None, metadata=dict(), disp_unit=None):
         elif data_unit[0] == 'cm': scale *= 0.01
         elif data_unit[0] == 'dm': scale *= 0.1
         elif data_unit[0] == 'km': scale *= 1000.
+        elif disp_unit[0] == 'in': scale *= 0.025399986284007407
+        elif disp_unit[0] == 'ft': scale *= 0.3047999902464003
+        elif disp_unit[0] == 'mi': scale *= 1609.3444978925634
 
     elif data_unit[0] == 'radian':
         phase2range = -float(metadata['WAVELENGTH']) / (4*np.pi)
@@ -1298,6 +1383,9 @@ def scale_data2disp_unit(data=None, metadata=dict(), disp_unit=None):
         elif disp_unit[0] == 'dm': scale *= phase2range * 10.0
         elif disp_unit[0] == 'm' : scale *= phase2range * 1.0
         elif disp_unit[0] == 'km': scale *= phase2range * 1/1000.0
+        elif disp_unit[0] == 'in': scale *= phase2range * 39.3701
+        elif disp_unit[0] == 'ft': scale *= phase2range * 3.28084
+        elif disp_unit[0] == 'mi': scale *= phase2range * 0.000621371
         elif disp_unit[0] in ['radians','radian','rad','r']:
             pass
         else:
@@ -1635,10 +1723,18 @@ def draw_scalebar(ax, geo_box, unit='degrees', loc=[0.2, 0.2, 0.1], labelpad=0.0
     ax.plot([lon1, lon1], [lat_c, lat_c + 0.1*length_disp], color=color)
 
     ## plot scale bar label
-    unit = 'm'
-    if length_meter >= 1000.0:
-        unit = 'km'
-        length_meter *= 0.001
+    if unit.split('/')[0]=='in' or unit.split('/')[0]=='ft' or unit.split('/')[0]=='mi':
+        unit = 'ft'
+        if length_meter >= 1000.0:
+            unit = 'mi'
+            length_meter *= 0.000621371
+        else:
+            length_meter *= 3.28084
+    else:
+        unit = 'm'
+        if length_meter >= 1000.0:
+            unit = 'km'
+            length_meter *= 0.001
     label = '{:.0f} {}'.format(length_meter, unit)
     txt_offset = (geo_box[1] - geo_box[3]) * labelpad
 
@@ -1649,3 +1745,4 @@ def draw_scalebar(ax, geo_box, unit='degrees', loc=[0.2, 0.2, 0.1], labelpad=0.0
             fontsize=font_size, color=color)
 
     return ax
+

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -772,6 +772,10 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             k = list(set(g1_list) & set(py2_mintpy_stack_files))[0]
         elif 'FILE_TYPE' in atr:
             k = atr['FILE_TYPE']
+            # catech exception for horizontal and vertical decomposition
+            if (k == 'None') and ('SenD' in d1_list or 'horizontal' \
+                in d1_list or 'vertical' in d1_list):
+                k = 'SenD'
         elif len(d1_list) > 0:
             k = d1_list[0]
         elif len(g1_list) > 0:

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -378,6 +378,23 @@ def transect_lines(z, atr, lines):
     return transect
 
 
+def get_plot_extent(cropped_metadata, data, geo_box):
+    """Adjust metadata to reflect user-specified plotting extents"""
+
+    cropped_metadata['WIDTH'] = data.shape[1]
+    cropped_metadata['LENGTH'] = data.shape[0]
+    cropped_metadata['X_FIRST'] = min(geo_box[::2])
+    cropped_metadata['Y_FIRST'] = max(geo_box[1::2])
+    cropped_metadata['LON_REF1'] = min(geo_box[::2])
+    cropped_metadata['LON_REF2'] = max(geo_box[::2])
+    cropped_metadata['LON_REF3'] = min(geo_box[::2])
+    cropped_metadata['LON_REF4'] = max(geo_box[::2])
+    cropped_metadata['LAT_REF1'] = max(geo_box[1::2])
+    cropped_metadata['LAT_REF2'] = max(geo_box[1::2])
+    cropped_metadata['LAT_REF3'] = min(geo_box[1::2])
+    cropped_metadata['LAT_REF4'] = min(geo_box[1::2])
+
+    return cropped_metadata
+
 
 #################################################################################
-

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1603,9 +1603,9 @@ class viewer():
             # update data
             # pass original pixel coordinates to properly handle bounds
             selfcopy = copy.deepcopy(self)
-            self.pix_box = (0,0,0,0)
+            self.pix_box = [0,0,0,0]
             data, self = update_data_with_plot_inps(data, self.atr, self)
-            self.pix_box = selfcopy.pix_box[:]
+            self.pix_box = selfcopy.pix_box
             del selfcopy
 
             # shift mask and data, if necesary

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1044,8 +1044,6 @@ def read_data4figure(i_start, i_end, inps, metadata):
                 ref_data = readfile.read(inps.file,
                                          datasetName=dset_list,
                                          box=ref_box,
-                                         xstep=inps.multilook_num,
-                                         ystep=inps.multilook_num,
                                          print_msg=False)[0]
                 for i in range(data.shape[0]):
                     mask = data[i, :, :] != 0.
@@ -1678,4 +1676,3 @@ def main(iargs=None):
 ##################################################################################################
 if __name__ == '__main__':
     main(sys.argv[1:])
-


### PR DESCRIPTION
**Description of proposed changes**

I have added in a series of interrelated, dependent changes concerning plotting flexibility of user-defined bounds, and support for plotting of vertical and horizontal GNSS components.

1. Allow users to plot data in expanded bounds. Originally the code superseded user-specified bounds in such cases in favor of tight bounds about the track. This flexibility is crucial in my experience as it makes it much easier to compile and mosaic figures of large study areas involving multiple tracks.

2. Mask DEM background where it falls outside of InSAR coverage or is coincident with masked/nodata values.

3. Suppress plotting of GPS stations that fall outside of InSAR coverage or are coincident with masked/nodata values. Again, this flexibility is a welcome addition for compiling figures. Perhaps we can make this a user-specified option (i.e. by default plot empty symbols where there are no valid InSAR pixels), but leave alone my other commit whereby such stations are not passed into the output CSV.

4. Introduce support for plotting vertical or horizontal GPS components if the user is plotting vertical or horizontal InSAR velocity components, respectively.

5. Update list of supported units to also support American convention (e.g. inches, feet, miles).


Working example before code allowed for bounds expanded beyond the range of the input dataset, and masked out GNSS stations and DEM pixels coincident with nodata values:
![test2_velocity_TECTscale_GPS](https://user-images.githubusercontent.com/13227405/133908073-480be879-390d-46b5-8fb5-0610271eb537.png)

After my introduced changes:
![test_OG](https://user-images.githubusercontent.com/13227405/133908082-95c1cdb2-4824-4ef5-9db1-90f1795e5fed.png)

