### PR TITLE
spatial_filter: refactor double difference

### DIFF
--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -116,13 +116,16 @@ def filter_data(data, filter_type, filter_par=None):
     elif filter_type == "double_difference":
         """Amplifies the local deformation signal by reducing the influence
         of regional deformation trends from atmospheric artifacts, tectonic
-        deformation, and other sources. Intend use is to identify landslide-related
+        deformation, and other sources. Intended use is to identify landslide-related
         deformation. Filter has the form:
 
             result =  regional mean of data - local mean of data
 
         where both the regional and local kernel size can be set using the
-        filter_par argument.
+        filter_par argument. The regional kernel has a doughnut shape 
+        because the pixels used to calculate the local mean are not
+        included in the regional mean. This ensures that the local mean
+        and regional mean results are separate.
         """
 
         local_kernel = morphology.disk(filter_par[0], np.float32)

--- a/mintpy/spatial_filter.py
+++ b/mintpy/spatial_filter.py
@@ -125,15 +125,18 @@ def filter_data(data, filter_type, filter_par=None):
         filter_par argument.
         """
 
-        kernel = morphology.disk(filter_par[0], np.float32)
-        kernel = kernel / kernel.flatten().sum()
-        local_filt = ndimage.convolve(data, kernel)
+        local_kernel = morphology.disk(filter_par[0], np.float32)
+        local_kernel = np.pad(local_kernel,filter_par[1] - filter_par[0],mode='constant')
 
-        kernel = morphology.disk(filter_par[1], np.float32)
-        kernel = kernel / kernel.flatten().sum()
-        regional_filt = ndimage.convolve(data, kernel)
+        regional_kernel = morphology.disk(filter_par[1], np.float32)
+        regional_kernel[local_kernel == 1] = 0
 
-        data_filt = regional_filt - local_filt
+        local_kernel /= local_kernel.sum(axis=(0,1))
+        regional_kernel /= regional_kernel.sum(axis=(0,1))
+        
+        combined_kernel = regional_kernel - local_kernel
+
+        data_filt = ndimage.convolve(data, combined_kernel)
 
     else:
         raise Exception('Un-recognized filter type: '+filter_type)


### PR DESCRIPTION
- combine the local and regional filter into
  one filter to reduce number of
  convolutional operations

- change regional filter shape from a disk to
  a doughnut

**Reminders**

- [x] Fix #xxxx
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
