### PR TITLE
parallel: divide num_core by num_thread if available

### DIFF
--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -7,7 +7,6 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         auto_path
         template
     /objects
-        cluster
         colors
         giant
         ramp
@@ -24,6 +23,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         fractal
 ------------------ level 1 --------------------
     /objects
+        cluster       (utils/utils0)
         conncomp      (objects/ramp)
         stack         (utils/ptime)
     /utils

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -12,6 +12,7 @@ import os
 import time
 import glob
 import shutil
+import subprocess
 import numpy as np
 from mintpy.utils import utils0 as ut0
 
@@ -357,19 +358,20 @@ class DaskCluster:
         if cluster_type == 'local':
             num_core = os.cpu_count()
 
-            # divide by the number of threads per core [for Linux only]
-            # as it works better on HPC, check https://github.com/insarlab/MintPy/issues/518
-            if ut0.which('lscpu') is not None:
-                # get the number of threads per core
-                # link: https://stackoverflow.com/questions/62652951
-                ps = subprocess.run(['lscpu'], capture_output=True, text=True).stdout.split('\n')
-                ns = [p.split(':')[1].strip() for p in ps if p.startswith('Thread(s) per core:')]
-                if len(ns) > 0:
-                    num_thread = int(ns[0])
-                    num_core = int(num_core / num_thread)
-
             # all --> num_core
             if num_worker == 'all':
+                # divide by the number of threads per core [for Linux only]
+                # as it works better on HPC, check https://github.com/insarlab/MintPy/issues/518
+                if ut0.which('lscpu') is not None:
+                    # get the number of threads per core
+                    # link: https://stackoverflow.com/questions/62652951
+                    ps = subprocess.run(['lscpu'], capture_output=True, text=True).stdout.split('\n')
+                    ns = [p.split(':')[1].strip() for p in ps if p.startswith('Thread(s) per core:')]
+                    if len(ns) > 0:
+                        num_thread = int(ns[0])
+                        num_core = int(num_core / num_thread)
+
+                # set num_worker to the number of cores
                 num_worker = str(num_core)
 
             # str --> int

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -18,7 +18,7 @@ import argparse
 import numpy as np
 
 import mintpy
-from mintpy.objects import sensor, RAMP_LIST
+from mintpy.objects import sensor, cluster, RAMP_LIST
 from mintpy.utils import readfile, writefile, utils as ut
 from mintpy.defaults.template import STEP_LIST
 import mintpy.workflow   # dynamic import of modules for smallbaselineApp
@@ -1187,8 +1187,10 @@ class TimeSeriesAnalysis:
         # run view
         start_time = time.time()
         run_parallel = False
-        if self.template['mintpy.compute.cluster']:
-            num_workers = int(self.template['mintpy.compute.numWorker'])
+        cluster_type = self.template['mintpy.compute.cluster']
+        if cluster_type:
+            num_workers = self.template['mintpy.compute.numWorker']
+            num_workers = cluster.DaskCluster.format_num_worker(cluster_type, num_workers)
 
             # limit number of parallel processes based on available CPU
             num_cores, run_parallel, Parallel, delayed = ut.check_parallel(


### PR DESCRIPTION
**Description of proposed changes**

+ `cluster.format_num_worker()`: divide the number of cores by the number of threads per core if found [for linux only] using `lscpu` command. Note again that this only affect the translation of `numWorker = all`. Fix #518.

+ `smallbaselineApp.plot_result()`: translate `mintpy.compute.numWorker = all`. Fix #689 

+ update API hierarchy of `cluster.py` as it now depends on `utils0.py`

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.