### PR TITLE
fix argv bug in view.py for pip installed version

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,9 +4,9 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  👋  Thanks for opening your first issue here! Please make sure you filled out the template with as much detail as possible. We appreciate that you took the time to contribute!
+  👋  Thanks for opening your first issue here! Please filled out the template with as much details as possible. We appreciate that you took the time to contribute!
 
-  Make sure you read our [contributing guidelines](https://github.com/insarlab/MintPy/blob/master/docs/CONTRIBUTING.md)
+  Make sure you read our [contributing guidelines](https://github.com/insarlab/MintPy/blob/master/docs/CONTRIBUTING.md).
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 

--- a/mintpy/save_gbis.py
+++ b/mintpy/save_gbis.py
@@ -64,7 +64,10 @@ def create_parser():
 def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
-    print('{} {}'.format(os.path.basename(__file__), ' '.join(iargs)))
+
+    inps.argv = iargs if iargs else sys.argv[1:]
+    print('{} {}'.format(os.path.basename(__file__), ' '.join(inps.argv)))
+
     inps.file = os.path.abspath(inps.file)
 
     # Backend setting
@@ -128,7 +131,7 @@ def read_data(inps):
     print('number of pixels after excluding zero phase value: {}'.format(np.sum(inps.mask)))
 
     # read geometry
-    inps.lat, inps.lon = ut.get_lat_lon(inps.metadata)
+    inps.lat, inps.lon = ut.get_lat_lon(inps.metadata, geom_file=inps.geom_file)
     inps.inc_angle = readfile.read(inps.geom_file, datasetName='incidenceAngle')[0]
     inps.head_angle = np.ones(inps.inc_angle.shape, dtype=np.float32) * float(inps.metadata['HEADING'])
     inps.height = readfile.read(inps.geom_file, datasetName='height')[0]

--- a/mintpy/simulation/decorrelation.py
+++ b/mintpy/simulation/decorrelation.py
@@ -24,7 +24,7 @@ def phase_pdf_ds(L, coherence=None, phi_num=1000, coh_step=0.005):
     Parameters: L         - int, number of independent looks
                 coherence - 1D np.array for the range of coherence, with value < 1.0 for valid operation
                 phi_num   - int, number of phase sample for the numerical calculation
-                coh_step  - float, incremental step of coherence
+                coh_step  - float, incremental step of coherence, used only if coherence is None.
     Returns:    pdf       - 2D np.array, phase PDF in size of (phi_num, len(coherence))
                 coherence - 1D np.array for the range of coherence
     Example:

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -100,7 +100,7 @@ def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
 
-    if '--gps-comp' in iargs:
+    if inps.gps_component:
         msg = '--gps-comp is not supported for {}'.format(os.path.basename(__file__))
         raise NotImplementedError(msg)
 

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -790,6 +790,14 @@ def round_to_1(x):
     return round(x, -digit)
 
 
+def round_up_to_odd(x):
+    """Round a float up to the next odd integer .
+    Link: https://stackoverflow.com/questions/31648729
+    """
+    y = np.ceil(x) // 2 * 2 + 1
+    return y.astype(np.int16)
+
+
 def highest_power_of_2(x):
     """Given a number x, find the highest power of 2 that <= x"""
     res = np.power(2, np.floor(np.log2(x)))


### PR DESCRIPTION
**Description of proposed changes**

+ view.py: catch the manually specified arguments via `sys.argv` for cmd or via `iargs` through python call, and save it to `inps.argv` for later-on checking. Fixed the same issue in save_gbis.py as well. Fix https://github.com/yunjunz/MintPy/issues/5.

+ view.py: add --math rad2deg/deg2rad

+ utils0: add round_up_to_odd()

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.