### PR TITLE
prep_hyp3: ignore whitespace in keys

### DIFF
--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -117,7 +117,12 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
 
     # add universal hyp3 metadata
     meta['PROCESSOR'] = 'hyp3'
-    meta['CENTER_LINE_UTC'] = hyp3_meta['UTCtime']
+
+    try:
+        meta['CENTER_LINE_UTC'] = hyp3_meta['UTC time']
+    except KeyError:
+        meta['CENTER_LINE_UTC'] = hyp3_meta['UTCtime']
+
     meta['ALOOKS'] = hyp3_meta['Azimuth looks']
     meta['RLOOKS'] = hyp3_meta['Range looks']
     meta['EARTH_RADIUS'] = hyp3_meta['Earth radius at nadir']

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -112,22 +112,17 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
     hyp3_meta = {}
     with open(meta_file, 'r') as f:
         for line in f:
-            key, value = line.strip().split(': ')
+            key, value = line.strip().replace(' ','').split(':')
             hyp3_meta[key] = value
 
     # add universal hyp3 metadata
     meta['PROCESSOR'] = 'hyp3'
-
-    try:
-        meta['CENTER_LINE_UTC'] = hyp3_meta['UTC time']
-    except KeyError:
-        meta['CENTER_LINE_UTC'] = hyp3_meta['UTCtime']
-
-    meta['ALOOKS'] = hyp3_meta['Azimuth looks']
-    meta['RLOOKS'] = hyp3_meta['Range looks']
-    meta['EARTH_RADIUS'] = hyp3_meta['Earth radius at nadir']
-    meta['HEIGHT'] = hyp3_meta['Spacecraft height']
-    meta['STARTING_RANGE'] = hyp3_meta['Slant range near']
+    meta['CENTER_LINE_UTC'] = hyp3_meta['UTCtime']
+    meta['ALOOKS'] = hyp3_meta['Azimuthlooks']
+    meta['RLOOKS'] = hyp3_meta['Rangelooks']
+    meta['EARTH_RADIUS'] = hyp3_meta['Earthradiusatnadir']
+    meta['HEIGHT'] = hyp3_meta['Spacecraftheight']
+    meta['STARTING_RANGE'] = hyp3_meta['Slantrangenear']
     # ensure negative value for the heading angle
     meta['HEADING'] = float(hyp3_meta['Heading']) % 360. - 360.
 
@@ -159,7 +154,7 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
 
     # note: HyP3 currently only supports Sentinel-1 data, so Sentinel-1
     #       configuration is hard-coded.
-    if hyp3_meta['Reference Granule'].startswith('S1'):
+    if hyp3_meta['ReferenceGranule'].startswith('S1'):
         meta['PLATFORM'] = 'Sen'
         meta['ANTENNA_SIDE'] = -1
         meta['WAVELENGTH'] = SPEED_OF_LIGHT / sensor.SEN['carrier_frequency']

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -112,7 +112,7 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
     hyp3_meta = {}
     with open(meta_file, 'r') as f:
         for line in f:
-            key, value = line.strip().replace(' ','').split(':')
+            key, value = line.strip().replace(' ','').split(':')[:2]
             hyp3_meta[key] = value
 
     # add universal hyp3 metadata


### PR DESCRIPTION
In the metadata file provided with HyP3 InSAR products, the syntax of the UTC time key has changed form `UTCtime` to `UTC time` and the prep_hyp3 scripts needs to be updated to reflect this.

A try except statement was added that first tries to index on `UTC time` , then indexes on `UTCtime` if this produces a `Key Error`. This ensures backward compatibility with old products.

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
