### PR TITLE
Update naming of timeseries_Residual.h5

### DIFF
--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -459,7 +459,7 @@ def correct_dem_error(inps, A_def):
     writefile.write(ts_cor, out_file=inps.outfile, metadata=atr, ref_file=ts_obj.file)
 
     # 3. Time-series of inversion residual
-    ts_ref_file = os.path.join(os.path.dirname(inps.outfile), 'timeseriesResidual.h5')
+    ts_ref_file = os.path.join(os.path.dirname(inps.outfile),'{}_Residual.h5'.format(os.path.splitext(inps.timeseries_file)[0]))
     writefile.write(ts_res, out_file=ts_ref_file, metadata=atr, ref_file=ts_obj.file)
 
     # 4. Time-series of estimated Step Model


### PR DESCRIPTION
Hi Yunjun,

I just changed the naming of the residual file.I think according to each atmospheric correction, we can have a new file for timeseries_Residual.h5 which can be used separately for uncertainty estimation. if someone produces several atmospheric corrections,the residual file remained same which is misleading

Best regards,
Mohammad

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
