### PR TITLE
update installation note, env setup and circle-ci testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,17 +32,12 @@ jobs:
           command: |
             export PYTHONUNBUFFERED=1
             # setup environment variable
-            export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${HOME}/tools/PyAPS:${HOME}/tools/PySolid
-            export PATH=${MINTPY_HOME}/mintpy:${CONDA_PREFIX}/bin:${PATH}
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
             # download source code
-            git clone https://github.com/yunjunz/PyAPS.git ${HOME}/tools/PyAPS
-            git clone https://github.com/insarlab/PySolid.git ${HOME}/tools/PySolid
             # install dependencies
             source activate root
-            mamba install --verbose --yes --file ${MINTPY_HOME}/docs/requirements.txt gdal">=3" fortran-compiler
-            # compile pysolid Fortran code
-            cd ${HOME}/tools/PySolid/pysolid
-            f2py -c -m solid solid.for
+            mamba install --verbose --yes --file ${MINTPY_HOME}/docs/requirements.txt
+            python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -v
             tropo_pyaps3.py -h
@@ -51,8 +46,7 @@ jobs:
       - run:
           name: Testing MintPy on Example Dataset 1/4 - FernandinaSenDT128 (ISCE/topsStack)
           command: |
-            export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${HOME}/tools/PyAPS:${HOME}/tools/PySolid
-            export PATH=${MINTPY_HOME}/mintpy:${CONDA_PREFIX}/bin:${PATH}
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             cd ${HOME}/data
             ${MINTPY_HOME}/tests/test_smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
@@ -60,8 +54,7 @@ jobs:
       - run:
           name: Testing MintPy on Example Dataset 2/4 - SanFranSenDT42 (ARIA)
           command: |
-            export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${HOME}/tools/PyAPS:${HOME}/tools/PySolid
-            export PATH=${MINTPY_HOME}/mintpy:${CONDA_PREFIX}/bin:${PATH}
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             cd ${HOME}/data
             ${MINTPY_HOME}/tests/test_smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
@@ -69,8 +62,7 @@ jobs:
       - run:
           name: Testing MintPy on Example Dataset 3/4 - WellsEnvD2T399 (Gamma)
           command: |
-            export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${HOME}/tools/PyAPS:${HOME}/tools/PySolid
-            export PATH=${MINTPY_HOME}/mintpy:${CONDA_PREFIX}/bin:${PATH}
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             cd ${HOME}/data
             ${MINTPY_HOME}/tests/test_smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
@@ -78,8 +70,7 @@ jobs:
       - run:
           name: Testing MintPy on Example Dataset 4/4 - WCapeSenAT29 (SNAP)
           command: |
-            export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${HOME}/tools/PyAPS:${HOME}/tools/PySolid
-            export PATH=${MINTPY_HOME}/mintpy:${CONDA_PREFIX}/bin:${PATH}
+            export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             cd ${HOME}/data
             ${MINTPY_HOME}/tests/test_smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29
@@ -89,4 +80,3 @@ workflows:
   test:
     jobs:
       - test
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,9 @@ jobs:
             export PYTHONUNBUFFERED=1
             # setup environment variable
             export PATH=${CONDA_PREFIX}/bin:${PATH}
-            # download source code
-            # install dependencies
+            # install dependencies and source code
             source activate root
-            mamba install --verbose --yes 'gdal>=3' --file ${MINTPY_HOME}/docs/requirements.txt
+            mamba install --verbose --yes gdal">=3" --file ${MINTPY_HOME}/docs/requirements.txt
             python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             # download source code
             # install dependencies
             source activate root
-            mamba install --verbose --yes --file gdal>=3 ${MINTPY_HOME}/docs/requirements.txt
+            mamba install --verbose --yes 'gdal>=3' --file ${MINTPY_HOME}/docs/requirements.txt
             python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Setting Environment with Miniconda
+          name: Setting Up Environment with Miniconda
           command: |
             apt update
             apt-get update --yes && apt-get upgrade --yes
@@ -27,7 +27,7 @@ jobs:
             ${HOME}/tools/miniconda3/bin/conda install -c conda-forge --yes mamba
 
       - run:
-          name: Installing MintPy, PyAPS and PySolid
+          name: Installing MintPy
           no_output_timeout: 30m
           command: |
             export PYTHONUNBUFFERED=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             # download source code
             # install dependencies
             source activate root
-            mamba install --verbose --yes --file ${MINTPY_HOME}/docs/requirements.txt
+            mamba install --verbose --yes --file gdal>=3 ${MINTPY_HOME}/docs/requirements.txt
             python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -v

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,7 +28,6 @@ dependencies:
   - pyaps3
   # for ARIA, FRInGE, HyP3, GMTSAR
   - gdal>=3
-  # - pyhdf   # required by MERRA, which is currently not supported in pyaps3
   # for pyresample
   - pyresample
   - openmp

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,12 +20,12 @@ dependencies:
   - lxml
   - matplotlib
   - numpy
+  - pyaps3
   - pykml>=0.2
   - pyproj
+  - pysolid
   - scikit-image
   - scipy
-  - pysolid
-  - pyaps3
   # for ARIA, FRInGE, HyP3, GMTSAR
   - gdal>=3
   # for pyresample

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.6,<3.9
+  - pip
   - cartopy
   - cvxopt
   - dask>=1.0
@@ -19,20 +20,14 @@ dependencies:
   - lxml
   - matplotlib
   - numpy
-  - pip
   - pykml>=0.2
   - pyproj
   - scikit-image
   - scipy
-  - pip:
-    - git+https://github.com/insarlab/PySolid.git
+  - pysolid
+  - pyaps3
   # for ARIA, FRInGE, HyP3, GMTSAR
   - gdal>=3
-  # for PyAPS
-  - cdsapi
-  - ecCodes
-  - netcdf4
-  - pygrib
   # - pyhdf   # required by MERRA, which is currently not supported in pyaps3
   # for pyresample
   - pyresample

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,14 +1,14 @@
-## Install MintPy
+## 1. Install the released version ##
 
-### Install the released version via conda
+#### a. via conda ####
 
-Mintpy is available on the [conda-forge](https://anaconda.org/conda-forge/mintpy) channel. The latest released version can be installed via `conda` as:
+MintPy is available on the [conda-forge](https://anaconda.org/conda-forge/mintpy) channel. The latest released version can be installed via `conda` as:
 
 ```bash
 conda install -c conda-forge mintpy
 ```
 
-### Install the released version via docker
+#### b. via docker ####
 
 Docker allows one to run MintPy in a dedicated container (essentially an efficient virtual machine) and to be independent of platform OS. After installing [docker](https://docs.docker.com/install/), run the following to pull the [MintPy container from DockerHub](https://hub.docker.com/r/forrestwilliams/mintpy) to your local machine, check more details at [here](docker.md).
 
@@ -16,15 +16,92 @@ Docker allows one to run MintPy in a dedicated container (essentially an efficie
 docker pull forrestwilliams/mintpy:1.3.1
 ```
 
-### Install the development version
+Then setup the account for ERA5 for tropospheric delay correction as described in [insarlab/PyAPS](https://github.com/insarlab/pyaps#2-account-setup-for-era5).
 
-The installation note below is tested on Linux and macOS, and is still experimental on Windows (may has bugs).
+## 2. Install the development version ##
 
-MintPy is written in Python 3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/docs/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree). You can control the number of threads used by setting the _environment variables_, e.g. `OMP_NUM_THREADS`.
+Note: The installation note below is tested on Linux and macOS, and is still experimental on Windows (may has bugs).
 
+MintPy is written in Python 3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/docs/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree).
 
+Quick links:
 
-### Notes for Mac users ###
++ [Install on Linux](#21-install-on-linux)
++ [Install on macOS](#22-install-on-macos)
++ [Install on Windows](#23-install-on-windows)
+
+### 2.1 Install on Linux ###
+
+#### a. Download source code ####
+
+Run the following in your terminal to download the development version of MintPy:
+
+```bash
+cd ~/tools
+git clone https://github.com/insarlab/MintPy.git
+```
+
+#### b. Install dependencies via conda ####
+
+Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) if you have not already done so. You may need to close and restart the shell for changes to take effect. 
+
+```bash
+# download and install miniconda
+# use wget or curl to download in command line or click from the web browser
+# for macOS, use Miniconda3-latest-MacOSX-x86_64.sh instead.
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/tools/miniconda3
+~/tools/miniconda3/bin/conda init bash
+```
+
+Install the dependencies into an custom existing environment [recommended] by running:
+
+```bash
+# To create a new custom environment, e.g. named "insar", run "conda create --name insar; conda activate insar"
+# To speedup conda install, try "conda install mamba", then use "mamba install" to replace "conda install"
+
+# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
+# Add "isce2"     below to install extra dependencies if you use ISCE-2
+conda install -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
+```
+
+Or install the dependencies to a new environment named "mintpy" by running:
+
+```bash
+conda env create -f MintPy/docs/environment.yml
+conda activate mintpy
+```
+
+#### c. Install MintPy ####
+
+Install MintPy into the current environment with pip by running:
+
+```bash
+python -m pip install MintPy
+```
+
+Or install MintPy with pip in development mode as below. The development mode allows one to install the package without copying files to your interpreter directory (e.g. the `site-packages` directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
+
+```bash
+python -m pip install -e MintPy
+```
+
+Or simply setup the environment variables as below in your source file (e.g. `~/.bash_profile` for _bash_ users or `~/.cshrc` for _csh/tcsh_ users), because MintPy is written in pure Python:
+
+```bash
+if [ -z ${PYTHONPATH+x} ]; then export PYTHONPATH=""; fi
+export MINTPY_HOME=~/tools/MintPy
+export PATH=${PATH}:${MINTPY_HOME}/mintpy
+export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}
+```
+
+#### d. Setup account for global atmospheric model ####
+
+Setup the account for ERA5 for tropospheric delay correction as described in [insarlab/PyAPS](https://github.com/insarlab/pyaps#2-account-setup-for-era5).
+
+### 2.2 Install on macOS ###
+
+#### a. Install Xcode and command line tools ####
 
 Install Xcode with command line tools, if you have not already done so.
 
@@ -39,56 +116,13 @@ Install Xcode with command line tools, if you have not already done so.
 
 + Install [XQuartz](https://www.xquartz.org), then restart the terminal.
 
+#### b. Install MintPy via conda ####
 
-### 1. Download MintPy ###
+Same as the [instruction for Linux](#21-install-on-linux).
 
-Run the following in your terminal to download the development version of MintPy:
+#### c. Install MintPy via MacPorts ####
 
-```bash
-git clone https://github.com/insarlab/MintPy.git
-```
-
-### 2. Install dependencies and MintPy ###
-
-
-#### a. via conda ####
-
-Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) if you have not already done so. You may need to close and restart the shell for changes to take effect.
-
-```bash
-# download and install miniconda
-# use wget or curl to download in command line or click from the web browser
-# curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o Miniconda3-latest-MacOSX-x86_64.sh
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-bash Miniconda3-latest-MacOSX-x86_64.sh
-```
-
-You may set up a new conda environment (recommended) for MintPy by running:
-
-```bash
-conda env create -f MintPy/docs/environment.yml
-conda activate mintpy
-```
-
-Or you can install the dependencies into an existing environment by running:
-
-```bash
-# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
-# Add "isce2"     below to install extra dependencies if you use ISCE-2
-conda install -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
-```
-
-Then install MintPy into the environment by running:
-```bash
-python -m pip install MintPy
-```
-
-For development of MintPy, you may want to use an "editable" install so changes MintPy will be immediately reflected in the environment by running:
-```bash
-python -m pip install -e MintPy
-```
-
-#### b. via MacPorts ####
+Same as the [instruction for Linux](#21-install-on-linux), except for the dependencies installation, which is as below.
 
 Install [macports](https://www.macports.org/install.php) if you have not done so. Add the following at the bottom of your `~/.bash_profile` file:
 
@@ -97,10 +131,6 @@ Install [macports](https://www.macports.org/install.php) if you have not done so
 export PATH=/opt/local/bin:/opt/local/sbin:${PATH}
 export MANPATH=/opt/local/share/man:${MANPATH}
 # Finished adapting your PATH environment variable for use with MacPorts.
-
-#For py36-pyhdf in macports
-export INCLUDE_DIRS=/opt/local/include
-export LIBRARY_DIRS=/opt/local/lib
 ```
 
 Update the port tree with the following command. If your network prevent the use of rsync or svn via http of port tree, try [Portfile Sync via a Snapshot Tarball](https://trac.macports.org/wiki/howto/PortTreeTarball).
@@ -109,51 +139,26 @@ Update the port tree with the following command. If your network prevent the use
 sudo port selfupdate
 ```
 
-Run the following in your terminal in `bash` to install the dependencies:
+Install the dependencies by running:
 
 ```bash
 # install dependencies with macports
 # use "port -N install" to use the safe default for prompt questions
 sudo port install $(cat MintPy/docs/ports.txt)
 
-# install dependencies not available on macports: pysolid, pykml, pykdtree, pyresample, cdsapi, pyhdf
+# install dependencies not available on macports: pysolid, pykml, pykdtree, pyresample, cdsapi
 sudo -H /opt/local/bin/pip install git+https://github.com/insarlab/PySolid.git
+sudo -H /opt/local/bin/pip install git+https://github.com/insarlab/PyAPS.git
 sudo -H /opt/local/bin/pip install git+https://github.com/tylere/pykml.git
 sudo -H /opt/local/bin/pip install git+https://github.com/storpipfugl/pykdtree.git
 sudo -H /opt/local/bin/pip install git+https://github.com/pytroll/pyresample.git
 sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
-sudo -H /opt/local/bin/pip install git+https://github.com/fhs/pyhdf.git
 ```
 
-Then install MintPy into the environment by running:
-```bash
-sudo -H /opt/local/bin/pip install MintPy
-```
+### 2.3 Install on Windows ###
 
-For development of MintPy, you may want to use an "editable" install so changes MintPy will be immediately reflected in the environment by running:
-```bash
-sudo -H /opt/local/bin/pip install -e MintPy
-```
+Same as the [instruction for Linux](#21-install-on-linux), except for the "c. Install MintPy" section, only the `pip install` approaches are recommended, as the "setup environment variable" approach is not tested.
 
-### Notes on [PySolid](https://github.com/insarlab/PySolid) ###
+## 3. Optional setup
 
-We use PySolid for solid Earth tides correction, which is available on conda-forge for Linux, macOS, and Windows. If the conda-forge version install from above does not work, run the following to compile from source:
-
-```bash
-# install Fortran compiler via conda
-conda install -c conda-forge fortran-compiler
-python -m pip install git+https://github.com/insarlab/PySolid
-```
-
-### Notes on [PyAPS](https://github.com/insarlab/PyAPS) ###
-
-+ We use PyAPS (Jolivet et al., 2011; 2014) for tropospheric delay correction calculated from Global Atmospheric Models (GAMs) such as ERA-5, ERA-Interim, HRES-ECMWF, MERRA and NARR.
-
-+ Check [Earthdef/PyAPS](http://earthdef.caltech.edu/projects/pyaps/wiki/Main#) for accounts setup information for ERA-Interim and MERRA.
-
-+ Check [GitHub/PyAPS](https://github.com/insarlab/PyAPS) for account setup for ERA-5. **Make sure that you:**
-
-  -   accept the data license in the Terms of use on ECMWF website and 
-  -   run `examples/TestECMWF.ipynb` to test the data downloading and running.
-
-+ If you defined an environment variable named `WEATHER_DIR` to contain the path to a directory, MintPy applications will download the GAM files into the indicated directory. Also, MintPy application will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
++ `WEATHER_DIR`: If you defined an environment variable named `WEATHER_DIR` to contain the path to a directory, MintPy applications will download the GAM files into the indicated directory. Also, MintPy application will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,54 +1,57 @@
 ## Install MintPy
 
-The installation note below is tested on Linxu and macOS. It is still experimental on Windows, so it may have bugs.
+Mintpy is available on [conda-forge](https://anaconda.org/conda-forge/mintpy) and [PyPI](https://pypi.org/project/mintpy/). The latest release can be installed via conda as:
 
-### Notes for Mac users ###
-
-Install Xcode with command line tools, if you have not already done so.
-
-+   Install `Xcode` from App store
-
-+   Install `command line tools` within XCode and agree to the terms of license.
-
-```
-xcode-select --install -s /Applications/Xcode.app/Contents/Developer/
-sudo xcodebuild -license
+```bash
+conda install -c conda-forge mintpy
 ```
 
-+   Install [XQuartz](https://www.xquartz.org), then restart the terminal.
+or via `pip` as:
+
+```bash
+python -m pip install mintpy
+```
+
+MinPy is tested on Linux and macOS. Installation is still experimental on Windows, so it may have bugs.
 
 ### Notes for Docker users ###
 
 Docker allows one to run MintPy in a dedicated container (essentially an efficient virtual machine) and to be independent of platform OS. After installing [docker](https://docs.docker.com/install/), run the following to pull the [MintPy container from DockerHub](https://hub.docker.com/r/forrestwilliams/mintpy) to your local machine, check more details at [here](docker.md).
 
-```
+```bash
 docker pull forrestwilliams/mintpy:1.3.1
 ```
 
-### 1. Download and Setup ###
 
-Run the following in your terminal to download the development version of MintPy and PyAPS:
+## Install the Development Version of MintPy
+
+### Notes for Mac users ###
+
+Install Xcode with command line tools, if you have not already done so.
+
++ Install `Xcode` from App store
+
++ Install `command line tools` within XCode and agree to the terms of license.
+
+  ```bash
+  xcode-select --install -s /Applications/Xcode.app/Contents/Developer/
+  sudo xcodebuild -license
+  ```
+
++ Install [XQuartz](https://www.xquartz.org), then restart the terminal.
+
+
+### 1. Download MintPy ###
+
+Run the following in your terminal to download the development version of MintPy:
 
 ```bash
-cd ~/tools
 git clone https://github.com/insarlab/MintPy.git
-git clone https://github.com/yunjunz/PyAPS.git
 ```
 
-Set the following environment variables in your source file (e.g. **_~/.bash_profile_** for _bash_ users or **_~/.cshrc_** for _csh/tcsh_ users).
+### 2. Install dependencies and MintPy ###
 
-```bash
-if [ -z ${PYTHONPATH+x} ]; then export PYTHONPATH=""; fi
-
-##--------- MintPy ------------------##
-export MINTPY_HOME=~/tools/MintPy
-export PATH=${PATH}:${MINTPY_HOME}/mintpy
-export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:~/tools/PyAPS
-```
-
-### 2. Install dependencies ###
-
-MintPy is written in Python3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/docs/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree). You can control the number of threads used by setting the _environment variables_, e.g. `OMP_NUM_THREADS`.
+MintPy is written in Python 3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/docs/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree). You can control the number of threads used by setting the _environment variables_, e.g. `OMP_NUM_THREADS`.
 
 #### a. via conda ####
 
@@ -56,35 +59,40 @@ Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) if you have 
 
 ```bash
 # download and install miniconda
-# use wget or curl to download in command line or click from the web brower
+# use wget or curl to download in command line or click from the web browser
 # curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o Miniconda3-latest-MacOSX-x86_64.sh
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-bash Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/tools/miniconda3
-~/tools/miniconda3/bin/conda init bash
+bash Miniconda3-latest-MacOSX-x86_64.sh
 ```
 
-Run the following in your terminal to install the dependencies to your conda environment (recommended). The default is _**base**_; a new custom environment is recommended.
+You may set up a new conda environment (recommended) for MintPy by running:
 
 ```bash
-# To create a new conda environment, e.g. named "insar", run "conda create --name insar; conda activate insar"
+conda env create -f MintPy/docs/environment.yml
+conda activate mintpy
+```
 
+Or you can install the dependencies into an existing environment by running:
+
+```bash
 # Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
 # Add "isce2"     below to install extra dependencies if you use ISCE-2
-conda install --yes -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
-
-$CONDA_PREFIX/bin/pip install git+https://github.com/insarlab/PySolid.git
+conda install -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
 ```
 
-Or run the following in your terminal to install the dependencies to a new environment _**mintpy**_:
-
+Then install MintPy into the environment by running:
+```bash
+python -m pip install MintPy
 ```
-conda env create -f $MINTPY_HOME/docs/environment.yml
-conda activate mintpy
+
+For development of MintPy, you may want to use an "editable" install so changes MintPy will be immediately reflected in the environment by running:
+```bash
+python -m pip install -e MintPy
 ```
 
 #### b. via MacPorts ####
 
-Install [macports](https://www.macports.org/install.php) if you have not done so. Add the following at the bottom of your **_~/.bash_profile_** file:
+Install [macports](https://www.macports.org/install.php) if you have not done so. Add the following at the bottom of your `~/.bash_profile` file:
 
 ```bash
 # MacPorts Installer addition on 2017-09-02_at_01:27:12: adding an appropriate PATH variable for use with MacPorts.
@@ -103,12 +111,12 @@ Update the port tree with the following command. If your network prevent the use
 sudo port selfupdate
 ```
 
-Run the following in your terminal in _bash_ to install the dependencies:
+Run the following in your terminal in `bash` to install the dependencies:
 
 ```bash
 # install dependencies with macports
 # use "port -N install" to use the safe default for prompt questions
-sudo port install $(cat $MINTPY_HOME/docs/ports.txt)
+sudo port install $(cat MintPy/docs/ports.txt)
 
 # install dependencies not available on macports: pysolid, pykml, pykdtree, pyresample, cdsapi, pyhdf
 sudo -H /opt/local/bin/pip install git+https://github.com/insarlab/PySolid.git
@@ -119,57 +127,35 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 sudo -H /opt/local/bin/pip install git+https://github.com/fhs/pyhdf.git
 ```
 
+Then install MintPy into the environment by running:
+```bash
+sudo -H /opt/local/bin/pip install MintPy
+```
+
+For development of MintPy, you may want to use an "editable" install so changes MintPy will be immediately reflected in the environment by running:
+```bash
+sudo -H /opt/local/bin/pip install -e MintPy
+```
+
 ### Notes on [PySolid](https://github.com/insarlab/PySolid) ###
 
-We use PySolid for solid Earth tides correction. If the pre-compiled version install from above does not work, run the following to compile from source:
+We use PySolid for solid Earth tides correction, which is available on conda-forge for Linux, macOS, and Windows. If the conda-forge version install from above does not work, run the following to compile from source:
 
 ```bash
 # install Fortran compiler via conda
 conda install -c conda-forge fortran-compiler
-
-# compile Fortran code into a Python interface using f2py
-cd ~/tools/PySolid/pysolid
-f2py -c -m solid solid.for
+python -m pip install git+https://github.com/insarlab/PySolid
 ```
 
-### Notes on [PyAPS](https://github.com/yunjunz/PyAPS) ###
+### Notes on [PyAPS](https://github.com/insarlab/PyAPS) ###
 
-+   We use PyAPS (Jolivet et al., 2011; 2014) for tropospheric delay correction calculated from Global Atmospheric Models (GAMs) such as ERA-5, ERA-Interim, HRES-ECMWF, MERRA and NARR.
++ We use PyAPS (Jolivet et al., 2011; 2014) for tropospheric delay correction calculated from Global Atmospheric Models (GAMs) such as ERA-5, ERA-Interim, HRES-ECMWF, MERRA and NARR.
 
-+   Check [Earthdef/PyAPS](http://earthdef.caltech.edu/projects/pyaps/wiki/Main#) for accounts setup information for ERA-Interim and MERRA.
++ Check [Earthdef/PyAPS](http://earthdef.caltech.edu/projects/pyaps/wiki/Main#) for accounts setup information for ERA-Interim and MERRA.
 
-+   Check [GitHub/PyAPS](https://github.com/yunjunz/PyAPS) for account setup for ERA-5. **Make sure that you:**
++ Check [GitHub/PyAPS](https://github.com/insarlab/PyAPS) for account setup for ERA-5. **Make sure that you:**
 
-    -   accept the data license in the Terms of use on ECMWF website and 
-    -   run `examples/TestECMWF.ipynb` to test the data downloading and running.
+  -   accept the data license in the Terms of use on ECMWF website and 
+  -   run `examples/TestECMWF.ipynb` to test the data downloading and running.
 
-+   If you defined an environment variable named `WEATHER_DIR` to contain the path to a
-directory, MintPy applications will download the GAM files into the indicated directory. Also MintPy
-application will look for the GAM files in the directory before downloading a new one to prevent downloading
-multiple copies if you work with different dataset that cover the same date/time.
-
-
-### For Windows via Conda ###
-
-```bash
-# 1. download source code
-cd ~/tools
-git clone https://github.com/insarlab/MintPy.git
-git clone https://github.com/yunjunz/PyAPS.git
-
-# 2. install dependencies
-# option 1 - install dependencies to an existing conda environment
-# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
-# Add "isce2"     below to install extra dependencies if you use ISCE-2
-conda install --yes -c conda-forge --file ~/tools/MintPy/docs/requirements.txt
-$CONDA_PREFIX/bin/pip install git+https://github.com/insarlab/PySolid.git
-
-# option 2 - install dependencies to a new environment named `mintpy`
-conda env create -f MintPy/docs/environment.yml
-conda activate mintpy
-
-# 3. install source code and setup path
-pip install -e ./MintPy
-pip install -e ./PyAPS
-conda env config vars set PATH=%PATH%;%cd%/MintPy/
-```
++ If you defined an environment variable named `WEATHER_DIR` to contain the path to a directory, MintPy applications will download the GAM files into the indicated directory. Also, MintPy application will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,20 +1,14 @@
 ## Install MintPy
 
-Mintpy is available on [conda-forge](https://anaconda.org/conda-forge/mintpy) and [PyPI](https://pypi.org/project/mintpy/). The latest release can be installed via conda as:
+### Install the released version via conda
+
+Mintpy is available on the [conda-forge](https://anaconda.org/conda-forge/mintpy) channel. The latest released version can be installed via `conda` as:
 
 ```bash
 conda install -c conda-forge mintpy
 ```
 
-or via `pip` as:
-
-```bash
-python -m pip install mintpy
-```
-
-MinPy is tested on Linux and macOS. Installation is still experimental on Windows, so it may have bugs.
-
-### Notes for Docker users ###
+### Install the released version via docker
 
 Docker allows one to run MintPy in a dedicated container (essentially an efficient virtual machine) and to be independent of platform OS. After installing [docker](https://docs.docker.com/install/), run the following to pull the [MintPy container from DockerHub](https://hub.docker.com/r/forrestwilliams/mintpy) to your local machine, check more details at [here](docker.md).
 
@@ -22,8 +16,13 @@ Docker allows one to run MintPy in a dedicated container (essentially an efficie
 docker pull forrestwilliams/mintpy:1.3.1
 ```
 
+### Install the development version
 
-## Install the Development Version of MintPy
+The installation note below is tested on Linux and macOS, and is still experimental on Windows (may has bugs).
+
+MintPy is written in Python 3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/docs/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree). You can control the number of threads used by setting the _environment variables_, e.g. `OMP_NUM_THREADS`.
+
+
 
 ### Notes for Mac users ###
 
@@ -51,7 +50,6 @@ git clone https://github.com/insarlab/MintPy.git
 
 ### 2. Install dependencies and MintPy ###
 
-MintPy is written in Python 3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/docs/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree). You can control the number of threads used by setting the _environment variables_, e.g. `OMP_NUM_THREADS`.
 
 #### a. via conda ####
 

--- a/docs/ports.txt
+++ b/docs/ports.txt
@@ -26,8 +26,6 @@ wget +ssl
 freetype
 tiff
 openmotif
-subversion
-python27
 python37
 fftw +gcc7
 fftw-single +gcc7
@@ -55,7 +53,6 @@ h5utils
 netcdf +gcc7
 netcdf-cxx
 netcdf-fortran
-ecCodes +gcc7
 postgresql95
 postgresql95-server
 proj
@@ -92,7 +89,6 @@ py37-sphinx
 py37-pip
 py37-cvxopt +accelerate +dsdp +fftw +glpk +gsl
 py37-joblib
-gmt5
 kealib
 pandoc
 zmq

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,12 +15,12 @@ joblib
 lxml
 matplotlib
 numpy
+pyaps3
 pykml>=0.2
 pyproj
+pysolid
 scikit-image
 scipy
-pysolid
-pyaps3
 # for ARIA, FRInGE, HyP3, GMTSAR
 # gdal>=3
 # for pyresample

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@
 # ports.txt            for actual installation via mac-ports
 # setup.py             for actual installation via pip [not finished yet]
 python>=3.6,<3.9
+pip
 cartopy
 cvxopt
 dask>=1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,7 +23,6 @@ pysolid
 pyaps3
 # for ARIA, FRInGE, HyP3, GMTSAR
 gdal>=3
-# - pyhdf   # required by MERRA, which is currently not supported in pyaps3
 # for pyresample
 pyresample
 openmp

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,21 +14,18 @@ joblib
 lxml
 matplotlib
 numpy
-pip
 pykml>=0.2
 pyproj
 scikit-image
 scipy
-# pyaps dependencies
-cdsapi
-ecCodes
-netcdf4
-pygrib
-# pyhdf  # required by MERRA, which is currently not supported in pyaps3
-# pyresample dependencies
+pysolid
+pyaps3
+# for ARIA, FRInGE, HyP3, GMTSAR
+gdal>=3
+# - pyhdf   # required by MERRA, which is currently not supported in pyaps3
+# for pyresample
 pyresample
 openmp
 pykdtree
 xarray
 zarr
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -22,7 +22,7 @@ scipy
 pysolid
 pyaps3
 # for ARIA, FRInGE, HyP3, GMTSAR
-gdal>=3
+# gdal>=3
 # for pyresample
 pyresample
 openmp

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 # requirements4rtd.txt for readthedocs, which uses pip with limited memory usage
-# requirements.txt     for actual installation via conda
-# environment.yml      for actual installation via conda create environment
-# ports.txt            for actual installation via mac-ports
-# setup.py             for actual installation via pip [not finished yet]
+# requirements.txt     for dependency installation via conda
+# environment.yml      for dependency installation via conda and create a new environment
+# ports.txt            for dependency installation via mac-ports
+# setup.py             for mintpy     installation via pip after the dependency installation above
 python>=3.6,<3.9
 pip
 cartopy

--- a/setup.py
+++ b/setup.py
@@ -74,17 +74,12 @@ def do_setup():
             "lxml",
             "matplotlib",
             "numpy",
+            "pyaps3",
             "pykml>=0.2",
             "pyproj",
             "setuptools",
             "scikit-image",
             "scipy",
-            # pyaps dependencies
-            "cdsapi",
-            "ecCodes",
-            "netcdf4",
-            "pygrib",
-            # "pyhdf", # required by MERRA, which is currently not supported in pyaps3
             # pyresample dependencies
             "pyresample",
             # "openmp",


### PR DESCRIPTION
Since #659 , there's no longer a need to manipulate `PATH` or `PYTHONPATH` as a `pip` install will correctly place the `mintpy` package and all executable scripts to be available in the environment. 

Additionally, PyPAS and PySolid are available via conda-forge and no longer need to be cloned and manually built/installed. 

*Draft because I need to do docs yet*

**Reminders**

- [x] Fix #xxxx
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
