### PR TITLE
dask: support numWorker input in percentage with improved stability 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
           MINTPY_HOME: /root/tools/MintPy
         user: root
     working_directory: /root/tools/MintPy
+    resource_class: medium
     steps:
       - checkout
       - run:

--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -7,6 +7,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         auto_path
         template
     /objects
+        cluster
         colors
         giant
         ramp
@@ -23,7 +24,6 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         fractal
 ------------------ level 1 --------------------
     /objects
-        cluster       (utils/utils0)
         conncomp      (objects/ramp)
         stack         (utils/ptime)
     /utils

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -5,10 +5,11 @@ mintpy.compute.maxMemory = auto #[float > 0.0], auto for 4, max memory to alloca
 ## parallel processing with dask
 ## currently apply to steps: invert_network, correct_topography
 ## cluster   = none to turn off the parallel computing
-## numWorker = all  to use all locally available cores (for cluster = local only)
+## numWorker = all  to use all of locally available cores (for cluster = local only)
+## numWorker = 80%  to use 80% of locally available cores (for cluster = local only)
 ## config    = none to rollback to the default name (same as the cluster type; for cluster != local)
 mintpy.compute.cluster   = auto #[local / slurm / pbs / lsf / none], auto for none, cluster type
-mintpy.compute.numWorker = auto #[int > 1 / all], auto for 4 (local) or 40 (slurm / pbs / lsf), num of workers
+mintpy.compute.numWorker = auto #[int > 1 / all / num%], auto for 4 (local) or 40 (slurm / pbs / lsf), num of workers
 mintpy.compute.config    = auto #[none / slurm / pbs / lsf ], auto for none (same as cluster), config name
 
 

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -575,7 +575,7 @@ def split2boxes(ifgram_file, max_memory=4, print_msg=True):
     ds_size = (ifg_obj.numIfgram * 2 + ifg_obj.numDate + 5) * length * width * 4
 
     num_box = int(np.ceil(ds_size * 1.5 / (max_memory * 1024**3)))
-    y_step = int(np.rint((length / num_box) / 10) * 10)
+    y_step = int(np.ceil((length / num_box) / 10) * 10)
     num_box = int(np.ceil(length / y_step))
     if print_msg and num_box > 1:
         print('maximum memory size: %.1E GB' % max_memory)

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -12,9 +12,7 @@ import os
 import time
 import glob
 import shutil
-import subprocess
 import numpy as np
-from mintpy.utils import utils0 as ut0
 
 
 # supported / tested clusters
@@ -53,6 +51,8 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
     else:
         dim_size = width
     step = int(np.ceil(dim_size / num_split))
+    step = max(step, 10)                       # constain the min step size
+    num_split = int(np.ceil(dim_size / step))  # trim the final number of boxes
 
     # get list of boxes
     sub_boxes = []
@@ -174,7 +174,7 @@ class DaskCluster:
 
 
     def open(self):
-        """Initiate and scale the cluster"""
+        """Initiate the cluster"""
 
         # initiate the cluster object
         # Look at the ~/.config/dask/mintpy.yaml file for changing the Dask configuration defaults
@@ -213,12 +213,6 @@ class DaskCluster:
                 with open('dask_command_run_from_python.txt', 'w') as f:
                     f.write(self.cluster.job_script() + '\n')
 
-        # This line submits num_worker jobs to the cluster to start a bunch of workers
-        # In tests on Pegasus `general` queue in Jan 2019, no more than 40 workers could RUN
-        # at once (other user's jobs gained higher priority in the general at that point)
-        print('scale the cluster to {} workers'.format(self.num_worker))
-        self.cluster.scale(self.num_worker)
-
 
     def run(self, func, func_data, results):
         """Wrapper function encapsulating submit_workers and compile_workers.
@@ -235,21 +229,27 @@ class DaskCluster:
         """
         from dask.distributed import Client
 
-        # This line needs to be in a function or in a `if __name__ == "__main__":` block. If it is in no function
-        # or "main" block, each worker will try to create its own client (which is bad) when loading the module
+        # split the primary box into sub boxes for workers AND
+        # update the number of workers based on split result
+        box = func_data["box"]
+        sub_boxes = split_box2sub_boxes(box, num_split=self.num_worker, dimension='x', print_msg=False)
+        self.num_worker = len(sub_boxes)
+        print('split patch into {} sub boxes in x direction for workers to process'.format(self.num_worker))
+
+        # start a bunch of workers from the cluster
+        print('scale Dask cluster to {} workers'.format(self.num_worker))
+        self.cluster.scale(self.num_worker)
+
         print('initiate Dask client')
         self.client = Client(self.cluster)
-
-        # split the primary box into sub boxes for each worker
-        box = func_data["box"]
-        sub_boxes = split_box2sub_boxes(box, num_split=self.num_worker, dimension='x')
-        print('split patch into {} sub boxes in x direction for workers to process'.format(len(sub_boxes)))
 
         # submit job for each worker
         futures, submission_time = self.submit_job(func, func_data, sub_boxes)
 
         # assemble results from all workers
-        return self.collect_result(futures, results, box, submission_time)
+        results = self.collect_result(futures, results, box, submission_time)
+
+        return results
 
 
     def submit_job(self, func, func_data, sub_boxes):
@@ -358,21 +358,30 @@ class DaskCluster:
         if cluster_type == 'local':
             num_core = os.cpu_count()
 
-            # all --> num_core
+            # all / percentage --> num_core
+            msg = f'numWorker = {num_worker}'
             if num_worker == 'all':
-                # divide by the number of threads per core [for Linux only]
-                # as it works better on HPC, check https://github.com/insarlab/MintPy/issues/518
-                if ut0.which('lscpu') is not None:
-                    # get the number of threads per core
-                    # link: https://stackoverflow.com/questions/62652951
-                    ps = subprocess.run(['lscpu'], capture_output=True, text=True).stdout.split('\n')
-                    ns = [p.split(':')[1].strip() for p in ps if p.startswith('Thread(s) per core:')]
-                    if len(ns) > 0:
-                        num_thread = int(ns[0])
-                        num_core = int(num_core / num_thread)
+                ## divide by the number of threads per core [for Linux only]
+                #import subprocess
+                #from mintpy.utils import utils0 as ut0
+                #if ut0.which('lscpu') is not None:
+                #    # get the number of threads per core
+                #    # link: https://stackoverflow.com/questions/62652951
+                #    ps = subprocess.run(['lscpu'], capture_output=True, text=True).stdout.split('\n')
+                #    ns = [p.split(':')[1].strip() for p in ps if p.startswith('Thread(s) per core:')]
+                #    if len(ns) > 0:
+                #        num_thread = int(ns[0])
+                #        num_core = int(num_core / num_thread)
 
                 # set num_worker to the number of cores
                 num_worker = str(num_core)
+                print('translate {} to {}'.format(msg, num_worker))
+
+            elif num_worker.endswith('%'):
+                num_worker = int(num_core * float(num_worker[:-1]) / 100)
+                print('translate {} to {}'.format(msg, num_worker))
+                if num_worker < 1 or num_worker >= num_core:
+                    raise ValueError('Invalid numWorker percentage!')
 
             # str --> int
             num_worker = int(num_worker)

--- a/mintpy/objects/sensor.py
+++ b/mintpy/objects/sensor.py
@@ -240,16 +240,19 @@ KSAT5 = {
 
 # ERS-1/2
 # from Table 2 in Jung et al. (2014)
+# from Imaging Radar class by Howard Zebker, 2021.
 ERS = {
-    'carrier_frequency'          : 5.300e9,   # Hz
-    'altitude'                   : 783e3,     # m, mean value
-    'antenna_length'             : 10.0,      # m
-    'doppler_bandwidth'          : 1500,      # Hz
-    'pulse_repetition_frequency' : 1680,      # Hz
-    'chirp_bandwidth'            : 15.55e6,   # Hz
-    'sampling_frequency'         : 18.96e6,   # Hz
-    'azimuth_pixel_size'         : 4.2,       # m
-    'ground_range_pixel_size'    : 20.2,      # m
+    'carrier_frequency'          : 5.300e9,     # Hz
+    'altitude'                   : 783e3,       # m, mean value
+    'antenna_length'             : 10.0,        # m
+    'doppler_bandwidth'          : 1500,        # Hz
+    'pulse_repetition_frequency' : 1679.9,      # Hz
+    'pulse_length'               : 37.12e-6,    # s
+    'chirp_bandwidth'            : 15.55e6,     # Hz
+    'chirp_slope'                : 4.189166e11, # Hz
+    'sampling_frequency'         : 18.96e6,     # Hz
+    'azimuth_pixel_size'         : 4.2,         # m
+    'ground_range_pixel_size'    : 20.2,        # m
 }
 
 # Envisat

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -22,7 +22,7 @@ EXAMPLE = """example:
   prep_hyp3.py  interferograms/*/*unw_phase_clip.tif
   prep_hyp3.py  interferograms/*/*corr_clip.tif
   prep_hyp3.py  interferograms/*/*dem_clip.tif
-  prep_hyp3.py  interferograms/*/*inc_map_clip.tif
+  prep_hyp3.py  interferograms/*/*lv_theta_clip.tif
   prep_hyp3.py  interferograms/*/*clip.tif
 """
 
@@ -34,7 +34,7 @@ DESCRIPTION = """
 
   A DEM filename is needed and a incidence angle filename is recommended  e.g.:
   1) S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_dem.tif
-  2) S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_inc_map.tif
+  2) S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_lv_theta.tif
 
   This script will read these files, read the geospatial metadata from GDAL,
   find the corresponding HyP3 metadata file (for interferograms and coherence),
@@ -50,7 +50,7 @@ DESCRIPTION = """
           S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2.txt
       For the geometry file 2 file are recommended:
           S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_dem_clip.tif     (required)
-          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_inc_map_clip.tif (optional but recommended)
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_lv_theta_clip.tif (optional but recommended)
 
   After running prep_hyp3.py:
       For each interferogram:
@@ -62,8 +62,8 @@ DESCRIPTION = """
       For the input geometry files:
           S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_dem_clip.tif
           S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_dem_clip.tif.rsc
-          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_inc_map_clip.tif
-          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_inc_map_clip.tif.rsc
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_lv_theta_clip.tif
+          S1AA_20161223T070700_20170116T070658_VVP024_INT80_G_ueF_74C2_lv_theta_clip.tif.rsc
 
   Notes:
     HyP3 currently only supports generation of Sentinel-1 interferograms, so

--- a/mintpy/save_kmz.py
+++ b/mintpy/save_kmz.py
@@ -46,19 +46,21 @@ EXAMPLE = """example:
   save_kmz.py geo/geo_ifgramStack.h5 20101120_20110220
   save_kmz.py geo/geo_geometryRadar.h5 height --cbar-label Elevation
 
-  # save full resolution velocity in radar-coordinates
-  # for ISCE products (with lookup table in radar coordinates) ONLY
-  # use --sub-x/y to reduce file size for a smooth Google Earth experience
+  # to generate placemarks for the file in radar coordinates, the corresponding
+  # geometry file with latitude & longitude in radar coordinates are required,
+  # such as provided by ISCE + MintPy workflow
   save_kmz.py velocity.h5 --sub-x 300 800 --sub-y 1000 1500 --step 1
 """
 
 
 def create_parser():
-    parser = argparse.ArgumentParser(description='Generate Google Earth KMZ file with raster image.',
+    parser = argparse.ArgumentParser(description='Generate Google Earth KMZ file (overlay / placemarks for files in geo / radar coordinates).',
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=EXAMPLE)
 
-    parser.add_argument('file', help='file to be converted, in geo coordinate.')
+    parser.add_argument('file', help='file to be converted, in geo or radar coordinate.\n'
+                        'Note: for files in radar-coordinate, the corresponding lookup table\n'
+                        'in radar-coordinate (as provided by ISCE) is required.')
     parser.add_argument('dset', nargs='?', help='date of timeseries, or date12 of interferograms to be converted')
     parser.add_argument('-m','--mask', dest='mask_file', metavar='FILE', help='mask file for display')
     parser.add_argument('--zero-mask', dest='zero_mask', action='store_true', help='Mask pixels with zero value.')
@@ -70,7 +72,8 @@ def create_parser():
     parser.add_argument('-g','--geom', dest='geom_file', metavar='FILE',
                         help='geometry file with lat/lon. [required for file in radar coordinates]')
     parser.add_argument('--step', dest='step', type=int, default=5,
-                        help='output one point per {step} pixels, to reduce file size (default: %(default)s).')
+                        help='output one point per {step} pixels, to reduce file size (default: %(default)s).\n'
+                             'For file in radar-coordinate ONLY.')
 
     # Data
     parser.add_argument('-v','--vlim', dest='vlim', nargs=2, metavar=('MIN', 'MAX'), type=float, help='Y/value limits for plotting.')


### PR DESCRIPTION
**Description of proposed changes**

This PR supports `mintpy.compute.numWorker = 80%` as input to use 80% of all available cores for dask, to be more flexible, together with some minor tuning for improved stability and revert the previous change of translation for all in #691.

+ cluster.DaskCluster:
   - run(): set the num of scaled workers to the num of boxes, to avoid unnecessary resource initiation
   - format_num_worker(): revert "divide num core by num of threads per core" as it's not right #518.
   - format_num_worker(): support num of workers in percentage, e.g. 80% to use 80% of all cores

+ ifgram_inversion: use ceil instead of rint to prevent the occurrence of extra small patches.

+ cluster.split_box2sub_boxes:
   - add a min step size constrain
   - trim the final number of boxes, to avoid negative dimension
 
**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.