### PR TITLE
[experimental] time series full covariance calc with 4D matrix IO

### DIFF
--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -318,7 +318,10 @@ class DaskCluster:
             for i, sub_result in enumerate(sub_results[:-1]):
                 num_dim = sub_result.ndim
 
-                if num_dim == 3:
+                if num_dim == 4:
+                    results[i][:, :, y0:y1, x0:x1] = sub_result
+
+                elif num_dim == 3:
                     results[i][:, y0:y1, x0:x1] = sub_result
 
                 elif num_dim == 2:
@@ -326,7 +329,7 @@ class DaskCluster:
 
                 else:
                     msg = "worker result has unexpected dimension: {}".format(num_dim)
-                    msg += '\nit should be either 2 or 3!'
+                    msg += '\nit should be either 2 or 3 or 4!'
                     raise Exception(msg)
 
         return results

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -219,7 +219,7 @@ class timeseries:
 
     def get_size(self):
         with h5py.File(self.file, 'r') as f:
-            self.numDate, self.length, self.width = f[self.name].shape
+            self.numDate, self.length, self.width = f[self.name].shape[-3:]
         return self.numDate, self.length, self.width
 
     def get_date_list(self):

--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -229,7 +229,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ds_unit_dict=None, ref_
                 ds_name_dict - dict, dataset structure definition
                                {dname : [dtype, dshape],
                                 dname : [dtype, dshape, None],
-                                dname : [dtype, dshape, 1/2/3D np.ndarray], #for aux data
+                                dname : [dtype, dshape, 1/2/3/4D np.ndarray], #for aux data
                                 ...
                                }
                 metadata     - dict, metadata
@@ -384,10 +384,11 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ds_unit_dict=None, ref_
 
 def write_hdf5_block(fname, data, datasetName, block=None, mode='a', print_msg=True):
     """Write data to existing HDF5 dataset in disk block by block.
-    Parameters: data        - np.ndarray 1/2/3D matrix
+    Parameters: data        - np.ndarray 1/2/3/4D matrix
                 datasetName - str, dataset name
-                block       - list of 2/4/6 int, for
-                              [zStart, zEnd,
+                block       - list of 2/4/6/8 int, for
+                              [d1Start, d1End,
+                               d2Start, d2End,
                                yStart, yEnd,
                                xStart, xEnd]
                 mode        - str, open mode
@@ -413,6 +414,11 @@ def write_hdf5_block(fname, data, datasetName, block=None, mode='a', print_msg=T
             block = [0, shape[0],
                      0, shape[1],
                      0, shape[2]]
+        elif len(shape) == 4:
+            block = [0, shape[0],
+                     0, shape[1],
+                     0, shape[2],
+                     0, shape[3]]
 
     # write
     if print_msg:
@@ -420,7 +426,13 @@ def write_hdf5_block(fname, data, datasetName, block=None, mode='a', print_msg=T
         print('open  HDF5 file {} in {} mode'.format(fname, mode))
         print("writing dataset /{:<25} block: {}".format(datasetName, block))
     with h5py.File(fname, mode) as f:
-        if len(block) == 6:
+        if len(block) == 8:
+            f[datasetName][block[0]:block[1],
+                           block[2]:block[3],
+                           block[4]:block[5],
+                           block[6]:block[7]] = data
+
+        elif len(block) == 6:
             f[datasetName][block[0]:block[1],
                            block[2]:block[3],
                            block[4]:block[5]] = data

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ def do_setup():
         author="Zhang Yunjun, Heresh Fattahi",
         author_email="yunjunzgeo@gmail.com",
 
+        license='GPL-3.0-or-later',
+        license_files=('LICENSE',),
+
         url=website,
         project_urls={
             "Bug Reports": "https://github.com/insarlab/mintpy/issues",


### PR DESCRIPTION
**Description of proposed changes**

+ 4D HDF5 file support for reading, writing and parallel computing.
+ add `ifgram_inversion.py --calc-cov` option to calculate the full covariance matrix for time series [tested on offset, not tested on phase]
+ add `timeseries2velocity.py --calc-cov` option to propagate the full TS covariance to the time function domain

This is an experimental feature: use very large memory and file size, and computation can be slow.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI / local test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.