### PR TITLE
set matplotlib<3.5 temporarily due to upstream repo bug

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - h5py<3
   - joblib
   - lxml
-  - matplotlib
+  - matplotlib<3.5
   - numpy
   - pyaps3
   - pykml>=0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ defusedxml
 h5py<3
 joblib
 lxml
-matplotlib
+matplotlib<3.5
 numpy
 pyaps3
 pykml>=0.2

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def do_setup():
             "h5py",
             "joblib",
             "lxml",
-            "matplotlib",
+            "matplotlib<3.5",
             "numpy",
             "pyaps3",
             "pykml>=0.2",


### PR DESCRIPTION
**Description of proposed changes**

set matplotlib<3.5 temporarily due to upstream repo bug (https://github.com/matplotlib/matplotlib/issues/21711), which leads error while saving figures to PDF files.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)