### PR TITLE
ifg_inv: bugfix for design matrix w/ date1 > date2 & release memory occupied by covariance matrix

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -373,7 +373,10 @@ def estimate_timeseries(A, B, y, tbase_diff, weight_sqrt=None, min_norm_velocity
         return ts, inv_quality, num_inv_obs
 
     # check 2 - matrix invertability (for WLS only because OLS contains it already)
-    # Commented after correcting design matrix B for non-sequential networks
+    # Yunjun, Mar 2022: from my vague memory, a singular design matrix B returns error from scipy.linalg,
+    #     but somehow gives results after weighting, so I decided to not trust that result via this check
+    # Sara, Mar 2022: comment this check after correcting design matrix B for non-sequential networks
+    #     a.k.a., networks with the first date not being the earlier date
     #if weight_sqrt is not None:
     #    try:
     #        linalg.inv(np.dot(B.T, B))

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -1337,7 +1337,7 @@ def ifgram_inversion(inps=None):
 
             # initiate the output data
             ts = np.zeros((num_date, box_len, box_wid), np.float32)
-            ts_cov = np.zeros((num_date, num_date, box_len, box_wid), np.float32) if inps.calcCov else None
+            ts_cov = np.zeros((num_date, num_date, box_len, box_wid), np.float32) if inps.calcCov else 0
             inv_quality = np.zeros((box_len, box_wid), np.float32)
             num_inv_obs = np.zeros((box_len, box_wid), np.float32)
 

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -373,6 +373,7 @@ def estimate_timeseries(A, B, y, tbase_diff, weight_sqrt=None, min_norm_velocity
         return ts, inv_quality, num_inv_obs
 
     # check 2 - matrix invertability (for WLS only because OLS contains it already)
+    # Commented after correcting design matrix B for non-sequential networks
     #if weight_sqrt is not None:
     #    try:
     #        linalg.inv(np.dot(B.T, B))

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -846,7 +846,7 @@ def ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='u
                 min_redundancy    - float, the min number of ifgrams for every acquisition.
                 calc_cov          - bool, calculate the time series covariance matrix.
     Returns:    ts                - 3D array in size of (num_date, num_row, num_col)
-                ts_cov            - 4D array in size of (num_date, num_date, num_row, num_col)
+                ts_cov            - 4D array in size of (num_date, num_date, num_row, num_col) or 0
                 inv_quality       - 2D array in size of (num_row, num_col)
                 num_inv_obs       - 2D array in size of (num_row, num_col)
                 box               - tuple of 4 int
@@ -896,7 +896,6 @@ def ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='u
 
         # calculate stack STD
         if calc_cov:
-            #A_std = get_design_matrix4std(stack_obj)[0]
             A_std, r0 = get_design_matrix4std(stack_obj)[:2]
             r1 = r0 + 1
             if weight_func == 'var':
@@ -1002,10 +1001,7 @@ def ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='u
 
     # 2.1 initiale the output matrices
     ts = np.zeros((num_date, num_pixel), np.float32)
-    if calc_cov:
-        ts_cov = np.zeros((num_date, num_date, num_pixel), np.float32)
-    else:
-        ts_cov = 0
+    ts_cov = np.zeros((num_date, num_date, num_pixel), np.float32) if calc_cov else 0
     inv_quality = np.zeros(num_pixel, np.float32)
     if 'offset' in obs_ds_name.lower():
         inv_quality *= np.nan
@@ -1341,12 +1337,9 @@ def ifgram_inversion(inps=None):
 
             # initiate the output data
             ts = np.zeros((num_date, box_len, box_wid), np.float32)
-            if inps.calcCov:
-                ts_cov = np.zeros((num_date, num_date, box_len, box_wid), np.float32)
-            else:
-                ts_cov = 0
+            ts_cov = np.zeros((num_date, num_date, box_len, box_wid), np.float32) if inps.calcCov else None
             inv_quality = np.zeros((box_len, box_wid), np.float32)
-            num_inv_obs  = np.zeros((box_len, box_wid), np.float32)
+            num_inv_obs = np.zeros((box_len, box_wid), np.float32)
 
             # initiate dask cluster and client
             cluster_obj = cluster.DaskCluster(inps.cluster, inps.numWorker, config_name=inps.config)

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -1155,10 +1155,7 @@ def ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='u
         ts_cov *= rg_pixel_size
         print('converting range offset unit from pixel ({:.2f} m) to meter'.format(rg_pixel_size))
 
-    if calc_cov:
-        return ts, ts_cov, inv_quality, num_inv_obs, box
-    else:
-        return ts, inv_quality, num_inv_obs, box
+    return ts, ts_cov, inv_quality, num_inv_obs, box
 
 
 def ifgram_inversion(inps=None):
@@ -1333,10 +1330,7 @@ def ifgram_inversion(inps=None):
         data_kwargs['box'] = box
         if not inps.cluster:
             # non-parallel
-            if inps.calcCov:
-                ts, ts_cov, inv_quality, num_inv_obs = ifgram_inversion_patch(**data_kwargs)[:-1]
-            else:
-                ts, inv_quality, num_inv_obs = ifgram_inversion_patch(**data_kwargs)[:-1]
+            ts, ts_cov, inv_quality, num_inv_obs = ifgram_inversion_patch(**data_kwargs)[:-1]
 
         else:
             # parallel
@@ -1353,16 +1347,10 @@ def ifgram_inversion(inps=None):
             cluster_obj.open()
 
             # run dask
-            if inps.calcCov:
-                ts, ts_cov, inv_quality, num_inv_obs = cluster_obj.run(
-                    func=ifgram_inversion_patch,
-                    func_data=data_kwargs,
-                    results=[ts, ts_cov, inv_quality, num_inv_obs])
-            else:
-                ts, inv_quality, num_inv_obs = cluster_obj.run(
-                    func=ifgram_inversion_patch,
-                    func_data=data_kwargs,
-                    results=[ts, inv_quality, num_inv_obs])
+            ts, ts_cov, inv_quality, num_inv_obs = cluster_obj.run(
+                func=ifgram_inversion_patch,
+                func_data=data_kwargs,
+                results=[ts, ts_cov, inv_quality, num_inv_obs])
 
             # close dask cluster and client
             cluster_obj.close()

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -329,11 +329,9 @@ class DaskCluster:
                     results[i][y0:y1, x0:x1] = sub_result
 
                 else:
-                    # following condition is for all outputs except covariance matrix which could be 0 (no dimension if not calculated)
-                    if i != 1:
-                        msg = "worker result has unexpected dimension: {}".format(num_dim)
-                        msg += '\nit should be either 2 or 3 or 4!'
-                        raise Exception(msg)
+                    msg = "worker result has unexpected dimension: {}".format(num_dim)
+                    msg += '\nit should be either 2 or 3 or 4!'
+                    raise Exception(msg)
 
         return results
 

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -329,6 +329,7 @@ class DaskCluster:
                     results[i][y0:y1, x0:x1] = sub_result
 
                 else:
+                    # following condition is for all outputs except covariance matrix which could be 0 (no dimension if not calculated)
                     if i != 1:
                         msg = "worker result has unexpected dimension: {}".format(num_dim)
                         msg += '\nit should be either 2 or 3 or 4!'

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -130,7 +130,7 @@ class DaskCluster:
 
     This object takes in a computing function for one block in space.
     For the computing function:
-        1. the output is always several matrices and one box.
+        1. the output is always several matrices (or None) and one box.
         2. the number of matrices may vary for different applications/functions.
         3. all matrices will be in 2D in size of (len, wid) or 3D in size of (n, len, wid),
            thus, the last two dimension (in space) will be the same.
@@ -222,10 +222,10 @@ class DaskCluster:
 
         :param func: function, a python function to run in parallel
         :param func_data: dict, a dictionary of the argument to pass to the function
-        :param results: list[numpy.nd.array], arrays of the appropriate structure representing
+        :param results: list[numpy.ndarray], arrays of the appropriate structure representing
                the final output of processed box (need to be in the same order as the function passed in
                submit_workers returns in)
-        :return: results: tuple(numpy.nd.arrays), the processed results of the box
+        :return: results: tuple(numpy.ndarray), the processed results of the box
         """
         from dask.distributed import Client
 
@@ -286,13 +286,13 @@ class DaskCluster:
         """Compile results from completed workers and recompiles their sub outputs into the output
         for the complete box being worked on.
         :param futures: list(dask.Future), list of futures representing future dask worker calculations
-        :param results: list[numpy.nd.array], arrays of the appropriate structure representing
+        :param results: list[numpy.ndarray], arrays of the appropriate structure representing
                the final output of processed box (need to be in the same order as the function passed in
                submit_workers returns in)
-        :param box: numpy.nd.array, the initial complete box being processed
+        :param box: numpy.ndarray, the initial complete box being processed
         :param submission_time: time, the time of submission of the dask workers (used to determine worker
                runtimes as a performance diagnostic)
-        :return: results: tuple(numpy.nd.arrays), the processed results of the box
+        :return: results: tuple(numpy.ndarray), the processed results of the box
         """
         from dask.distributed import as_completed
 
@@ -317,21 +317,20 @@ class DaskCluster:
             # catch result - matrices
             # and loop across all of the returned data to rebuild complete box
             for i, sub_result in enumerate(sub_results[:-1]):
-                num_dim = sub_result.ndim
-
-                if num_dim == 4:
-                    results[i][:, :, y0:y1, x0:x1] = sub_result
-
-                elif num_dim == 3:
-                    results[i][:, y0:y1, x0:x1] = sub_result
-
-                elif num_dim == 2:
-                    results[i][y0:y1, x0:x1] = sub_result
-
-                else:
-                    msg = "worker result has unexpected dimension: {}".format(num_dim)
-                    msg += '\nit should be either 2 or 3 or 4!'
-                    raise Exception(msg)
+                if sub_result is not None:
+                    num_dim = sub_result.ndim
+                    if num_dim == 4:
+                        results[i][:, :,
+                                   y0:y1, x0:x1] = sub_result
+                    elif num_dim == 3:
+                        results[i][:,
+                                   y0:y1, x0:x1] = sub_result
+                    elif num_dim == 2:
+                        results[i][y0:y1, x0:x1] = sub_result
+                    else:
+                        msg = "worker result has unexpected dimension: {}".format(num_dim)
+                        msg += '\nit should be either 2 or 3 or 4!'
+                        raise Exception(msg)
 
         return results
 

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -242,6 +242,7 @@ class DaskCluster:
 
         print('initiate Dask client')
         self.client = Client(self.cluster)
+        self.client.get_versions(check=True)
 
         # submit job for each worker
         futures, submission_time = self.submit_job(func, func_data, sub_boxes)
@@ -328,9 +329,10 @@ class DaskCluster:
                     results[i][y0:y1, x0:x1] = sub_result
 
                 else:
-                    msg = "worker result has unexpected dimension: {}".format(num_dim)
-                    msg += '\nit should be either 2 or 3 or 4!'
-                    raise Exception(msg)
+                    if i != 1:
+                        msg = "worker result has unexpected dimension: {}".format(num_dim)
+                        msg += '\nit should be either 2 or 3 or 4!'
+                        raise Exception(msg)
 
         return results
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -1059,13 +1059,20 @@ class ifgramStack:
             ind1, ind2 = [date_list.index(d) for d in date12_list[i].split('_')]
             A[i, ind1] = -1
             A[i, ind2] = 1
-            B[i, ind1:ind2] = tbase[ind1+1:ind2+1] - tbase[ind1:ind2]
+            if ind1 < ind2:
+                B[i, ind1:ind2] = tbase[ind1 + 1:ind2 + 1] - tbase[ind1:ind2]
+            else:
+                B[i, ind2:ind1] = tbase[ind2:ind1] - tbase[ind2 + 1:ind1 + 1]
 
         # Remove reference date as it can not be resolved
         if refDate != 'no':
             # default refDate
             if refDate is None:
-                refDate = date_list[0]
+                check_single_reference = np.all([True if i == date1s[0] else False for i in date1s])
+                if check_single_reference:
+                    refDate = date1s[0]
+                else:
+                    refDate = date_list[0]
 
             # apply refDate
             if refDate:

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -1053,6 +1053,8 @@ class ifgramStack:
         tbase = np.array(tbase, dtype=np.float32) / 365.25
 
         # calculate design matrix
+        # A for minimizing the residual of phase
+        # B for minimizing the residual of phase velocity
         A = np.zeros((num_ifgram, num_date), np.float32)
         B = np.zeros((num_ifgram, num_date), np.float32)
         for i in range(num_ifgram):
@@ -1068,8 +1070,8 @@ class ifgramStack:
         if refDate != 'no':
             # default refDate
             if refDate is None:
-                check_single_reference = np.all([True if i == date1s[0] else False for i in date1s])
-                if check_single_reference:
+                single_reference = len(set(date1s)) == 1
+                if single_reference:
                     refDate = date1s[0]
                 else:
                     refDate = date_list[0]

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -1061,6 +1061,7 @@ class ifgramStack:
             ind1, ind2 = [date_list.index(d) for d in date12_list[i].split('_')]
             A[i, ind1] = -1
             A[i, ind2] = 1
+            # support date12_list with the first date NOT being the earlier date
             if ind1 < ind2:
                 B[i, ind1:ind2] = tbase[ind1 + 1:ind2 + 1] - tbase[ind1:ind2]
             else:
@@ -1070,8 +1071,9 @@ class ifgramStack:
         if refDate != 'no':
             # default refDate
             if refDate is None:
-                single_reference = len(set(date1s)) == 1
-                if single_reference:
+                # for single   reference network, use the same reference date
+                # for multiple reference network, use the first date
+                if len(set(date1s)) == 1:
                     refDate = date1s[0]
                 else:
                     refDate = date_list[0]


### PR DESCRIPTION
**Description of proposed changes**

1. There is a bug in the calculation of design matrix for ifgram inversion using minimum norm phase velocity. Currently the matrix only works for a network with sequential interferograms where the secondary images are always after reference date. So basically it does not work for some networks, for example a single reference network with the reference image in the middle. Incorrect timeseries are resulted where they are zero for dates before reference. Also weighting does not work in that case.

Proposed changes:
- Correct design matrix calculation
- Correct reference date based on interferograms
- Remove the condition where rules out weighted inversion for non redundant network 

2. The second issue is regarding the memory and failure of Dask during inversion. The default of ifgram inversion is to not calculate/write covariance matrix of the timeseries which is a huge 4D matrix. But the problem is that it allocates memory for covariance matrix during inversion even when you don't want to calculate it

proposed changes:
- Release memory occupied by covariance matrix if it is not opted to calculate for.


