### PR TITLE
env: revert matplotlib<3.5 & rm pykdtree/xarray/zarr

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - h5py<3
   - joblib
   - lxml
-  - matplotlib<3.5
+  - matplotlib
   - numpy
   - pyaps3
   - pykml>=0.2

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -31,6 +31,3 @@ dependencies:
   # for pyresample
   - pyresample
   - openmp
-  - pykdtree
-  - xarray
-  - zarr

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ defusedxml
 h5py<3
 joblib
 lxml
-matplotlib<3.5
+matplotlib
 numpy
 pyaps3
 pykml>=0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,6 +26,3 @@ scipy
 # for pyresample
 pyresample
 openmp
-pykdtree
-xarray
-zarr

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def do_setup():
             "h5py",
             "joblib",
             "lxml",
-            "matplotlib<3.5",
+            "matplotlib",
             "numpy",
             "pyaps3",
             "pykml>=0.2",

--- a/setup.py
+++ b/setup.py
@@ -80,12 +80,9 @@ def do_setup():
             "setuptools",
             "scikit-image",
             "scipy",
-            # pyresample dependencies
+            # for pyresample
             "pyresample",
             # "openmp",
-            "pykdtree",
-            "xarray",
-            "zarr",
         ],
 
         # package discovery


### PR DESCRIPTION
**Description of proposed changes**

+ Revert "set matplotlib<3.5 temporarily due to upstream repo bug" as the upstream bug has been fixed (https://github.com/matplotlib/matplotlib/issues/21711).

+ rm `pykdtree/xarray/zarr` for pyresample, as they are now properly installed by `conda install pyresample`, thus, no manual setup is needed anymore.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)