### PR TITLE
asc_desc2horz_vert: speedup pixel-wise inversion via win-by-win

### DIFF
--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -385,6 +385,7 @@ class GPS:
 
         self.dates = np.array([dt.datetime.strptime(i, "%y%b%d") for i in data[:, 1]])
         #self.dates = np.array([ptime.decimal_year2datetime(i) for i in data[:, 2]])
+        self.date_list = [x.strftime('%Y%m%d') for x in self.dates]
 
         (self.dis_e,
          self.dis_n,

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -151,8 +151,6 @@ class timeseries:
 
     File structure: https://mintpy.readthedocs.io/en/latest/api/data_structure/#timeseries
     """
-    # point get_design_matrix4time_func() to utils.time_func for backward compatibility
-    get_design_matrix4time_func = time_func.get_design_matrix4time_func
 
     def __init__(self, file=None):
         self.file = file

--- a/tests/test_asc_desc2horz_vert.py
+++ b/tests/test_asc_desc2horz_vert.py
@@ -65,10 +65,8 @@ def main(iargs=None):
     dlos1 = ut.enu2los(dE, dN, dU, inc_angle=los_inc_angle[1], az_angle=los_az_angle[1])
 
     # asc / desc LOS --> horz / vert [estimation]
-    dlos = np.vstack((dlos0.reshape(1, -1), dlos1.reshape(1, -1)))
+    dlos = np.vstack((dlos0.reshape(1, length, width), dlos1.reshape(1, length, width)))
     estH, estV = asc_desc2horz_vert(dlos, los_inc_angle, los_az_angle, horz_az_angle)
-    estH = estH.reshape(length, width)
-    estV = estV.reshape(length, width)
 
     # check difference between the trush and estimation
     print(f'mean difference for horz / vert: {np.nanmean(estH - simH)} / {np.nanmean(estH - simH)}')


### PR DESCRIPTION
**Description of proposed changes**

+ `asc_desc2horz_vert.py`:
   - use a window-by-window strategy to speedup the pixel-wised inversion
   - add `get_design_matrix4east_north_up()` for future 3D decomposition
   - bug fix for --oo option during file writing

+ `gps.GPS.read_displacement()`: add `self.date_list` member variable, for easy use

+ `stack.timeseries`: remove get_design_matrix4time_func, as it's not used anywhere in mintpy anymore, to avoid circular imports

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1040/workflows/ef66917e-0b36-4d26-b12a-82db414654a6/jobs/1039) (green)
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.