### PR TITLE
generic multi-dataset file (e.g. velocity) support in `add/diff/deramp`

### DIFF
--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -153,7 +153,7 @@ def add_file(fnames, out_file=None, force=False):
                 # ignore ds_name if input file has single dataset
                 ds_name2read = None if len(ds_names_list[i+1]) == 1 else ds_name
                 # read
-                data2 = readfile.read(fnames[i], datasetName=ds_name2read)[0]
+                data2 = readfile.read(fname, datasetName=ds_name2read)[0]
                 # apply operation
                 data = add_matrix(data, data2)
             dsDict[ds_name] = data

--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -135,10 +135,13 @@ def add_file(fnames, out_file=None, force=False):
 
     else:
         dsDict = {}
-        dsNames = readfile.get_dataset_list(fnames[0])
+        dsNames = []
+        for fname in fnames:
+            dsNames.append(readfile.get_dataset_list(fname))
+        dsNames = list(set.intersection(*map(set, dsNames)))
+        print('List of common datasets across files: ', dsNames)
+
         for dsName in dsNames:
-            if not dsName and all(k1 and k2 == 'velocity'):
-                dsName = 'velocity'
             # ignore dsName if input file has single dataset
             dsName2read = None if len(dsNames) == 1 else dsName
 

--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -78,12 +78,15 @@ def add_file(fnames, out_file=None, force=False):
             out_file += '_plus_' + os.path.splitext(os.path.basename(fnames[i]))[0]
         out_file += ext
 
-    atr1 = readfile.read_attribute(fnames[0])
-    atr2 = readfile.read_attribute(fnames[1])
+    # Read filenames, attributes, and FILE_TYPE
+    file1, file2 = fnames[0], fnames[1]
+    atr1 = readfile.read_attribute(file1)
+    k1 = atr1['FILE_TYPE']
+    atr2 = readfile.read_attribute(file2)
+    k2 = atr2['FILE_TYPE']
+    print('input files are: {} and {}'.format(k1, k2))
 
-    if atr1['FILE_TYPE'] == 'timeseries':
-        file1, file2 = fnames[0], fnames[1]
-
+    if k1 == 'timeseries':
         # check dates shared by two timeseries files
         dateList1 = timeseries(file1).get_date_list()
         dateList2 = timeseries(file2).get_date_list()
@@ -134,6 +137,8 @@ def add_file(fnames, out_file=None, force=False):
         dsDict = {}
         dsNames = readfile.get_dataset_list(fnames[0])
         for dsName in dsNames:
+            if not dsName and all(k1 and k2 == 'velocity'):
+                dsName = 'velocity'
             # ignore dsName if input file has single dataset
             dsName2read = None if len(dsNames) == 1 else dsName
 

--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -134,7 +134,7 @@ def add_file(fnames, out_file=None, force=False):
 
     else:
         # get common dataset list
-        ds_names_list = [readfile.get_dataset_list(x) for x in [file1] + file2]
+        ds_names_list = [readfile.get_dataset_list(x) for x in fnames]
         ds_names = list(set.intersection(*map(set, ds_names_list)))
         # if all files have one dataset, ignore dataset name variation and take the 1st one as reference
         if all(len(x) == 1 for x in ds_names_list):

--- a/mintpy/add.py
+++ b/mintpy/add.py
@@ -141,7 +141,7 @@ def add_file(fnames, out_file=None, force=False):
             ds_names = ds_names_list[0]
         print('List of common datasets across files: ', ds_names)
         if len(ds_names) < 1:
-            raise ValueError('No common datasets found among files:\n{}'.format([file1] + file2))
+            raise ValueError('No common datasets found among files:\n{}'.format(fnames))
 
         # loop over each file
         dsDict = {}

--- a/mintpy/diff.py
+++ b/mintpy/diff.py
@@ -244,12 +244,14 @@ def diff_file(file1, file2, out_file=None, force=False, max_num_pixel=2e8):
         dsDict[dsName] = data
         writefile.write(dsDict, out_file=out_file, ref_file=file1)
 
-    # Sing dataset file
+    # Single dataset file
     else:
-        data1 = readfile.read(file1)[0]
+        dsName = 'velocity' if k1 == 'velocity' else None
+        data1 = readfile.read(file1, datasetName=dsName)[0]
         data = np.array(data1, data1.dtype)
         for fname in file2:
-            data2 = readfile.read(fname)[0]
+            dsName = 'velocity' if k2 == 'velocity' else None
+            data2 = readfile.read(fname, datasetName=dsName)[0]
             data = np.array(data, dtype=np.float32) - np.array(data2, dtype=np.float32)
             data = np.array(data, data1.dtype)
         print('writing >>> '+out_file)

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -837,7 +837,9 @@ def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None
             with open(coeff_file, 'a') as f:
                 f.write('{}    '.format(atr['FILE_TYPE']))
         # read
-        data = readfile.read(fname)[0]
+        if not datasetName and k == 'velocity':
+            datasetName = 'velocity'
+        data = readfile.read(fname, datasetName=datasetName)[0]
         # deramp
         data = deramp(data, mask,
                       ramp_type=ramp_type,


### PR DESCRIPTION
+ add.py: when operating on velocity files, operate on velocity dset as default
+ diff.py: when operating on velocity files, operate on velocity dset as default
+ utils1..py: when deramping on velocity files, operate on velocity dset as default

**Description of proposed changes**

Here propose to operate on the velocity dataset as default when using the following functions/codes on the velocity files (`FILE_TYPE`=velocity)

Before, the default for deramping is operating on the first dataset, not necessarily the "velocity" if there are multiple fields in it, e.g., "annualAmplitude".

Also the same situation in `add.py` and `diff.py`.

This is a quick tweak, it would be even better to allow a user-defined `dataset` when calling the function, which could be in another PR.

Thanks for reviewing it.


**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
