### PR TITLE
plot_network: color-code network/matrix plot based on temp/perp baselines

### DIFF
--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -37,6 +37,7 @@ EXAMPLE = """example:
   plot_network.py inputs/ifgramStack.h5
   plot_network.py inputs/ifgramStack.h5 -t smallbaselineApp.cfg --nodisplay   #Save figures to files without display
   plot_network.py inputs/ifgramStack.h5 -t smallbaselineApp.cfg --show-kept   #Do not plot dropped ifgrams
+  plot_network.py inputs/ifgramStack.h5  --tb --tbv 0 365.25 -c2 RdYlBu_r  #Color lines by temporal baseline with -c2 cmap
   plot_network.py coherenceSpatialAvg.txt
 
   # offsetSNR
@@ -75,6 +76,19 @@ def create_parser():
 
     coh.add_argument('-v', '--vlim', nargs=2, type=float, default=(0.2, 1.0),
                      help='display range')
+
+    # Display baseline in the network plot
+    coh = parser.add_argument_group('Display Baseline', 'Color lines in the network plot with baseline instead of coherence')
+    coh.add_argument('--tb', '--tbase', dest='tbColor', action='store_true',
+                     help='color using temporal baseline')
+    coh.add_argument('--pb', '--pbase', dest='pbColor', action='store_true',
+                     help='color using perpendicular baseline')
+    coh.add_argument('--tbv', '--tbvlim', dest='tbvlim', nargs=2, type=float, default=(0, 365.25),
+                     help='display color range for temporal baseline [day]. (default: %(default)s)')
+    coh.add_argument('--pbv', '--pbvlim', dest='pbvlim', nargs=2, type=float, default=(0, 180.0),
+                     help='display color range for perpendicular baseline [meter]. (default: %(default)s)')
+    coh.add_argument('-c2', '--colormap2', dest='cmap_name2', default='RdYlBu_r',
+                     help='colormap name for the network display (baseline coloring). Default: %(default)s')
 
     # Figure  Setting
     fig = parser.add_argument_group('Figure', 'Figure settings for display')
@@ -233,6 +247,7 @@ def check_colormap(inps):
     # in case the manually input list is not in order
     inps.cmap_vlist = sorted(inps.cmap_vlist)
     inps.colormap = pp.ColormapExt(inps.cmap_name, vlist=inps.cmap_vlist).colormap
+    inps.colormap2 = pp.ColormapExt(inps.cmap_name2, vlist=inps.cmap_vlist).colormap
 
     return inps
 

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -12,7 +12,7 @@ import argparse
 import numpy as np
 import matplotlib.pyplot as plt
 from mintpy.objects import ifgramStack
-from mintpy.utils import ptime, readfile, utils as ut, plot as pp
+from mintpy.utils import readfile, utils as ut, plot as pp
 # suppress UserWarning from matplotlib
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -12,9 +12,7 @@ import argparse
 import numpy as np
 import matplotlib.pyplot as plt
 from mintpy.objects import ifgramStack
-from mintpy.utils import (readfile,
-                          utils as ut,
-                          plot as pp)
+from mintpy.utils import ptime, readfile, utils as ut, plot as pp
 # suppress UserWarning from matplotlib
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")
@@ -37,7 +35,8 @@ EXAMPLE = """example:
   plot_network.py inputs/ifgramStack.h5
   plot_network.py inputs/ifgramStack.h5 -t smallbaselineApp.cfg --nodisplay   #Save figures to files without display
   plot_network.py inputs/ifgramStack.h5 -t smallbaselineApp.cfg --show-kept   #Do not plot dropped ifgrams
-  plot_network.py inputs/ifgramStack.h5  --tb --tbv 0 365.25 -c2 RdYlBu_r  #Color lines by temporal baseline with -c2 cmap
+  plot_network.py inputs/ifgramStack.h5 -d tbase -v 0 365.25 -c RdYlBu_r      #Color-code lines by temporal      baseline
+  plot_network.py inputs/ifgramStack.h5 -d pbase -v 0 180    -c RdYlBu_r      #Color-code lines by perpendicular baseline
   plot_network.py coherenceSpatialAvg.txt
 
   # offsetSNR
@@ -56,37 +55,27 @@ def create_parser():
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=EXAMPLE)
 
-    parser.add_argument('file',
-                        help='file with network information, ifgramStack.h5 or coherenceSpatialAvg.txt')
+    parser.add_argument('file', help='file with network information, ifgramStack.h5 or coherenceSpatialAvg.txt')
     parser.add_argument('--show-kept', dest='disp_drop', action='store_false',
                         help='display kept interferograms only, without dropped interferograms')
-    parser.add_argument('-d', '--dset', type=str, dest='dsetName', default='coherence',
-                        help='dataset used to calculate the mean')
 
-    # Display coherence
-    coh = parser.add_argument_group('Display Coherence', 'Show coherence of each interferogram pair with color')
-    coh.add_argument('-t', '--template', dest='template_file',
-                     help='template file with options below:\n'+TEMPLATE)
-    coh.add_argument('-c', '--colormap', dest='cmap_name', default='RdBu_truncate',
-                     help='colormap name for the network display. Default: RdBu_truncate')
-    coh.add_argument('--cmap-vlist', dest='cmap_vlist', type=float, nargs=3, default=[0.2, 0.4, 1.0],
-                     help='normalized start/jump/end value for truncated colormap. Default: 0.2 0.4 1.0')
-    coh.add_argument('--mask', dest='maskFile', default='waterMask.h5',
-                     help='mask file used to calculate the coherence. Default: waterMask.h5 or None.')
+    # Color-code coherence/baseline in the network/matrix plot
+    color = parser.add_argument_group('Color-code network/matrix plot',
+                                      'color-code phase/offset pairs with coherence/baseline in network/matrix plot')
+    color.add_argument('-d', '--dset', type=str, dest='dsetName', default='coherence',
+                       choices={'coherence','offsetSNR','pbase','tbase'},
+                       help='dataset used to calculate the mean. (default: %(default)s)')
+    color.add_argument('-v', '--vlim', nargs=2, type=float, default=(0.2, 1.0), help='display range')
 
-    coh.add_argument('-v', '--vlim', nargs=2, type=float, default=(0.2, 1.0),
-                     help='display range')
+    color.add_argument('-t', '--template', dest='template_file',
+                       help='template file with options below:\n'+TEMPLATE)
+    color.add_argument('--mask', dest='maskFile', default='waterMask.h5',
+                       help='mask file used to calculate the coherence. Default: waterMask.h5 or None.')
 
-    # Display baseline in the network plot
-    coh = parser.add_argument_group('Display Baseline', 'Color lines in the network plot with baseline instead of coherence')
-    coh.add_argument('--tb', '--tbase', dest='tbColor', action='store_true',
-                     help='color using temporal baseline')
-    coh.add_argument('--pb', '--pbase', dest='pbColor', action='store_true',
-                     help='color using perpendicular baseline')
-    coh.add_argument('--tbv', '--tbvlim', dest='tbvlim', nargs=2, type=float, default=(0, 365.25),
-                     help='display color range for temporal baseline [day]. (default: %(default)s)')
-    coh.add_argument('--pbv', '--pbvlim', dest='pbvlim', nargs=2, type=float, default=(0, 180.0),
-                     help='display color range for perpendicular baseline [meter]. (default: %(default)s)')
+    color.add_argument('-c', '--colormap', dest='cmap_name', default='RdBu_truncate',
+                       help='colormap name for the network display. Default: RdBu_truncate')
+    color.add_argument('--cmap-vlist', dest='cmap_vlist', type=float, nargs=3, default=[0.2, 0.4, 1.0],
+                       help='normalized start/jump/end value for truncated colormap. Default: 0.2 0.4 1.0')
 
     # Figure  Setting
     fig = parser.add_argument_group('Figure', 'Figure settings for display')
@@ -122,6 +111,11 @@ def create_parser():
 def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
+
+    # save argv (to check the manually specified arguments)
+    # use iargs        for python call
+    # use sys.argv[1:] for command line call
+    inps.argv = iargs if iargs else sys.argv[1:]
 
     # check input file type
     if inps.file.endswith(('.h5','.he5')):
@@ -169,14 +163,27 @@ def read_network_info(inps):
 
     ## 1. Read date, pbase, date12 and coherence
     if ext == '.h5':
-        inps.date12List = ifgramStack(inps.file).get_date12_list(dropIfgram=False)
-        inps.dateList = ifgramStack(inps.file).get_date_list(dropIfgram=False)
-        inps.pbaseList = ifgramStack(inps.file).get_perp_baseline_timeseries(dropIfgram=False)
-        inps.cohList = ut.spatial_average(inps.file,
-                                          datasetName=inps.dsetName,
-                                          maskFile=inps.maskFile,
-                                          saveList=True,
-                                          checkAoi=False)[0]
+        stack_obj = ifgramStack(inps.file)
+        stack_obj.open()
+        inps.date12List = stack_obj.get_date12_list(dropIfgram=False)
+        inps.dateList = stack_obj.get_date_list(dropIfgram=False)
+        inps.pbaseList = stack_obj.get_perp_baseline_timeseries(dropIfgram=False)
+
+        if inps.dsetName in readfile.get_dataset_list(inps.file):
+            inps.cohList = ut.spatial_average(inps.file,
+                                              datasetName=inps.dsetName,
+                                              maskFile=inps.maskFile,
+                                              saveList=True,
+                                              checkAoi=False)[0]
+        elif inps.dsetName == 'pbase':
+            inps.cohList = np.abs(stack_obj.pbaseIfgram).tolist()
+
+        elif inps.dsetName == 'tbase':
+            inps.cohList = stack_obj.tbaseIfgram.tolist()
+
+        else:
+            raise ValueError(f'{inps.dsetName} NOT found in file: {inps.file}!')
+
     elif ext == '.txt':
         inps.date12List = np.loadtxt(inps.file, dtype=bytes).astype(str)[:,0].tolist()
 
@@ -225,7 +232,7 @@ def read_network_info(inps):
 def check_colormap(inps):
     """Check input colormaps."""
     # adjust color jump if no --cmap-vlist is input
-    if inps.cohList is not None and '--cmap-vlist' not in sys.argv:
+    if inps.cohList is not None and '--cmap-vlist' not in inps.argv:
         # use template value
         key = 'mintpy.network.minCoherence'
         if key in inps.template.keys():
@@ -259,12 +266,21 @@ def main(iargs=None):
     # Plot settings
     inps = check_colormap(inps)
     if inps.dsetName == 'coherence':
+        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'coherenceHistory', 'coherenceMatrix', 'network']]
         inps.ds_name = 'Coherence'
-        figNames = [i+'.pdf' for i in ['bperpHistory', 'coherenceMatrix', 'coherenceHistory', 'network']]
+        inps.cbar_label = 'Average Spatial Coherence'
     elif inps.dsetName == 'offsetSNR':
+        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'SNRHistory', 'SNRMatrix', 'network']]
         inps.ds_name = 'SNR'
-        figNames = [i+'.pdf' for i in ['bperpHistory', 'SNRMatrix', 'SNRHistory', 'network']]
-    inps.cbar_label = 'Average Spatial {}'.format(inps.ds_name)
+        inps.cbar_label = 'Average Spatial SNR'
+    elif inps.dsetName == 'tbase':
+        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'tbaseHistory', 'tbaseMatrix', 'network']]
+        inps.ds_name = 'Temporal Baseline'
+        inps.cbar_label = 'Temporal Baseline [day]'
+    elif inps.dsetName == 'pbase':
+        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'pbaseRangeHistory', 'pbaseMatrix', 'network']]
+        inps.ds_name = 'Perp Baseline'
+        inps.cbar_label = 'Perp Baseline [m]'
 
     # Fig 1 - Baseline History
     fig, ax = plt.subplots(figsize=inps.fig_size)
@@ -274,11 +290,21 @@ def main(iargs=None):
                                     vars(inps),
                                     inps.dateList_drop)
     if inps.save_fig:
-        fig.savefig(figNames[0], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-        print('save figure to {}'.format(figNames[0]))
+        fig.savefig(fig_names[0], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+        print('save figure to {}'.format(fig_names[0]))
 
     if inps.cohList is not None:
-        # Fig 2 - Coherence Matrix
+        # Fig 2 - Min/Max Coherence History
+        fig, ax = plt.subplots(figsize=inps.fig_size)
+        ax = pp.plot_coherence_history(ax,
+                                       inps.date12List,
+                                       inps.cohList,
+                                       p_dict=vars(inps))
+        if inps.save_fig:
+            fig.savefig(fig_names[2], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+            print('save figure to {}'.format(fig_names[2]))
+
+        # Fig 3 - Coherence Matrix
         fig, ax = plt.subplots(figsize=inps.fig_size)
         ax = pp.plot_coherence_matrix(ax,
                                       inps.date12List,
@@ -286,18 +312,8 @@ def main(iargs=None):
                                       inps.date12List_drop,
                                       p_dict=vars(inps))[0]
         if inps.save_fig:
-            fig.savefig(figNames[1], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-            print('save figure to {}'.format(figNames[1]))
-
-        # Fig 3 - Min/Max Coherence History
-        fig, ax = plt.subplots(figsize=inps.fig_size)
-        ax = pp.plot_coherence_history(ax,
-                                       inps.date12List,
-                                       inps.cohList,
-                                       p_dict=vars(inps))
-        if inps.save_fig:
-            fig.savefig(figNames[2], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-            print('save figure to {}'.format(figNames[2]))
+            fig.savefig(fig_names[1], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+            print('save figure to {}'.format(fig_names[1]))
 
     # Fig 4 - Interferogram Network
     fig, ax = plt.subplots(figsize=inps.fig_size)
@@ -308,8 +324,8 @@ def main(iargs=None):
                          vars(inps),
                          inps.date12List_drop)
     if inps.save_fig:
-        fig.savefig(figNames[3], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-        print('save figure to {}'.format(figNames[3]))
+        fig.savefig(fig_names[3], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+        print('save figure to {}'.format(fig_names[3]))
 
     if inps.disp_fig:
         print('showing ...')

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -87,8 +87,6 @@ def create_parser():
                      help='display color range for temporal baseline [day]. (default: %(default)s)')
     coh.add_argument('--pbv', '--pbvlim', dest='pbvlim', nargs=2, type=float, default=(0, 180.0),
                      help='display color range for perpendicular baseline [meter]. (default: %(default)s)')
-    coh.add_argument('-c2', '--colormap2', dest='cmap_name2', default='RdYlBu_r',
-                     help='colormap name for the network display (baseline coloring). Default: %(default)s')
 
     # Figure  Setting
     fig = parser.add_argument_group('Figure', 'Figure settings for display')
@@ -247,7 +245,6 @@ def check_colormap(inps):
     # in case the manually input list is not in order
     inps.cmap_vlist = sorted(inps.cmap_vlist)
     inps.colormap = pp.ColormapExt(inps.cmap_name, vlist=inps.cmap_vlist).colormap
-    inps.colormap2 = pp.ColormapExt(inps.cmap_name2, vlist=inps.cmap_vlist).colormap
 
     return inps
 

--- a/mintpy/timeseries_rms.py
+++ b/mintpy/timeseries_rms.py
@@ -20,7 +20,7 @@ from mintpy.utils import readfile, ptime, utils as ut, plot as pp
 TEMPLATE = get_template_content('residual_RMS')
 
 EXAMPLE = """example:
-  timeseries_rms.py  timeseriesResidual.h5 
+  timeseries_rms.py  timeseriesResidual.h5
   timeseries_rms.py  timeseriesResidual.h5  --template smallbaselineApp.cfg
   timeseries_rms.py  timeseriesResidual.h5  -m maskTempCoh.h5  --cutoff 3
 """
@@ -132,7 +132,7 @@ def analyze_rms(date_list, rms_list, inps):
     return inps
 
 
-def plot_rms_bar(ax, date_list, rms, cutoff=3., font_size=12, 
+def plot_rms_bar(ax, date_list, rms, cutoff=3., font_size=12,
                  tick_year_num=1, legend_loc='best',
                  disp_legend=True, disp_side_plot=True, disp_thres_text=False,
                  ylabel='Residual phase RMS [mm]'):
@@ -222,8 +222,8 @@ def main(iargs=None):
     (inps.rms_list,
      inps.date_list,
      inps.rms_file) = ut.get_residual_rms(inps.timeseries_file,
-                                          mask_file=inps.maskFile,
-                                          ramp_type=inps.deramp)
+                                         mask_file=inps.maskFile,
+                                         ramp_type=inps.deramp)
 
     analyze_rms(inps.date_list, inps.rms_list, inps)
     return

--- a/mintpy/timeseries_rms.py
+++ b/mintpy/timeseries_rms.py
@@ -222,8 +222,8 @@ def main(iargs=None):
     (inps.rms_list,
      inps.date_list,
      inps.rms_file) = ut.get_residual_rms(inps.timeseries_file,
-                                         mask_file=inps.maskFile,
-                                         ramp_type=inps.deramp)
+                                          mask_file=inps.maskFile,
+                                          ramp_type=inps.deramp)
 
     analyze_rms(inps.date_list, inps.rms_list, inps)
     return

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -529,7 +529,7 @@ def plot_coherence_history(ax, date12List, cohList, p_dict={}):
     ax.bar(x_list, np.nanmin(coh_mat, axis=0), bar_width.days, label='Min {}'.format(p_dict['ds_name']))
 
     if p_dict['disp_title']:
-        ax.set_title('{} History of All Related Pairs'.format(p_dict['ds_name']))
+        ax.set_title('{} History: Min/Max of All Related Pairs'.format(p_dict['ds_name']))
 
     ax = auto_adjust_xaxis_date(ax, datevector, fontsize=p_dict['fontsize'],
                                 every_year=p_dict['every_year'])[0]
@@ -537,7 +537,7 @@ def plot_coherence_history(ax, date12List, cohList, p_dict={}):
 
     #ax.set_xlabel('Time [years]', fontsize=p_dict['fontsize'])
     ax.set_ylabel(p_dict['ds_name'], fontsize=p_dict['fontsize'])
-    ax.legend(loc='lower right')
+    ax.legend(loc='best')
 
     return ax
 
@@ -578,10 +578,6 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     if 'disp_cbar'   not in p_dict.keys():  p_dict['disp_cbar']   = True
     if 'colormap'    not in p_dict.keys():  p_dict['colormap']    = 'RdBu'
     if 'vlim'        not in p_dict.keys():  p_dict['vlim']        = [0.2, 1.0]
-    if 'tbColor'     not in p_dict.keys():  p_dict['tbColor']     = False
-    if 'pbColor'     not in p_dict.keys():  p_dict['pbColor']     = False
-    if 'tbvlim'      not in p_dict.keys():  p_dict['tbvlim']      = [0.0, 365.25]
-    if 'pbvlim'      not in p_dict.keys():  p_dict['pbvlim']      = [0.0, 180.0]
     if 'disp_title'  not in p_dict.keys():  p_dict['disp_title']  = True
     if 'disp_drop'   not in p_dict.keys():  p_dict['disp_drop']   = True
     if 'disp_legend' not in p_dict.keys():  p_dict['disp_legend'] = True
@@ -638,12 +634,6 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
         data_max = max(cohList)
         disp_min = p_dict['vlim'][0]
         disp_max = p_dict['vlim'][1]
-        if p_dict['tbColor']:
-            disp_min, disp_max = p_dict['tbvlim']
-            p_dict['cbar_label'] = 'Temporal baseline [day]'
-        elif p_dict['pbColor']:
-            disp_min, disp_max = p_dict['pbvlim']
-            p_dict['cbar_label'] = 'Spatial baseline [m]'
         if print_msg:
             print('showing coherence')
             print('data range: {}'.format([data_min, data_max]))
@@ -681,14 +671,8 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
             y = np.array([pbaseList[idx1], pbaseList[idx2]])
             if cohList is not None:
                 val = cohList[date12List.index(date12)]
-                if p_dict['tbColor']:
-                    val = tbase12[date12List.index(date12)]
-                    disp_min, disp_max = p_dict['tbvlim']
-                elif p_dict['pbColor']:
-                    val = pbase12[date12List.index(date12)]
-                    disp_min, disp_max = p_dict['pbvlim']
                 val_norm = (val - disp_min) / (disp_max - disp_min)
-                ax.plot(x, y, '-', lw=p_dict['linewidth'], alpha=transparency, c=cmap(val_norm))
+                ax.plot(x, y, '--', lw=p_dict['linewidth'], alpha=transparency, c=cmap(val_norm))
             else:
                 ax.plot(x, y, '--', lw=p_dict['linewidth'], alpha=transparency, c='k')
 
@@ -701,12 +685,6 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
         y = np.array([pbaseList[idx1], pbaseList[idx2]])
         if cohList is not None:
             val = cohList[date12List.index(date12)]
-            if p_dict['tbColor']:
-                val = tbase12[date12List.index(date12)]
-                disp_min, disp_max = p_dict['tbvlim']
-            elif p_dict['pbColor']:
-                val = pbase12[date12List.index(date12)]
-                disp_min, disp_max = p_dict['pbvlim']
             val_norm = (val - disp_min) / (disp_max - disp_min)
             ax.plot(x, y, '-', lw=p_dict['linewidth'], alpha=transparency, c=cmap(val_norm))
         else:

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
 # Author: Zhang Yunjun, 2018                               #
 ############################################################
-# 
+#
 # Recommend import:
 #     from mintpy.utils import plot as pp
 
@@ -577,7 +577,6 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     if 'cbar_size'   not in p_dict.keys():  p_dict['cbar_size']   = '3%'
     if 'disp_cbar'   not in p_dict.keys():  p_dict['disp_cbar']   = True
     if 'colormap'    not in p_dict.keys():  p_dict['colormap']    = 'RdBu'
-    if 'colormap2'   not in p_dict.keys():  p_dict['colormap2']   = 'RdYlBu'
     if 'vlim'        not in p_dict.keys():  p_dict['vlim']        = [0.2, 1.0]
     if 'tbColor'     not in p_dict.keys():  p_dict['tbColor']     = False
     if 'pbColor'     not in p_dict.keys():  p_dict['pbColor']     = False
@@ -592,12 +591,8 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     # support input colormap: string for colormap name, or colormap object directly
     if isinstance(p_dict['colormap'], str):
         cmap = ColormapExt(p_dict['colormap']).colormap
-        if p_dict['tbColor'] or p_dict['pbColor']:
-            cmap = ColormapExt(p_dict['colormap2']).colormap
     elif isinstance(p_dict['colormap'], mpl.colors.LinearSegmentedColormap):
         cmap = p_dict['colormap']
-        if p_dict['tbColor'] or p_dict['pbColor']:
-            cmap = p_dict['colormap2']
     else:
         raise ValueError('unrecognized colormap input: {}'.format(p_dict['colormap']))
 
@@ -1774,7 +1769,7 @@ def read_gmt_lonlat_file(ll_file, SNWE=None, min_dist=10):
         prog_bar.close()
         ax.set_xlim(inps.geo_box[0], inps.geo_box[2])
         ax.set_ylim(inps.geo_box[3], inps.geo_box[1])
-                
+
     """
     # read text file
     lines = None
@@ -1786,7 +1781,7 @@ def read_gmt_lonlat_file(ll_file, SNWE=None, min_dist=10):
         lines = lines[:1000]
 
     # loop to extract/organize the data into list of arrays
-    num_line = len(lines)    
+    num_line = len(lines)
     faults = []
     fault = []
     prog_bar = ptime.progressBar(maxValue=num_line)

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -577,7 +577,12 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     if 'cbar_size'   not in p_dict.keys():  p_dict['cbar_size']   = '3%'
     if 'disp_cbar'   not in p_dict.keys():  p_dict['disp_cbar']   = True
     if 'colormap'    not in p_dict.keys():  p_dict['colormap']    = 'RdBu'
+    if 'colormap2'   not in p_dict.keys():  p_dict['colormap2']   = 'RdYlBu'
     if 'vlim'        not in p_dict.keys():  p_dict['vlim']        = [0.2, 1.0]
+    if 'tbColor'     not in p_dict.keys():  p_dict['tbColor']     = False
+    if 'pbColor'     not in p_dict.keys():  p_dict['pbColor']     = False
+    if 'tbvlim'      not in p_dict.keys():  p_dict['tbvlim']      = [0.0, 365.25]
+    if 'pbvlim'      not in p_dict.keys():  p_dict['pbvlim']      = [0.0, 180.0]
     if 'disp_title'  not in p_dict.keys():  p_dict['disp_title']  = True
     if 'disp_drop'   not in p_dict.keys():  p_dict['disp_drop']   = True
     if 'disp_legend' not in p_dict.keys():  p_dict['disp_legend'] = True
@@ -587,8 +592,12 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
     # support input colormap: string for colormap name, or colormap object directly
     if isinstance(p_dict['colormap'], str):
         cmap = ColormapExt(p_dict['colormap']).colormap
+        if p_dict['tbColor'] or p_dict['pbColor']:
+            cmap = ColormapExt(p_dict['colormap2']).colormap
     elif isinstance(p_dict['colormap'], mpl.colors.LinearSegmentedColormap):
         cmap = p_dict['colormap']
+        if p_dict['tbColor'] or p_dict['pbColor']:
+            cmap = p_dict['colormap2']
     else:
         raise ValueError('unrecognized colormap input: {}'.format(p_dict['colormap']))
 
@@ -634,6 +643,12 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
         data_max = max(cohList)
         disp_min = p_dict['vlim'][0]
         disp_max = p_dict['vlim'][1]
+        if p_dict['tbColor']:
+            disp_min, disp_max = p_dict['tbvlim']
+            p_dict['cbar_label'] = 'Temporal baseline [day]'
+        elif p_dict['pbColor']:
+            disp_min, disp_max = p_dict['pbvlim']
+            p_dict['cbar_label'] = 'Spatial baseline [m]'
         if print_msg:
             print('showing coherence')
             print('data range: {}'.format([data_min, data_max]))
@@ -670,9 +685,15 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
             x = np.array([dates[idx1], dates[idx2]])
             y = np.array([pbaseList[idx1], pbaseList[idx2]])
             if cohList is not None:
-                coh = cohList[date12List.index(date12)]
-                coh_norm = (coh - disp_min) / (disp_max - disp_min)
-                ax.plot(x, y, '--', lw=p_dict['linewidth'], alpha=transparency, c=cmap(coh_norm))
+                val = cohList[date12List.index(date12)]
+                if p_dict['tbColor']:
+                    val = tbase12[date12List.index(date12)]
+                    disp_min, disp_max = p_dict['tbvlim']
+                elif p_dict['pbColor']:
+                    val = pbase12[date12List.index(date12)]
+                    disp_min, disp_max = p_dict['pbvlim']
+                val_norm = (val - disp_min) / (disp_max - disp_min)
+                ax.plot(x, y, '-', lw=p_dict['linewidth'], alpha=transparency, c=cmap(val_norm))
             else:
                 ax.plot(x, y, '--', lw=p_dict['linewidth'], alpha=transparency, c='k')
 
@@ -684,9 +705,15 @@ def plot_network(ax, date12List, dateList, pbaseList, p_dict={}, date12List_drop
         x = np.array([dates[idx1], dates[idx2]])
         y = np.array([pbaseList[idx1], pbaseList[idx2]])
         if cohList is not None:
-            coh = cohList[date12List.index(date12)]
-            coh_norm = (coh - disp_min) / (disp_max - disp_min)
-            ax.plot(x, y, '-', lw=p_dict['linewidth'], alpha=transparency, c=cmap(coh_norm))
+            val = cohList[date12List.index(date12)]
+            if p_dict['tbColor']:
+                val = tbase12[date12List.index(date12)]
+                disp_min, disp_max = p_dict['tbvlim']
+            elif p_dict['pbColor']:
+                val = pbase12[date12List.index(date12)]
+                disp_min, disp_max = p_dict['pbvlim']
+            val_norm = (val - disp_min) / (disp_max - disp_min)
+            ax.plot(x, y, '-', lw=p_dict['linewidth'], alpha=transparency, c=cmap(val_norm))
         else:
             ax.plot(x, y, '-', lw=p_dict['linewidth'], alpha=transparency, c='k')
 

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -86,7 +86,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
     fc = np.loadtxt(std_file, dtype=bytes).astype(str)
     std_list = fc[:, 1].astype(np.float32).tolist()
     date_list = list(fc[:, 0])
-    return std_list, date_list
+    return std_list, date_list, std_file
 
 
 def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_type='quadratic'):

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -53,6 +53,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                 ramp_type - string, ramp type, e.g. linear, quadratic, no for do not remove ramp
     Returns:    std_list  - list of float, standard deviation of deramped input timeseries file
                 date_list - list of string in YYYYMMDD format, corresponding dates
+                std_file  - string, text file with std and date info.
     Example:    import mintpy.utils.utils as ut
                 std_list, date_list = ut.get_residual_std('timeseries_ERA5_demErrInvResid.h5',
                                                           'maskTempCoh.h5')

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -56,7 +56,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                 std_file  - string, text file with std and date info.
     Example:    import mintpy.utils.utils as ut
                 std_list, date_list = ut.get_residual_std('timeseries_ERA5_demErrInvResid.h5',
-                                                          'maskTempCoh.h5')
+                                                          'maskTempCoh.h5')[:2]
     """
     # Intermediate files name
     if ramp_type == 'no':


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Here are two proposed changes:

1). The displacement map in `tsview.py` needs to be projected onto a specific Cartopy projection (e.g., ccrs.PlateCarree()) to properly overlay the coastline. This is added. But I am not sure whether there should be tunable projections. For small regions (for most of the cases), I think it is fine.

2). In 'plot_network.py', Other than coherence, I personally think it would be good to also allow the lines (connecting acquisitions) to be colored based on their temporal or spatial baselines. This is just for network design displaying purposes. You can reject that as well.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.