### PR TITLE
view: bugfix for DEM masking

### DIFF
--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1010,22 +1010,19 @@ def prepare_dem_background(dem, inps=None, print_msg=True):
             print(('show contour in step of {} m '
                    'with smoothing factor of {}').format(inps.dem_contour_step,
                                                          inps.dem_contour_smooth))
+
     # masking
-    if inps and inps.mask_dem:
-        if print_msg:
-            print('mask DEM to be consistent with valid data coverage')
-        if dem_shade is not None:
-            # need to reshape max to match multi-dimensional DEM shade
-            shade_mask = np.repeat(inps.msk[:, :, np.newaxis], 4, axis=2)
-            if shade_mask.shape == dem_shade.shape:
-                dem_shade[shade_mask[:, :, 0] == 0.] = np.nan
-            else:
-                print('WARNING: DEM has different size than mask, ignore --mask-dem and continue.')
-        if dem_contour is not None:
-            if inps.msk.shape == dem_contour.shape:
+    if inps and inps.mask_dem and (dem_shade is not None or dem_contour is not None):
+        dem_shape = [x.shape[:2] for x in [dem_shade, dem_contour] if x is not None]
+        if inps.msk.shape == dem_shape:
+            if print_msg:
+                print('mask DEM to be consistent with valid data coverage')
+            if dem_shade is not None:
+                dem_shade[inps.msk == 0] = np.nan
+            if dem_contour is not None:
                 dem_contour[inps.msk == 0] = np.nan
-            else:
-                print('WARNING: DEM has different size than mask, ignore --mask-dem and continue.')
+        else:
+            print('WARNING: DEM has different size than mask, ignore --mask-dem and continue.')
 
     return dem_shade, dem_contour, dem_contour_sequence
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1013,7 +1013,7 @@ def prepare_dem_background(dem, inps=None, print_msg=True):
 
     # masking
     if inps and inps.mask_dem and (dem_shade is not None or dem_contour is not None):
-        dem_shape = [x.shape[:2] for x in [dem_shade, dem_contour] if x is not None]
+        dem_shape = [x.shape[:2] for x in [dem_shade, dem_contour] if x is not None][0]
         if inps.msk.shape == dem_shape:
             if print_msg:
                 print('mask DEM to be consistent with valid data coverage')

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1012,15 +1012,20 @@ def prepare_dem_background(dem, inps=None, print_msg=True):
                                                          inps.dem_contour_smooth))
     # masking
     if inps and inps.mask_dem:
-        if inps.msk.shape == dem_contour.shape:
-            if print_msg:
-                print('mask DEM to be consistent with valid data coverage')
-            if dem_shade is not None:
-                dem_shade[inps.msk == 0] = np.nan
-            if dem_contour is not None:
+        if print_msg:
+            print('mask DEM to be consistent with valid data coverage')
+        if dem_shade is not None:
+            # need to reshape max to match multi-dimensional DEM shade
+            shade_mask = np.repeat(inps.msk[:, :, np.newaxis], 4, axis=2)
+            if shade_mask.shape == dem_shade.shape:
+                dem_shade[shade_mask[:, :, 0] == 0.] = np.nan
+            else:
+                print('WARNING: DEM has different size than mask, ignore --mask-dem and continue.')
+        if dem_contour is not None:
+            if inps.msk.shape == dem_contour.shape:
                 dem_contour[inps.msk == 0] = np.nan
-        else:
-            print('WARNING: DEM has different size than mask, ignore --mask-dem and continue.')
+            else:
+                print('WARNING: DEM has different size than mask, ignore --mask-dem and continue.')
 
     return dem_shade, dem_contour, dem_contour_sequence
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1487,6 +1487,10 @@ def prep_slice(cmd, auto_fig=False):
     # masking
     if inps.zero_mask:
         data = np.ma.masked_where(data == 0., data)
+        # update or initiate mask
+        if inps.msk is None:
+            inps.msk = np.ones(data.shape, dtype=np.int8)
+        inps.msk[~np.isnan(data)] = 0
     if inps.msk is not None:
         data = np.ma.masked_where(inps.msk == 0., data)
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -1474,6 +1474,7 @@ def prep_slice(cmd, auto_fig=False):
                               datasetName=inps.ref_date,
                               box=inps.pix_box,
                               print_msg=False)[0]
+
     # reference in space for unwrapPhase
     if (inps.key in ['ifgramStack']
             and inps.dset[0].split('-')[0].startswith('unwrapPhase')
@@ -1484,15 +1485,20 @@ def prep_slice(cmd, auto_fig=False):
                                  box=(ref_x, ref_y, ref_x+1, ref_y+1),
                                  print_msg=False)[0]
         data[data != 0.] -= ref_data
+
     # masking
     if inps.zero_mask:
         data = np.ma.masked_where(data == 0., data)
-        # update or initiate mask
-        if inps.msk is None:
-            inps.msk = np.ones(data.shape, dtype=np.int8)
-        inps.msk[~np.isnan(data)] = 0
     if inps.msk is not None:
         data = np.ma.masked_where(inps.msk == 0., data)
+    else:
+        inps.msk = np.ones(data.shape, dtype=np.bool_)
+    # update/save mask info
+    if np.ma.is_masked(data):
+        inps.msk *= ~data.mask
+        inps.msk *= ~np.isnan(data.data)
+    else:
+        inps.msk *= ~np.isnan(data)
 
     data, inps = update_data_with_plot_inps(data, atr, inps)
 


### PR DESCRIPTION
**Description of proposed changes**

When I attempted to use the `--mask-dem` option, here is the error I got:
```
reading DEM: geometryGeo.h5 ...
display data in transparency: 0.8
plot in geo-coordinate
plotting DEM background ...
show shaded relief DEM
Traceback (most recent call last):
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/MintPy/mintpy/view.py", line 1659, in <module>
    main(sys.argv[1:])
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/MintPy/mintpy/view.py", line 1653, in main
    obj.plot()
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/MintPy/mintpy/view.py", line 1605, in plot
    ax, self, im, cbar = plot_slice(ax, data, self.atr, self)
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/MintPy/mintpy/view.py", line 526, in plot_slice
    pp.plot_dem_background(ax=ax, geo_box=inps.geo_box,
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/MintPy/mintpy/utils/plot.py", line 1055, in plot_dem_background
    dem_contour_seq) = prepare_dem_background(dem, inps=inps, print_msg=print_msg)
  File "/u/leffe-data/ssangha/conda_installation/stable_july30_2020/MintPy/mintpy/utils/plot.py", line 1015, in prepare_dem_background
    if inps.msk.shape == dem_contour.shape:
AttributeError: 'NoneType' object has no attribute 'shape'
```

This problem arose because when attempting to mask the dem shade and contours, the code expects the `dem_contour` object to exist at all times, which cannot be the case if the user wishes to suppress the contours or if this condition is meet in `view.py`:
```
    # DEM contour display
    if max(inps.pix_box[3] - inps.pix_box[1],
           inps.pix_box[2] - inps.pix_box[0]) > 2e3:
        inps.disp_dem_contour = False
```

This was check was updated, but then I noticed that dem shade masking still failed:
```
WARNING: DEM has different size than mask, ignore --mask-dem and continue.
```

After printing out the two arrays and referring to the documentation for the `LightSource` module of matplotlib, I realized this was because the `dem_shade` array is generated as an array with 4 layers. I thus updated the code with this in mind.


However after this I noticed that even when I specify the `--mask-dem` and `--zero-mask` option, the masked pixels in the InSAR field are not masked in the dem:
![OG_velocity_TECTscale_noGPSjustDEM](https://user-images.githubusercontent.com/13227405/134859728-1d3846d9-0dfc-4b6f-8bbd-323d717ecb1b.png)

I thus introduced a more simplified update such that the `msk` array in memory reflects these nodata values:
![velocity_TECTscale_noGPSjustDEM](https://user-images.githubusercontent.com/13227405/134859732-91ebc207-2d46-4eee-aca1-aac39915dcc5.png)


**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
