### PR TITLE
add `mintpy.unwrapError.connCompMinArea` option

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -149,8 +149,8 @@ mintpy.unwrapError.numSample       = auto  #[int>1], auto for 100, number of sam
 ##     before estimating the phase difference between reliable regions and added back after the correction.
 ## bridgePtsRadius - half size of the window used to calculate the median value of phase difference
 mintpy.unwrapError.ramp            = auto  #[linear / quadratic], auto for no; recommend linear for L-band data
+mintpy.unwrapError.ConnCompMinArea = auto  #[1-inf], auto for 2.5e3, minimum region/area size of a single connComponent
 mintpy.unwrapError.bridgePtsRadius = auto  #[1-inf], auto for 50, half size of the window around end points
-
 
 ########## 5. invert_network
 ## Invert network of interferograms into time-series using weighted least sqaure (WLS) estimator.

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -152,6 +152,7 @@ mintpy.unwrapError.numSample       = auto  #[int>1], auto for 100, number of sam
 mintpy.unwrapError.ramp            = auto  #[linear / quadratic], auto for no; recommend linear for L-band data
 mintpy.unwrapError.bridgePtsRadius = auto  #[1-inf], auto for 50, half size of the window around end points
 
+
 ########## 5. invert_network
 ## Invert network of interferograms into time-series using weighted least sqaure (WLS) estimator.
 ## weighting options for least square inversion [fast option available but not best]:

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -136,6 +136,7 @@ mintpy.reference.minCoherence  = auto   #[0.0-1.0], auto for 0.85, minimum coher
 ## c. bridging+phase_closure - recommended when there is a small percentage of errors left after bridging
 mintpy.unwrapError.method          = auto  #[bridging / phase_closure / bridging+phase_closure / no], auto for no
 mintpy.unwrapError.waterMaskFile   = auto  #[waterMask.h5 / no], auto for waterMask.h5 or no [if not found]
+mintpy.unwrapError.connCompMinArea = auto  #[1-inf], auto for 2.5e3, discard regions smaller than the min size in pixels
 
 ## phase_closure options:
 ## numSample - a region-based strategy is implemented to speedup L1-norm regularized least squares inversion.
@@ -149,7 +150,6 @@ mintpy.unwrapError.numSample       = auto  #[int>1], auto for 100, number of sam
 ##     before estimating the phase difference between reliable regions and added back after the correction.
 ## bridgePtsRadius - half size of the window used to calculate the median value of phase difference
 mintpy.unwrapError.ramp            = auto  #[linear / quadratic], auto for no; recommend linear for L-band data
-mintpy.unwrapError.ConnCompMinArea = auto  #[1-inf], auto for 2.5e3, minimum region/area size of a single connComponent
 mintpy.unwrapError.bridgePtsRadius = auto  #[1-inf], auto for 50, half size of the window around end points
 
 ########## 5. invert_network

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -60,6 +60,7 @@ mintpy.unwrapError.waterMaskFile     = waterMask.h5
 mintpy.unwrapError.numSample         = 100
 
 mintpy.unwrapError.ramp              = no
+mintpy.unwrapError.ConnCompMinArea   = 2.5e3
 mintpy.unwrapError.bridgePtsRadius   = 50
 
 

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -56,11 +56,11 @@ mintpy.reference.minCoherence    = 0.85
 ########## correct_unwrap_error
 mintpy.unwrapError.method            = no
 mintpy.unwrapError.waterMaskFile     = waterMask.h5
+mintpy.unwrapError.connCompMinArea   = 2.5e3
 
 mintpy.unwrapError.numSample         = 100
 
 mintpy.unwrapError.ramp              = no
-mintpy.unwrapError.ConnCompMinArea   = 2.5e3
 mintpy.unwrapError.bridgePtsRadius   = 50
 
 

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -295,7 +295,9 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
     length = int(atr_geo['LENGTH'])
     width = int(atr_geo['WIDTH'])
     ts_tide = np.zeros((num_date, length, width), dtype=np.float32)
-    step_size = ut.round_to_1(abs(float(atr_geo['Y_STEP'])))/0.0001*300
+    # default step size in meter: ~30 pixels
+    step_size = ut.round_to_1(abs(float(atr_geo['Y_STEP'])) * 108e3 * 30)
+
     # loop for calc
     print('\n'+'-'*50)
     print('calculating solid Earth tides using solid.for (D. Milbert, 2018) ...')

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -295,7 +295,7 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
     length = int(atr_geo['LENGTH'])
     width = int(atr_geo['WIDTH'])
     ts_tide = np.zeros((num_date, length, width), dtype=np.float32)
-
+    step_size = ut.round_to_1(abs(float(atr_geo['Y_STEP'])))/0.0001*300
     # loop for calc
     print('\n'+'-'*50)
     print('calculating solid Earth tides using solid.for (D. Milbert, 2018) ...')
@@ -305,7 +305,7 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
         (tide_e,
          tide_n,
          tide_u) = pysolid.calc_solid_earth_tides_grid(dt_obj, atr_geo,
-                                                       step_size=3e3,
+                                                       step_size=step_size,
                                                        display=False,
                                                        verbose=verbose)
 

--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -557,7 +557,7 @@ def main(iargs=None):
         # update mode
         if inps.update_mode and run_or_skip(inps) == 'skip':
             return inps.ifgram_file
-        print(inps)
+        
         # solve integer ambiguity for common connected components
         common_regions = get_common_region_int_ambiguity(ifgram_file=inps.ifgram_file,
                                                          cc_mask_file=inps.cc_mask_file,

--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -75,6 +75,8 @@ def create_parser():
                         help='common connected components file, required for --action correct')
     parser.add_argument('-n','--num-sample', dest='numSample', type=int, default=100,
                         help='Number of randomly samples/pixels for each common connected component.')
+    parser.add_argument('-m', '--min-area', dest='ConnCompMinArea', type=float, default=2.5e3,
+                        help='minimum region/area size of a single connComponent.')
 
     parser.add_argument('-a','--action', dest='action', type=str, default='correct',
                         choices={'correct', 'calculate'},
@@ -146,6 +148,8 @@ def read_template2inps(template_file, inps=None):
                 inpsDict[key] = value
             elif key in ['numSample']:
                 inpsDict[key] = int(value)
+            elif key in ['ConnCompMinArea']:
+                inpsDict[key] = float(value)
 
     return inps
 
@@ -367,13 +371,14 @@ def plot_num_triplet_with_nonzero_integer_ambiguity(fname, display=False, font_s
 
 ##########################################################################################
 def get_common_region_int_ambiguity(ifgram_file, cc_mask_file, water_mask_file=None, num_sample=100,
-                                    dsNameIn='unwrapPhase'):
+                                    dsNameIn='unwrapPhase', conncomp_min_area=2.5e3):
     """Solve the phase unwrapping integer ambiguity for the common regions among all interferograms
     Parameters: ifgram_file     : str, path of interferogram stack file
                 cc_mask_file    : str, path of common connected components file
                 water_mask_file : str, path of water mask file
                 num_sample      : int, number of pixel sampled for each region
                 dsNameIn        : str, dataset name of the unwrap phase to be corrected
+                conncomp_min_area : float: minimum region/area size
     Returns:    common_regions  : list of skimage.measure._regionprops._RegionProperties object
                     modified by adding two more variables:
                     sample_coords : 2D np.ndarray in size of (num_sample, 2) in int64 format
@@ -399,64 +404,67 @@ def get_common_region_int_ambiguity(ifgram_file, cc_mask_file, water_mask_file=N
         print('refine common mask based on water mask file', water_mask_file)
         cc_mask[water_mask == 0] = 0
 
-    label_img, num_label = conncomp.label_conn_comp(cc_mask, min_area=2.5e3, print_msg=True)
+    label_img, num_label = conncomp.label_conn_comp(cc_mask, min_area=conncomp_min_area, print_msg=True)
     common_regions = measure.regionprops(label_img)
     print('number of common regions:', num_label)
+    if num_label == 0:
+        print('WARNING: min area size ({}) is large, '
+              'try using a smaller value in template for mintpy.unwrapError.ConnCompMinArea'.format(conncomp_min_area))
+    else:
+        # add sample_coords / int_ambiguity
+        print('number of samples per region:', num_sample)
+        print('solving the phase-unwrapping integer ambiguity for {}'.format(dsNameIn))
+        print('\tbased on the closure phase of interferograms triplets (Yunjun et al., 2019)')
+        print('\tusing the L1-norm regularzed least squares approximation (LASSO) ...')
+        for i in range(num_label):
+            common_reg = common_regions[i]
+            # sample_coords
+            idx = sorted(np.random.choice(common_reg.area, num_sample, replace=False))
+            common_reg.sample_coords = common_reg.coords[idx, :].astype(int)
 
-    # add sample_coords / int_ambiguity
-    print('number of samples per region:', num_sample)
-    print('solving the phase-unwrapping integer ambiguity for {}'.format(dsNameIn))
-    print('\tbased on the closure phase of interferograms triplets (Yunjun et al., 2019)')
-    print('\tusing the L1-norm regularzed least squares approximation (LASSO) ...')
-    for i in range(num_label):
-        common_reg = common_regions[i]
-        # sample_coords
-        idx = sorted(np.random.choice(common_reg.area, num_sample, replace=False))
-        common_reg.sample_coords = common_reg.coords[idx, :].astype(int)
+            # solve for int_ambiguity
+            U = np.zeros((num_ifgram, num_sample))
+            if common_reg.label == label_img[stack_obj.refY, stack_obj.refX]:
+                print('{}/{} skip calculation for the reference region'.format(i+1, num_label))
+            else:
+                prog_bar = ptime.progressBar(maxValue=num_sample, prefix='{}/{}'.format(i+1, num_label))
+                for j in range(num_sample):
+                    # read unwrap phase
+                    y, x = common_reg.sample_coords[j, :]
+                    unw = ifginv.read_stack_obs(stack_obj,
+                                                box=(x, y, x+1, y+1),
+                                                ref_phase=ref_phase,
+                                                obs_ds_name=dsNameIn,
+                                                dropIfgram=True,
+                                                print_msg=False).reshape(num_ifgram, -1)
 
-        # solve for int_ambiguity
-        U = np.zeros((num_ifgram, num_sample))
-        if common_reg.label == label_img[stack_obj.refY, stack_obj.refX]:
-            print('{}/{} skip calculation for the reference region'.format(i+1, num_label))
-        else:
-            prog_bar = ptime.progressBar(maxValue=num_sample, prefix='{}/{}'.format(i+1, num_label))
-            for j in range(num_sample):
-                # read unwrap phase
-                y, x = common_reg.sample_coords[j, :]
-                unw = ifginv.read_stack_obs(stack_obj,
-                                            box=(x, y, x+1, y+1),
-                                            ref_phase=ref_phase,
-                                            obs_ds_name=dsNameIn,
-                                            dropIfgram=True,
-                                            print_msg=False).reshape(num_ifgram, -1)
+                    # calculate closure_int
+                    closure_pha = np.dot(C, unw)
+                    closure_int = matrix(np.round((closure_pha - ut.wrap(closure_pha)) / (2.*np.pi)))
 
-                # calculate closure_int
-                closure_pha = np.dot(C, unw)
-                closure_int = matrix(np.round((closure_pha - ut.wrap(closure_pha)) / (2.*np.pi)))
+                    # solve for U
+                    U[:,j] = np.round(l1regls(-C, closure_int, alpha=1e-2, show_progress=0)).flatten()
+                    prog_bar.update(j+1, every=5)
+                prog_bar.close()
+            # add int_ambiguity
+            common_reg.int_ambiguity = np.median(U, axis=1)
+            common_reg.date12_list = date12_list
 
-                # solve for U
-                U[:,j] = np.round(l1regls(-C, closure_int, alpha=1e-2, show_progress=0)).flatten()
-                prog_bar.update(j+1, every=5)
-            prog_bar.close()
-        # add int_ambiguity
-        common_reg.int_ambiguity = np.median(U, axis=1)
-        common_reg.date12_list = date12_list
+        #sort regions by size to facilitate the region matching later
+        common_regions.sort(key=lambda x: x.area, reverse=True)
 
-    #sort regions by size to facilitate the region matching later
-    common_regions.sort(key=lambda x: x.area, reverse=True)
-
-    # plot sample result
-    fig_size = pp.auto_figure_size(label_img.shape, disp_cbar=False)
-    fig, ax = plt.subplots(figsize=fig_size)
-    ax.imshow(label_img, cmap='jet')
-    for common_reg in common_regions:
-        ax.plot(common_reg.sample_coords[:,1],
-                common_reg.sample_coords[:,0], 'k.', ms=2)
-    pp.auto_flip_direction(stack_obj.metadata, ax, print_msg=False)
-    out_img = 'common_region_sample.png'
-    fig.savefig(out_img, bbox_inches='tight', transparent=True, dpi=300)
-    print('saved common regions and sample pixels to file', out_img)
-    plt.close(fig)
+        # plot sample result
+        fig_size = pp.auto_figure_size(label_img.shape, disp_cbar=False)
+        fig, ax = plt.subplots(figsize=fig_size)
+        ax.imshow(label_img, cmap='jet')
+        for common_reg in common_regions:
+            ax.plot(common_reg.sample_coords[:,1],
+                    common_reg.sample_coords[:,0], 'k.', ms=2)
+        pp.auto_flip_direction(stack_obj.metadata, ax, print_msg=False)
+        out_img = 'common_region_sample.png'
+        fig.savefig(out_img, bbox_inches='tight', transparent=True, dpi=300)
+        print('saved common regions and sample pixels to file', out_img)
+        plt.close(fig)
 
     return common_regions
 
@@ -547,19 +555,23 @@ def main(iargs=None):
         # update mode
         if inps.update_mode and run_or_skip(inps) == 'skip':
             return inps.ifgram_file
-
+        print(inps)
         # solve integer ambiguity for common connected components
         common_regions = get_common_region_int_ambiguity(ifgram_file=inps.ifgram_file,
                                                          cc_mask_file=inps.cc_mask_file,
                                                          water_mask_file=inps.waterMaskFile,
                                                          num_sample=inps.numSample,
-                                                         dsNameIn=inps.datasetNameIn)
+                                                         dsNameIn=inps.datasetNameIn,
+                                                         conncomp_min_area=inps.ConnCompMinArea)
 
         # apply the integer ambiguity from common conn comp to the whole ifgram
-        run_unwrap_error_phase_closure(inps.ifgram_file, common_regions,
-                                       water_mask_file=inps.waterMaskFile,
-                                       dsNameIn=inps.datasetNameIn,
-                                       dsNameOut=inps.datasetNameOut)
+        if len(common_regions) == 0:
+            print('skip phase closure correction ...')
+        else:
+            run_unwrap_error_phase_closure(inps.ifgram_file, common_regions,
+                                           water_mask_file=inps.waterMaskFile,
+                                           dsNameIn=inps.datasetNameIn,
+                                           dsNameOut=inps.datasetNameOut)
 
     else:
         # calculate the number of triplets with non-zero integer ambiguity

--- a/mintpy/unwrap_error_phase_closure.py
+++ b/mintpy/unwrap_error_phase_closure.py
@@ -557,7 +557,7 @@ def main(iargs=None):
         # update mode
         if inps.update_mode and run_or_skip(inps) == 'skip':
             return inps.ifgram_file
-        
+
         # solve integer ambiguity for common connected components
         common_regions = get_common_region_int_ambiguity(ifgram_file=inps.ifgram_file,
                                                          cc_mask_file=inps.cc_mask_file,

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -632,6 +632,11 @@ def get_slice_list(fname, no_complex=False):
             obj.open(print_msg=False)
             slice_list = obj.sliceList
 
+        elif k == 'timeseries' and 'slc' in d1_list:
+            with h5py.File(fname, 'r') as f:
+                dates = f['date'][:]
+            slice_list = ['slc-{}'.format(i.decode('UTF-8')) for i in dates]
+
         else:
             ## Find slice by walking through the file structure
             length, width = int(atr['LENGTH']), int(atr['WIDTH'])


### PR DESCRIPTION
**Description of proposed changes**

Some of the parameters which were hardcoded, are change to be optional.

1. The step size in solid earth tide function (made adaptive based on input file info)
2. The min_area in label_conn_comp (added an option in template)
3. Added support for slcStack to read slice list

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.