### PR TITLE
bugfix for `timeseries2velocity.py --bootstrap --save-res`

### DIFF
--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -612,6 +612,9 @@ def run_timeseries2time_func(inps):
             m[:, mask] = m_boot.mean(axis=0).reshape(num_param, -1)
             m_std[:, mask] = m_boot.std(axis=0).reshape(num_param, -1)
             del m_boot
+            
+            # Get design matrix for full time series
+            G = time_func.get_design_matrix4time_func(inps.dateList,model=model, ref_date=inps.ref_date, seconds=seconds)
 
 
         else:

--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -316,11 +316,9 @@ def read_exclude_date(inps, dateListAll):
 
 
 def read_date_info(inps):
-    """Get inps.excludeDate full list
-    Inputs:
-        inps          - Namespace,
-    Output:
-        inps.excludeDate  - list of string for exclude date in YYYYMMDD format
+    """Read dates used in the estimation and its related info.
+    Parameters: inps - Namespace
+    Returns:    inps - Namespace
     """
     if inps.key == 'timeseries':
         tsobj = timeseries(inps.timeseries_file)
@@ -612,9 +610,9 @@ def run_timeseries2time_func(inps):
             m[:, mask] = m_boot.mean(axis=0).reshape(num_param, -1)
             m_std[:, mask] = m_boot.std(axis=0).reshape(num_param, -1)
             del m_boot
-            
-            # Get design matrix for full time series
-            G = time_func.get_design_matrix4time_func(inps.dateList,model=model, ref_date=inps.ref_date, seconds=seconds)
+
+            # get design matrix to calculate the residual time series
+            G = time_func.get_design_matrix4time_func(inps.dateList, model=model, ref_date=inps.ref_date, seconds=seconds)
 
 
         else:


### PR DESCRIPTION
When running `timeseries2velocity.py` with bootstrapping, we use the function `time_func.estimate_time_func` to repeatedly fit the time series data. This function returns the design matrix, `G`,  however when bootstrapping we don't assign the design matrix to a variable, meaning that if we try to save the residual file we get the error `UnboundLocalError: local variable 'G' referenced before assignment` at line 702. 

Related to https://github.com/insarlab/MintPy/pull/654

**Description of proposed changes**

If we want to output the residual when bootstrapping, we need to get the full design matrix. I've added a line of code to do this.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.