### PR TITLE
writefile: add `write_binary()` for generic binary file writing

### DIFF
--- a/docs/api/attributes.md
+++ b/docs/api/attributes.md
@@ -41,6 +41,8 @@ The following attributes vary for each interferogram:
 +  FILE_PATH = absolute file path   
 +  PROCESSOR = processing software, i.e. isce, aria, snap, gamma, roipac etc.
 +  DATA_TYPE = data type, i.e. float32, int16, etc., for isce product read using GDAL
++  BANDS = number of bands, for binary file I/O.
++  INTERLEAVE = band interleave type, i.e. BSQ, BIL, BIP for binary file I/O.
 +  UNIT = data unit, i.e. m, m/yr, radian, and 1 for file without unit, such as coherence [[source]](https://github.com/insarlab/MintPy/blob/main/mintpy/objects/stack.py#L75)
 +  REF_DATE = reference date
 +  REF_X/Y/LAT/LON = column/row/latitude/longitude of reference point

--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -41,7 +41,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         resample      (utils/{readfile, utils0, ptime})
         coord         (utils/{readfile, utils0, utils1})
     /utils
-        writefile     (objects/{stack},         utils/{readfile})
+        writefile     (utils/{readfile})
         network       (objects/{stack, sensor}, utils/{readfile})
 ------------------ level 4 --------------------
     /objects

--- a/mintpy/mask.py
+++ b/mintpy/mask.py
@@ -166,9 +166,9 @@ def mask_isce_file(in_file, mask_file, out_file=None):
     fbase, ext = os.path.splitext(in_file)
     if ext == '.unw':
         amp = readfile.read_binary(in_file, (length, width), data_type=data_type,
-                                   num_band=num_band, band_interleave=interleave, band=1)
+                                   num_band=num_band, interleave=interleave, band=1)
         pha = readfile.read_binary(in_file, (length, width), data_type=data_type,
-                                   num_band=num_band, band_interleave=interleave, band=2)
+                                   num_band=num_band, interleave=interleave, band=2)
         pha[mask == 0] = 0
         data = np.hstack((amp, pha)).flatten()
     elif ext == '.int':

--- a/mintpy/mask.py
+++ b/mintpy/mask.py
@@ -104,13 +104,11 @@ def update_mask_with_inps(mask, inps=None, print_msg=True):
 
 def mask_file(fname, mask_file, out_file, inps=None):
     """ Mask input fname with mask_file
-    Inputs:
-        fname/mask_file - string, 
-        inps_dict - dictionary including the following options:
-                    subset_x/y - list of 2 ints, subset in x/y direction
-                    threshold - float, threshold/minValue to generate mask
-    Output:
-        out_file - string
+    Parameters: fname     - str, file to be masked
+                mask_file - str, mask file
+                out_file  - str, output file name
+                inps      - namespace object, from cmd_line_parse()
+    Returns:    out_file  - str, output file name
     """
     if not inps:
         inps = cmd_line_parse()
@@ -120,7 +118,6 @@ def mask_file(fname, mask_file, out_file, inps=None):
     mask = update_mask_with_inps(mask, inps)
 
     # masking input file
-    atr = readfile.read_attribute(fname)
     dsNames = readfile.get_dataset_list(fname)
     maxDigit = max([len(i) for i in dsNames])
     dsDict = {}
@@ -141,7 +138,7 @@ def mask_file(fname, mask_file, out_file, inps=None):
 
 def mask_isce_file(in_file, mask_file, out_file=None):
     if not in_file:
-        return    
+        return
 
     # read mask_file
     print('read mask from {}'.format(mask_file))
@@ -150,8 +147,8 @@ def mask_isce_file(in_file, mask_file, out_file=None):
     # mask isce file
     atr = readfile.read_attribute(in_file)
     length, width = int(atr['LENGTH']), int(atr['WIDTH'])
-    interleave = atr['scheme'].upper()
-    num_band = int(atr['number_bands'])
+    interleave = atr['INTERLEAVE'].upper()
+    num_band = int(atr['BANDS'])
 
     # default short name for data type from ISCE
     dataTypeDict = {

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -303,35 +303,18 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='average', margin=
     # for binary file with 2 bands, always use BIL scheme
     if (len(dsDict.keys()) == 2
             and os.path.splitext(infile)[1] not in ['.h5','.he5']
-            and atr.get('scheme', 'BIL').upper() != 'BIL'):
-        print('the input binary file has 2 bands with band interleave as: {}'.format(atr['scheme']))
+            and atr.get('INTERLEAVE', 'BIL').upper() != 'BIL'):
+        print('the input binary file has 2 bands with band interleave as: {}'.format(atr['INTERLEAVE']))
         print('for the output binary file, change the band interleave to BIL as default.')
-        atr['scheme'] = 'BIL'
+        atr['INTERLEAVE'] = 'BIL'
 
     if ext not in ['.h5', '.he5']:
+        atr['BANDS'] = len(dsDict.keys())
         writefile.write(dsDict, out_file=outfile, metadata=atr, ref_file=infile)
 
         # write extra metadata files for ISCE data files
         if os.path.isfile(infile+'.xml') or os.path.isfile(infile+'.aux.xml'):
-            # write ISCE XML file
-            dtype_gdal = readfile.NUMPY2GDAL_DATATYPE[atr['DATA_TYPE']]
-            dtype_isce = readfile.GDAL2ISCE_DATATYPE[dtype_gdal]
-            writefile.write_isce_xml(
-                outfile,
-                width=int(atr['WIDTH']),
-                length=int(atr['LENGTH']),
-                bands=len(dsDict.keys()),
-                data_type=dtype_isce,
-                scheme=atr['scheme'],
-                image_type=atr['FILE_TYPE'])
-            print(f'write file: {outfile}.xml')
-
-            # write GDAL VRT file
-            if os.path.isfile(infile+'.vrt'):
-                from isceobj.Util.ImageUtil import ImageLib as IML
-                img = IML.loadImage(outfile)[0]
-                img.renderVRT()
-                print(f'write file: {outfile}.vrt')
+            writefile.write_isce_xml(atr, outfile)
 
     return outfile
 


### PR DESCRIPTION
**Description of proposed changes**

+ add `BANDS` and `INTERLEAVE` to the standard mintpy self-generated metadata list. Grab it in readfile.py and update the documentation accordingly.

+ writefile: add `write_binary()` for generic binary file writing, and use it in `write()` for simpler and more powerful writing capability.

+ writefile: refactor `write_isce_xml()` to take mintpy attributes dict as input, for simpler usage; and use it in `geocode.py`, `subset.py` and `multilook.py`.

+ `utls.plot.auto_figure_title()`: keep suffix for single-subplot from multi-dset file, to bring back the old naming style interrupted by #661. Thank you @falkamelung for identifying it.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.