### PR TITLE
read/write/plot: improved flexibility for h5 file

### DIFF
--- a/mintpy/geocode.py
+++ b/mintpy/geocode.py
@@ -296,7 +296,8 @@ def run_geocode(inps):
         # instantiate output file
         file_is_hdf5 = os.path.splitext(infile)[1] in ['.h5', '.he5']
         if file_is_hdf5:
-            writefile.layout_hdf5(outfile, metadata=atr, ref_file=infile)
+            compression = readfile.get_hdf5_compression(infile)
+            writefile.layout_hdf5(outfile, metadata=atr, ref_file=infile, compression=compression)
         else:
             dsDict = dict()
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -487,7 +487,7 @@ class geometry:
             self.geocoded = True
 
         with h5py.File(self.file, 'r') as f:
-            self.datasetNames = [i for i in geometryDatasetNames if i in f.keys()]
+            self.datasetNames = [i for i in f.keys() if isinstance(f[i], h5py.Dataset)]
             self.sliceList = list(self.datasetNames)
             if 'bperp' in f.keys():
                 self.dateList = [i.decode('utf8') for i in f['date'][:]]

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -758,7 +758,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             k = 'ifgramStack'
         elif any(i in d1_list for i in ['height', 'latitude', 'azimuthCoord']):
             k = 'geometry'
-        elif any(i in g1_list+d1_list for i in ['timeseries', 'displacement']):
+        elif any(i in g1_list+d1_list for i in ['timeseries']):
             k = 'timeseries'
         elif any(i in d1_list for i in ['velocity']):
             k = 'velocity'
@@ -989,6 +989,10 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             atr['DATA_TYPE'] = dataTypeDict[data_type]
 
     # UNIT
+    if datasetName:
+        # ignore Std because it shares the same unit as base parameter
+        # e.g. velocityStd and velocity
+        datasetName = datasetName.replace('Std','')
     k = atr['FILE_TYPE'].replace('.', '')
     if k == 'ifgramStack':
         if datasetName and datasetName in datasetUnitDict.keys():

--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -15,18 +15,23 @@ from mintpy.objects import timeseries
 from mintpy.utils import readfile
 
 
-def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None):
+def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None, ds_unit_dict=None):
     """ Write one file.
-    Parameters: datasetDict : dict of dataset, with key = datasetName and value = 2D/3D array, e.g.:
+    Parameters: datasetDict  - dict of dataset, with key = datasetName and value = 2D/3D array, e.g.:
                     {'height'        : np.ones((   200,300), dtype=np.int16),
                      'incidenceAngle': np.ones((   200,300), dtype=np.float32),
                      'bperp'         : np.ones((80,200,300), dtype=np.float32),
                      ...}
-                out_file : str, output file name
-                metadata : dict of attributes
-                ref_file : str, reference file to get auxliary info
-                compression : str, compression while writing to HDF5 file, None, "lzf", "gzip"
-    Returns:    out_file : str
+                out_file     - str, output file name
+                metadata     - dict of attributes
+                ref_file     - str, reference file to get auxliary info
+                compression  - str, compression while writing to HDF5 file, None, "lzf", "gzip"
+                ds_unit_dict - dict, dataset unit definition
+                    {dname : dunit,
+                     dname : dunit,
+                     ...
+                    }
+    Returns:    out_file     - strs
     Examples:   dsDict = dict()
                 dsDict['velocity'] = np.ones((200,300), dtype=np.float32)
                 write(datasetDict=dsDict, out_file='velocity.h5', metadata=atr)
@@ -122,6 +127,14 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None)
                     f.attrs[key] = str(value)
                 except:
                     f.attrs[key] = str(value.encode('utf-8'))
+
+            # write attributes in dataset level
+            if ds_unit_dict is not None:
+                for key, value in ds_unit_dict.items():
+                    if value is not None:
+                        f[key].attrs['UNIT'] = value
+                        print(f'add /{key:<{maxDigit}} attribute: UNIT = {value}')
+
         print('finished writing to {}'.format(out_file))
 
     # ISCE / ROI_PAC GAMMA / Image product

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -843,10 +843,7 @@ def read_dataset_input(inps):
                                                 inps.search_dset)[1]
     else:
         # default dataset to display for certain type of files
-        if inps.key == 'geometry':
-            inps.dset = list(geometryDatasetNames)
-            inps.dset.remove('bperp')
-        elif inps.key == 'ifgramStack':
+        if inps.key == 'ifgramStack':
             inps.dset = ['unwrapPhase']
         elif inps.key == 'HDFEOS':
             inps.dset = ['displacement']
@@ -858,6 +855,9 @@ def read_dataset_input(inps):
             inps.dset = [obj.sliceList[0].split('-')[0]]
         else:
             inps.dset = inps.sliceList
+            # do not plot 3D-bperp by default
+            if inps.key == 'geometry':
+                inps.dset = [x for x in inps.dset if not x.startswith('bperp')]
 
         inps.dsetNumList = search_dataset_input(inps.sliceList,
                                                 inps.dset,


### PR DESCRIPTION
**Description of proposed changes**

+ read/plot: support geometry h5 file with other undefined datasets, e.g. "displacement", which is useful for single-pair displacement products for generic sharing purpose.
+ read.read_attribute(): ignore Std while grabbing UNIT
+ writefile.write(): add optional ds_unit_dict arg to specify different data unit for each dataset, same as layout_hdf5()
+ geocode: same h5 compression bwt. input/output

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.