### PR TITLE
coord.lalo2yx(): replace np.float128 with np.longdouble for Windows

### DIFF
--- a/mintpy/objects/coord.py
+++ b/mintpy/objects/coord.py
@@ -86,6 +86,7 @@ class coordinate:
         # input format
         if isinstance(coord_in, np.ndarray):
             coord_in = coord_in.tolist()
+        # note: np.float128 is not supported on Windows OS, use np.longdouble as a platform neutral syntax
         if isinstance(coord_in, (float, np.float16, np.float32, np.float64, np.longdouble)):
             coord_in = [coord_in]
         coord_in = list(coord_in)

--- a/mintpy/objects/coord.py
+++ b/mintpy/objects/coord.py
@@ -86,7 +86,7 @@ class coordinate:
         # input format
         if isinstance(coord_in, np.ndarray):
             coord_in = coord_in.tolist()
-        if isinstance(coord_in, (float, np.float16, np.float32, np.float64, np.float128)):
+        if isinstance(coord_in, (float, np.float16, np.float32, np.float64, np.longdouble)):
             coord_in = [coord_in]
         coord_in = list(coord_in)
 


### PR DESCRIPTION
**Description of proposed changes**

Simple change that modifies `np.float128` object to `np.longdouble`. This is because float128 is not supported on Windows OS and will raise errors for Windows users.

**Reminders**

- [ ] Fix #698
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
