### PR TITLE
image_stitch: bugfix & update plotting

### DIFF
--- a/mintpy/image_stitch.py
+++ b/mintpy/image_stitch.py
@@ -241,7 +241,7 @@ def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None, disp_fig=False):
     # colorbar
     fig.subplots_adjust(right=0.9)
     cax = fig.add_axes([0.901, 0.3, 0.01, 0.4])
-    cbar = plt.colorbar(im, cax=cax)
+    plt.colorbar(im, cax=cax)
 
     # output
     fig.savefig(out_fig, bbox_inches='tight', transparent=True, dpi=150)

--- a/mintpy/image_stitch.py
+++ b/mintpy/image_stitch.py
@@ -221,10 +221,10 @@ def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None, disp_fig=False):
     """plot stitching result"""
 
     fig = plt.figure(figsize=[15.0, 8.0])
-    fig = plt.subplot(2,2,1);  plt.imshow(mat11);     plt.title('input file 1');    plt.colorbar()
-    fig = plt.subplot(2,2,2);  plt.imshow(mat22);     plt.title('input file 2');    plt.colorbar()
-    fig = plt.subplot(2,2,3);  plt.imshow(mat);       plt.title('merged');          plt.colorbar()
-    fig = plt.subplot(2,2,4);  plt.imshow(mat_diff);  plt.title('input file diff'); plt.colorbar()
+    plt.subplot(2,2,1);  plt.imshow(mat11);     plt.title('input file 1');    plt.colorbar()
+    plt.subplot(2,2,2);  plt.imshow(mat22);     plt.title('input file 2');    plt.colorbar()
+    plt.subplot(2,2,3);  plt.imshow(mat);       plt.title('merged');          plt.colorbar()
+    plt.subplot(2,2,4);  plt.imshow(mat_diff);  plt.title('input file diff'); plt.colorbar()
     plt.tight_layout()
 
     # output

--- a/mintpy/image_stitch.py
+++ b/mintpy/image_stitch.py
@@ -16,7 +16,9 @@ try:
     from skimage.transform import rescale
 except ImportError:
     raise ImportError('Could not import skimage!')
-from mintpy.utils import readfile, writefile
+
+from mintpy.utils import readfile, writefile, plot as pp
+from mintpy.multilook import multilook_data
 
 
 #############################################################################################
@@ -37,12 +39,13 @@ def create_parser():
     parser.add_argument('-o', '--output', dest='outfile', required=True,
                         help='output file name')
 
-    #parser.add_argument('--manual', dest='manual_match', action='store_true',
-    #                    help='manually select lines to estimate offset for matching.')
+    # stitch option
     parser.add_argument('--no-offset', dest='apply_offset', action='store_false',
                         help='Do not apply offset if data sets are merely to be stitched '
                              'and no adjustment of values needs to be made '
                              '(i.e., for two coherence maps), use this flag')
+
+    # plot options
     parser.add_argument('--nodisplay', dest='disp_fig', action='store_false',
                         help='do not display the result ploting.')
     return parser
@@ -220,12 +223,25 @@ def stitch_two_matrices(mat1, atr1, mat2, atr2, apply_offset=True, print_msg=Tru
 def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None, disp_fig=False):
     """plot stitching result"""
 
-    fig = plt.figure(figsize=[15.0, 8.0])
-    plt.subplot(2,2,1);  plt.imshow(mat11);     plt.title('input file 1');    plt.colorbar()
-    plt.subplot(2,2,2);  plt.imshow(mat22);     plt.title('input file 2');    plt.colorbar()
-    plt.subplot(2,2,3);  plt.imshow(mat);       plt.title('merged');          plt.colorbar()
-    plt.subplot(2,2,4);  plt.imshow(mat_diff);  plt.title('input file diff'); plt.colorbar()
-    plt.tight_layout()
+    # plot settings
+    titles = ['file 1', 'file 2', 'stitched', 'difference']
+    mat_mli = multilook_data(mat, 20, 20, method='mean')
+    vmin = np.nanmin(mat_mli)
+    vmax = np.nanmax(mat_mli)
+    fig_size = pp.auto_figure_size(ds_shape=mat.shape, scale=1.4, disp_cbar=True, print_msg=True)
+
+    # plot
+    fig, axs = plt.subplots(nrows=2, ncols=2, figsize=fig_size, sharex=True, sharey=True)
+    for ax, data, title in zip(axs.flatten(), [mat11, mat22, mat, mat_diff], titles):
+        im = ax.imshow(data, vmin=vmin, vmax=vmax, interpolation='nearest')
+        ax.set_title(title, fontsize=12)
+        ax.tick_params(which='both', direction='in', labelsize=12, left=True, right=True, top=True, bottom=True)
+    fig.tight_layout()
+
+    # colorbar
+    fig.subplots_adjust(right=0.9)
+    cax = fig.add_axes([0.901, 0.3, 0.01, 0.4])
+    cbar = plt.colorbar(im, cax=cax)
 
     # output
     fig.savefig(out_fig, bbox_inches='tight', transparent=True, dpi=150)


### PR DESCRIPTION
**Description of proposed changes**

`fig` is used as a variable for the whole figure, and then each of the subplots. This mean that `fig.savefig` results in the error `AttributeError: 'AxesSubplot' object has no attribute 'savefig'`

Removed `fig=` on the `subplot` lines

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.