### PR TITLE
Dockerfile: rewrite using Micromamba Image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,29 +10,33 @@ LABEL \
     "Dockerfile Author"="Forrest Williams" \
     "Email"="forrestfwilliams@icloud.com"
 
-# Install git and vim
+# Install command line tools: git, vim and wget
 USER root
 RUN apt-get update && \
     apt-get install -y git vim wget && \
     rm -rf /var/lib/apt/lists/*
 
-# Clone MintPy and PyAPS repositories
+# Setup path / environment for MintPy
 USER micromamba
 WORKDIR /home/micromamba
 
+ARG MINTPY_HOME=/home/micromamba/tools/MintPy
+ARG PYAPS_HOME=/home/micromamba/tools/PyAPS
+
+ENV PATH=${MINTPY_HOME}/mintpy:/opt/conda/bin:${PATH}
+ENV PYTHONPATH=${MINTPY_HOME}:${PYAPS_HOME}
+
+# Download source code
 RUN mkdir /home/micromamba/tools && \
-    git clone https://github.com/insarlab/MintPy.git /home/micromamba/tools/MintPy && \
-    git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS
+    git clone https://github.com/insarlab/MintPy.git ${MINTPY_HOME} && \
+    git clone https://github.com/yunjunz/PyAPS.git ${PYAPS_HOME}
 
-# Prepare environment for MintPy
-ENV PATH=/home/micromamba/tools/MintPy/mintpy:/opt/conda/bin:${PATH}
-ENV PYTHONPATH=/home/micromamba/tools/MintPy:/home/micromamba/tools/PyAPS
-
+# Install dependencies
 # # # Optionally add Jupyter Lab to environment file
-# # RUN echo "  - jupyterlab\n  - ipympl" >> /home/micromamba/tools/MintPy/docs/environment.yml
+# # RUN echo "  - jupyterlab\n  - ipympl" >> ${MINTPY_HOME}/docs/environment.yml
 
 # ADD mintpy.yml /tmp
-RUN micromamba install -y -n base -f /home/micromamba/tools/MintPy/docs/environment.yml python=3.6 && \
+RUN micromamba install -y -n base -f ${MINTPY_HOME}/docs/environment.yml python=3.6 && \
     micromamba clean --all --yes
 
 # # Have the container start with a Jupyter Lab instance

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Use mambaforge as the base image
 # Builds in ~9.5 min and is ~ 2.5 GB on a windows laptop
-FROM mambaorg/micromamba
+FROM mambaorg/micromamba:0.15.3
 
 # Label image
 LABEL \
@@ -17,6 +17,7 @@ ARG user=micromamba
 USER root
 RUN apt-get update && \
     apt-get install -y git vim && \
+    rm /var/lib/apt/lists/* && \
     mkdir /home/micromamba/tools && \
     git clone https://github.com/insarlab/MintPy.git /home/micromamba/tools/MintPy && \
     git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH=${MINTPY_HOME}/mintpy:/opt/conda/bin:${PATH}
 ENV PYTHONPATH=${MINTPY_HOME}:${PYAPS_HOME}
 
 # Download source code
-RUN mkdir /home/micromamba/tools && \
+RUN mkdir -p ${MINTPY_HOME} ${PYAPS_HOME} && \
     git clone https://github.com/insarlab/MintPy.git ${MINTPY_HOME} && \
     git clone https://github.com/yunjunz/PyAPS.git ${PYAPS_HOME}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,8 @@ LABEL \
 # Install command line tools: git, vim and wget
 USER root
 RUN apt-get update && \
-    apt-get install -y git vim wget && \
+    apt-get install -y --no-install-recommends git vim wget && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Setup path / environment for MintPy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,14 +17,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Clone MintPy and PyAPS repositories
-USER $user
-RUN mkdir /home/$user/tools && \
-    git clone https://github.com/insarlab/MintPy.git /home/$user/tools/MintPy && \
-    git clone https://github.com/yunjunz/PyAPS.git /home/$user/tools/PyAPS
+USER micromamba
+WORKDIR /home/micromamba
+
+RUN mkdir /home/micromamba/tools && \
+    git clone https://github.com/insarlab/MintPy.git /home/micromamba/tools/MintPy && \
+    git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS
 
 # Prepare environment for MintPy
-ARG MINTPY_HOME=/home/$user/tools/MintPy
-ARG PYAPS_HOME=/home/$user/tools/PyAPS
+ARG MINTPY_HOME=/home/micromamba/tools/MintPy
+ARG PYAPS_HOME=/home/micromamba/tools/PyAPS
 ARG PYTHON3DIR=/opt/conda
 
 ENV MINTPY_HOME=${MINTPY_HOME}
@@ -38,9 +40,6 @@ ENV PYTHONPATH=${MINTPY_HOME}:${PYAPS_HOME}
 # ADD mintpy.yml /tmp
 RUN micromamba install -y -n base -f ${MINTPY_HOME}/docs/environment.yml python=3.6 && \
     micromamba clean --all --yes
-
-# Set work directory
-WORKDIR /home/$user
 
 # # Have the container start with a Jupyter Lab instance
 # CMD ["jupyter", "lab", "--port=8888", "--no-browser", "--ip=0.0.0.0","--NotebookApp.token=mintpy"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,72 +1,46 @@
-# use debian as base image
-FROM debian:stretch
+# Use mambaforge as the base image
+# Builds in ~9.5 min and is ~ 2.5 GB on a windows laptop
+FROM mambaorg/micromamba
 
 # Label image
 LABEL \
     "Description"="Container for open source time series InSAR processing with Mintpy" \
     "Github Source"="https://github.com/insarlab/MintPy/" \
     "Installation"="https://github.com/insarlab/MintPy/blob/main/docs/installation.md" \
-    "Dockerfile Author"="Andre Theron" \
-    "Email"="andretheronsa@gmail.com"
+    "Dockerfile Author"="Forrest Williams" \
+    "Email"="forrestfwilliams@icloud.com"
 
-# Install useful programs
+# Set user name (the micromamba image comes with the micromamba user)
+ARG user=micromamba
+
+# Clone MintPy and PyAPS repositories
+USER root
 RUN apt-get update && \
-    apt-get install -y \
-    git \
-    python3 \
-    python3-pip \
-    wget \ 
-    vim \
-    zip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    apt-get install -y git vim && \
+    mkdir /home/micromamba/tools && \
+    git clone https://github.com/insarlab/MintPy.git /home/micromamba/tools/MintPy && \
+    git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS
 
-# Change default shell from dash to bash permanently
-SHELL ["/bin/bash", "-c"]
+# Prepare environment for MintPy
+ARG MINTPY_HOME=/home/$user/tools/MintPy
+ARG PYAPS_HOME=/home/$user/tools/PyAPS
+ARG PYTHON3DIR=/opt/conda
 
-# Prepare build time environment for conda and mintpy
-ARG MINTPY_HOME=/home/python/MintPy
-ARG PYTHON3DIR=/home/python/miniconda3
-ARG PYAPS_HOME=/home/python/PyAPS
-ARG WORK_DIR=/home/work/
-
-# Prepare container environment
 ENV MINTPY_HOME=${MINTPY_HOME}
-ENV PYTHON3DIR=${PYTHON3DIR}
 ENV PYAPS_HOME=${PYAPS_HOME}
 ENV PATH=${MINTPY_HOME}/mintpy:${PYTHON3DIR}/bin:${PATH}
-ENV PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${PYAPS_HOME}
-ENV PROJ_LIB=${PYTHON3DIR}/share/proj
+ENV PYTHONPATH=${MINTPY_HOME}:${PYAPS_HOME}
 
-# Set workdir
-WORKDIR /home/python
+# # # Optionally add Jupyter Lab to environment file
+# # RUN echo "  - jupyterlab\n  - ipympl" >> ${MINTPY_HOME}/docs/environment.yml
 
-# Pull and config mintpy
-RUN git clone https://github.com/insarlab/MintPy.git
+# ADD mintpy.yml /tmp
+RUN micromamba install -y -n base -f ${MINTPY_HOME}/docs/environment.yml python=3.6 && \
+    micromamba clean --all --yes
 
-# Pull and config PyAPS
-RUN git clone https://github.com/yunjunz/PyAPS.git
+# Create user and set work directory
+USER $user
+WORKDIR /home/$user
 
-# Install miniconda
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh && \
-    chmod +x ./Miniconda3-4.5.4-Linux-x86_64.sh  && \
-    ./Miniconda3-4.5.4-Linux-x86_64.sh -b -p ${PYTHON3DIR} && \
-    rm ./Miniconda3-4.5.4-Linux-x86_64.sh
-
-# Install dependencies
-RUN ${PYTHON3DIR}/bin/conda config --add channels conda-forge && \
-    ${PYTHON3DIR}/bin/conda install --yes --file ${MINTPY_HOME}/docs/requirements.txt
-
-# Install pykml
-RUN ${PYTHON3DIR}/bin/pip install git+https://github.com/yunjunz/pykml.git
-
-# Set working directory ENV - map a host data volume to this using "docker build . -t mintpy && docker run mintpy -v /host/path/to/data:/home/work/"
-RUN mkdir -p ${WORK_DIR}
-ENV WORK_DIR=${WORK_DIR}
-WORKDIR ${WORK_DIR}
-
-# Copy custom app scripts to app folder - not required
-COPY ["./", "/home/app/"]
-
-# Run entrypoint script - not required
-CMD ["python3", "/home/app/app.py"]
+# # Have the container start with a Jupyter Lab instance
+# CMD ["jupyter", "lab", "--port=8888", "--no-browser", "--ip=0.0.0.0","--NotebookApp.token=mintpy"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG user=micromamba
 USER root
 RUN apt-get update && \
     apt-get install -y git vim && \
-    rm /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* && \
     mkdir /home/micromamba/tools && \
     git clone https://github.com/insarlab/MintPy.git /home/micromamba/tools/MintPy && \
     git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ LABEL \
 # Install git and vim
 USER root
 RUN apt-get update && \
-    apt-get install -y git vim && \
+    apt-get install -y git vim wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Clone MintPy and PyAPS repositories
@@ -25,20 +25,14 @@ RUN mkdir /home/micromamba/tools && \
     git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS
 
 # Prepare environment for MintPy
-ARG MINTPY_HOME=/home/micromamba/tools/MintPy
-ARG PYAPS_HOME=/home/micromamba/tools/PyAPS
-ARG PYTHON3DIR=/opt/conda
-
-ENV MINTPY_HOME=${MINTPY_HOME}
-ENV PYAPS_HOME=${PYAPS_HOME}
-ENV PATH=${MINTPY_HOME}/mintpy:${PYTHON3DIR}/bin:${PATH}
-ENV PYTHONPATH=${MINTPY_HOME}:${PYAPS_HOME}
+ENV PATH=/home/micromamba/tools/MintPy/mintpy:/opt/conda/bin:${PATH}
+ENV PYTHONPATH=/home/micromamba/tools/MintPy:/home/micromamba/tools/PyAPS
 
 # # # Optionally add Jupyter Lab to environment file
-# # RUN echo "  - jupyterlab\n  - ipympl" >> ${MINTPY_HOME}/docs/environment.yml
+# # RUN echo "  - jupyterlab\n  - ipympl" >> /home/micromamba/tools/MintPy/docs/environment.yml
 
 # ADD mintpy.yml /tmp
-RUN micromamba install -y -n base -f ${MINTPY_HOME}/docs/environment.yml python=3.6 && \
+RUN micromamba install -y -n base -f /home/micromamba/tools/MintPy/docs/environment.yml python=3.6 && \
     micromamba clean --all --yes
 
 # # Have the container start with a Jupyter Lab instance

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use mambaforge as the base image
-# Builds in ~9.5 min and is ~ 2.5 GB on a windows laptop
+# Builds in ~ 4.25 min and is ~ 2.6 GB on a windows laptop
 FROM mambaorg/micromamba:0.15.3
 
 # Label image
@@ -10,17 +10,17 @@ LABEL \
     "Dockerfile Author"="Forrest Williams" \
     "Email"="forrestfwilliams@icloud.com"
 
-# Set user name (the micromamba image comes with the micromamba user)
-ARG user=micromamba
-
-# Clone MintPy and PyAPS repositories
+# Install git and vim
 USER root
 RUN apt-get update && \
     apt-get install -y git vim && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir /home/micromamba/tools && \
-    git clone https://github.com/insarlab/MintPy.git /home/micromamba/tools/MintPy && \
-    git clone https://github.com/yunjunz/PyAPS.git /home/micromamba/tools/PyAPS
+    rm -rf /var/lib/apt/lists/*
+
+# Clone MintPy and PyAPS repositories
+USER $user
+RUN mkdir /home/$user/tools && \
+    git clone https://github.com/insarlab/MintPy.git /home/$user/tools/MintPy && \
+    git clone https://github.com/yunjunz/PyAPS.git /home/$user/tools/PyAPS
 
 # Prepare environment for MintPy
 ARG MINTPY_HOME=/home/$user/tools/MintPy
@@ -39,8 +39,7 @@ ENV PYTHONPATH=${MINTPY_HOME}:${PYAPS_HOME}
 RUN micromamba install -y -n base -f ${MINTPY_HOME}/docs/environment.yml python=3.6 && \
     micromamba clean --all --yes
 
-# Create user and set work directory
-USER $user
+# Set work directory
 WORKDIR /home/$user
 
 # # Have the container start with a Jupyter Lab instance

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,25 +5,25 @@ Thanks to Andre Theron for putting together an [MintPy container on DockerHub](h
 To pull the MintPy container from Dockerhub to your local machine: 
 
 ```
-docker pull andretheronsa/mintpy:latest
+docker pull forrestwilliams/mintpy:latest
 ```
 
 To start an interactive shell session in the container from the terminal, with bash for example: 
 
 ```
-docker run -it andretheronsa/mintpy:latest bash
+docker run -it forrestwilliams/mintpy:latest bash
 ```
 
 To map data on the host (local) machine to the container use [volumes](https://docs.docker.com/storage/volumes/):
 
 ```
-docker run -it -v /path/to/data/dir:/home/work/ andretheronsa/mintpy:latest bash
+docker run -it -v /path/to/data/dir:/home/work/ forrestwilliams/mintpy:latest bash
 ```
 
 Background processing is possible using something like:  
 
 ```
-docker run -it -v /path/to/data/dir:/home/work/ andretheronsa/mintpy:latest python /home/python/MintPy/mintpy/smallbaselineApp.py /home/work/smallbaselineApp.cfg
+docker run -it -v /path/to/data/dir:/home/work/ forrestwilliams/mintpy:latest python /home/python/MintPy/mintpy/smallbaselineApp.py /home/work/smallbaselineApp.cfg
 ```
 
 ### Notes ###

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
 ## Running as Docker container
 
-Thanks to Andre Theron for putting together an [MintPy container on DockerHub](https://hub.docker.com/r/andretheronsa/mintpy). [Docker](https://docs.docker.com/get-started/) allows you to run MintPy in a dedicated container (essentially an efficient virtual machine). [Here](https://docs.docker.com/install/) is the instruction to install docker.
+Thanks to Andre Theron for putting together an [MintPy container on DockerHub](https://hub.docker.com/r/forrestwilliams/mintpy). [Docker](https://docs.docker.com/get-started/) allows you to run MintPy in a dedicated container (essentially an efficient virtual machine). [Here](https://docs.docker.com/install/) is the instruction to install docker.
 
 To pull the MintPy container from Dockerhub to your local machine: 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ sudo xcodebuild -license
 
 ### Notes for Docker users ###
 
-Docker allows one to run MintPy in a dedicated container (essentially an efficient virtual machine) and to be independent of platform OS. After installing [docker](https://docs.docker.com/install/), run the following to pull the [MintPy container from DockerHub](https://hub.docker.com/r/andretheronsa/mintpy) to your local machine, check more details at [here](docker.md).
+Docker allows one to run MintPy in a dedicated container (essentially an efficient virtual machine) and to be independent of platform OS. After installing [docker](https://docs.docker.com/install/), run the following to pull the [MintPy container from DockerHub](https://hub.docker.com/r/forrestwilliams/mintpy) to your local machine, check more details at [here](docker.md).
 
 ```
 docker pull andretheronsa/mintpy:latest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ sudo xcodebuild -license
 Docker allows one to run MintPy in a dedicated container (essentially an efficient virtual machine) and to be independent of platform OS. After installing [docker](https://docs.docker.com/install/), run the following to pull the [MintPy container from DockerHub](https://hub.docker.com/r/forrestwilliams/mintpy) to your local machine, check more details at [here](docker.md).
 
 ```
-docker pull andretheronsa/mintpy:latest
+docker pull forrestwilliams/mintpy:1.3.1
 ```
 
 ### 1. Download and Setup ###


### PR DESCRIPTION
References issue #123 
A recent build can be found at `https://hub.docker.com/repository/docker/forrestwilliams/mintpy`

- Rewrites the MintPy dockerfile using the mambaorg/micromamba image
- Shorter build times and slightly smaller image!
- Forces Python=3.6 for faster image build
- Sets the user as micromamba, not root
- Optionally allows the image to start with a Jupyter Lab instance

**Reminders**

- [x] Fix #xxxx
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
