### PR TITLE
ignore pyresample warning for xarray/zarr

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 [![Language](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/)
 [![CircleCI](https://img.shields.io/circleci/build/github/insarlab/MintPy.svg?logo=circleci&label=test)](https://circleci.com/gh/insarlab/MintPy)
 [![Docs Status](https://readthedocs.org/projects/mintpy/badge/?color=green&version=latest)](https://mintpy.readthedocs.io/?badge=latest)
-[![Version](https://img.shields.io/badge/version-v1.3.2-green.svg)](https://github.com/insarlab/MintPy/releases)
+[![Version](https://img.shields.io/github/v/release/insarlab/MintPy?color=green)](https://github.com/insarlab/MintPy/releases)
 [![License](https://img.shields.io/badge/license-GPLv3-yellow.svg)](https://github.com/insarlab/MintPy/blob/main/LICENSE)
 [![Forum](https://img.shields.io/badge/forum-Google%20Groups-orange.svg)](https://groups.google.com/g/mintpy)
 [![Citation](https://img.shields.io/badge/doi-10.1016%2Fj.cageo.2019.104331-blue)](https://doi.org/10.1016/j.cageo.2019.104331)

--- a/mintpy/objects/coord.py
+++ b/mintpy/objects/coord.py
@@ -231,6 +231,12 @@ class coordinate:
         Returns:    az/rg     - np.array / int, range/azimuth pixel number
                     az/rg_res - float, residul/uncertainty of coordinate conversion
         """
+        # ensure longitude is within (-180, 180]
+        if np.isscalar(lon):
+            lon = lon - 360. if lon > 180. else lon
+        else:
+            lon[lon > 180.] -= 360
+
         self.open()
         if self.geocoded:
             az = self.lalo2yx(lat, coord_type='lat')

--- a/mintpy/objects/resample.py
+++ b/mintpy/objects/resample.py
@@ -7,16 +7,15 @@
 #     from mintpy.objects.resample import resample
 
 
-try:
-    import pyresample as pr
-except ImportError:
-    raise ImportError('Can not import pyresample!')
-
 import os
+import warnings
 import h5py
 import numpy as np
 from scipy import ndimage
 from scipy.interpolate import RegularGridInterpolator as RGI
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', UserWarning)
+    import pyresample as pr
 from mintpy.objects.cluster import split_box2sub_boxes
 from mintpy.utils import readfile, ptime, utils0 as ut
 


### PR DESCRIPTION
**Description of proposed changes**

+ objects.resample: Use warnings.catch_warnings() to ignore the potential UserWarning while import pyresample without xarray/zarr installed.

+ objects.coord.geo2radar(): support lon > 180.

+ README: use shields API instead of hardwired value to auto grab the version number in the badge

**Reminders**

- [x] Fix https://groups.google.com/g/mintpy/c/LfhjD9t7gHI
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.