### PR TITLE
bugfix: timeseries2velocity `--save-res` excluded dates

### DIFF
--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -480,8 +480,13 @@ def run_timeseries2time_func(inps):
         for key in ['REF_DATE']:
             if key in atrR.keys():
                 atrR.pop(key)
-        writefile.layout_hdf5(inps.res_file, metadata=atrR, ref_file=inps.timeseries_file)
-
+        date_len = len(inps.dateList[0])
+        ds_name_dict = {
+            "date"       : [np.dtype(f'S{date_len}'), (num_date,), np.array(inps.dateList, dtype=np.string_)],
+            "timeseries" : [np.float32,               (num_date, length, width), None]
+        }
+        writefile.layout_hdf5(inps.res_file, ds_name_dict=ds_name_dict, metadata=atrR)
+    
 
     ## estimation
 

--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -477,9 +477,11 @@ def run_timeseries2time_func(inps):
     # timeseries_res: attributes + instantiate output file
     if inps.save_res:
         atrR = dict(atr)
+        # remove REF_DATE attribute
         for key in ['REF_DATE']:
             if key in atrR.keys():
                 atrR.pop(key)
+        # prepare ds_name_dict manually, instead of using ref_file, to support --ex option
         date_len = len(inps.dateList[0])
         ds_name_dict = {
             "date"       : [np.dtype(f'S{date_len}'), (num_date,), np.array(inps.dateList, dtype=np.string_)],


### PR DESCRIPTION
A bugfix for issue #739, which was brought up by @olliestephenson.

When saving time-series residuals during `timeseries2velocity.py`, the code did not ignore the excluded dates. It writes residuals for all the dates we haven't excluded, leaving the final N date entries empty (where N is the number of dates we have excluded). This means that the residuals no longer line up with the correct dates.

Now the code instantiates the output time-series residual hdf5 file with the correct number of dates, accounting for the excluded dates.

This bugfix is a realization of the suggested solution from @olliestephenson, in which we pass the shape of the timeseries with the excluded dates removed to `layout_hdf5` via the `ds_name_dict` argument.

Co-authored by @yunjunz 

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [x] Fix #739 
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
