### PR TITLE
wrap up version 1.3.2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 [![Language](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/)
 [![CircleCI](https://img.shields.io/circleci/build/github/insarlab/MintPy.svg?logo=circleci&label=test)](https://circleci.com/gh/insarlab/MintPy)
 [![Docs Status](https://readthedocs.org/projects/mintpy/badge/?color=green&version=latest)](https://mintpy.readthedocs.io/?badge=latest)
-[![Version](https://img.shields.io/badge/version-v1.3.1-green.svg)](https://github.com/insarlab/MintPy/releases)
+[![Version](https://img.shields.io/badge/version-v1.3.2-green.svg)](https://github.com/insarlab/MintPy/releases)
 [![License](https://img.shields.io/badge/license-GPLv3-yellow.svg)](https://github.com/insarlab/MintPy/blob/main/LICENSE)
 [![Forum](https://img.shields.io/badge/forum-Google%20Groups-orange.svg)](https://groups.google.com/g/mintpy)
 [![Citation](https://img.shields.io/badge/doi-10.1016%2Fj.cageo.2019.104331-blue)](https://doi.org/10.1016/j.cageo.2019.104331)

--- a/mintpy/__init__.py
+++ b/mintpy/__init__.py
@@ -1,15 +1,5 @@
 # get version info
-from mintpy.version import release_version, logo
-__version__ = release_version
+from mintpy.version import version_num, logo
+__version__ = version_num
 __logo__ = logo
-
-## check environment variable
-#import os
-#import sys
-#mintpy_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-#sys.path.insert(1, mintpy_path)
-#sys.path.insert(1, os.path.join(mintpy_path, 'defaults'))
-#sys.path.insert(1, os.path.join(mintpy_path, 'objects'))
-#sys.path.insert(1, os.path.join(mintpy_path, 'simulation'))
-#sys.path.insert(1, os.path.join(mintpy_path, 'utils'))
 

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -111,7 +111,7 @@ def cmd_line_parse(iargs=None):
 
     # -v (print software version)
     if inps.version:
-        print(mintpy.version.release_description)
+        print(mintpy.version.version_description)
         sys.exit(0)
 
     # check all input template files
@@ -181,7 +181,7 @@ def read_inps2run_steps(inps, step_list, plot_only=False):
     if len(run_steps) > 0:
         # for single step - compact version info
         if len(run_steps) == 1:
-            print(mintpy.version.release_description)
+            print(mintpy.version.version_description)
         else:
             print(mintpy.version.logo)
 

--- a/mintpy/version.py
+++ b/mintpy/version.py
@@ -4,11 +4,35 @@
 
 import os
 import subprocess
+import collections
 
 
 ###########################################################################
+Tag = collections.namedtuple('Tag', 'version date')
+release_history = (
+    Tag('1.3.2', '2021-11-21'),
+    Tag('1.3.1', '2021-08-02'),
+    Tag('1.3.0', '2021-03-06'),
+    Tag('1.2.3', '2020-07-14'),
+    Tag('1.2.2', '2020-04-27'),
+    Tag('1.2.1', '2020-03-30'),
+    Tag('1.2.0', '2020-01-03'),
+    Tag('1.2beta', '2019-08-08'),
+    Tag('1.2alpha', '2019-07-28'),
+    Tag('1.1.2', '2019-05-14'),
+    Tag('1.1.1', '2019-05-08'),
+    Tag('1.1.0', '2019-04-24'),
+    Tag('1.0.0', '2018-11-07'),
+    Tag('0.4.0', '2018-03-11'),
+    Tag('0.3.0', '2017-06-03'),
+    Tag('0.2.1', '2017-03-11'),
+    Tag('0.2.0', '2016-07-14'),
+    Tag('0.1.0', '2015-11-23'),
+)
+release_version = release_history[0].version
+release_date = release_history[0].date
 
-def get_release_info(version='v1.3.1', date='2021-08-02'):
+def get_version_info(version='v{}'.format(release_version), date=release_date):
     """Grab version and date of the latest commit from a git repository"""
     # go to the repository directory
     dir_orig = os.getcwd()
@@ -38,10 +62,10 @@ def get_release_info(version='v1.3.1', date='2021-08-02'):
 
 ###########################################################################
 
-release_version, release_date = get_release_info()
-release_description = """MintPy release version {v}, release date {d}""".format(
-    v=release_version,
-    d=release_date,
+version_num, version_date = get_version_info()
+version_description = """MintPy version {v}, date {d}""".format(
+    v=version_num,
+    d=version_date,
 )
 
 # generate_from: http://patorjk.com/software/taag/
@@ -61,7 +85,7 @@ ___________________________________________________________
    Miami InSAR Time-series software in Python    \______/ 
           MintPy {v}, {d}
 ___________________________________________________________
-""".format(v=release_version, d=release_date)
+""".format(v=version_num, d=version_date)
 
 website = 'https://github.com/insarlab/MintPy'
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -767,7 +767,7 @@ def read_input_file_info(inps):
     if 'DATA_TYPE' in atr.keys():
         msg += ' in {} format'.format(atr['DATA_TYPE'])
 
-    vprint('run {} in {}'.format(os.path.basename(__file__), version.release_description))
+    vprint('run {} in {}'.format(os.path.basename(__file__), version.version_description))
     vprint(msg)
 
     ## size and name

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ with open("docs/README.md", "r") as f:
 with open("mintpy/version.py", "r") as f:
     lines = f.readlines()
     # version
-    line = [line for line in lines if line.startswith("def get_release_info")][0].strip()
-    version = line.replace("'",'"').split('"')[1].split('v')[1]
+    line = [line for line in lines if line.strip().startswith("Tag(")][0].strip()
+    version = line.replace("'",'"').split('"')[1]
     # description
     line = [line for line in lines if line.startswith("description")][0].strip()
     description = line.replace("'",'"').split('"')[1]


### PR DESCRIPTION
**Description of proposed changes**

+ version.py: add release_history as list of Tags
   - use Tag from collection module to save the release history explicitly
   - distinguish between release version number/date and version number/date
   - update version_number/date/description usage in __inti__.py, view.py and smallbaselineApp.py

+ bump the release version number to 1.3.2

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.