### PR TITLE
save_hdfeos5.py: allows for suffix in filename

### DIFF
--- a/mintpy/save_hdfeos5.py
+++ b/mintpy/save_hdfeos5.py
@@ -52,6 +52,7 @@ def create_parser():
                         help='Average spatial coherence file, i.e. avgSpatialCoh.h5')
     parser.add_argument('-m', '--mask', dest='mask_file', help='Mask file')
     parser.add_argument('-g', '--geometry', dest='geom_file', help='geometry file')
+    parser.add_argument('--suffix', dest='suffix', help='suffix to be appended to file name (e.g. PS)')
 
     parser.add_argument('--update', action='store_true',
                         help='Enable update mode, a.k.a. put XXXXXXXX as endDate in filename if endDate < 1 year')
@@ -242,7 +243,7 @@ def metadata_mintpy2unavco(meta_in, dateList):
     return unavco_meta
 
 
-def get_output_filename(metadata, update_mode=False, subset_mode=False):
+def get_output_filename(metadata, suffix=None, update_mode=False, subset_mode=False):
     """Get output file name of HDF-EOS5 time-series file."""
     SAT = metadata['mission']
     SW = metadata['beam_mode']
@@ -263,7 +264,10 @@ def get_output_filename(metadata, update_mode=False, subset_mode=False):
         print('Update mode is ON, put endDate as XXXXXXXX.')
         DATE2 = 'XXXXXXXX'
 
-    outName = SAT+'_'+SW+'_'+RELORB+'_'+FRAME+'_'+DATE1+'_'+DATE2+'.he5'
+    if suffix == None:
+       outName = SAT+'_'+SW+'_'+RELORB+'_'+FRAME+'_'+DATE1+'_'+DATE2+'.he5'
+    else:
+       outName = SAT+'_'+SW+'_'+RELORB+'_'+FRAME+'_'+DATE1+'_'+DATE2+'_'+suffix+'.he5'
 
     if subset_mode:
         print('Subset mode is enabled, put subset range info in output filename.')
@@ -463,6 +467,7 @@ def main(iargs=None):
 
     # Get output filename
     out_file = get_output_filename(metadata=meta,
+                                   suffix=inps.suffix,
                                    update_mode=inps.update,
                                    subset_mode=inps.subset)
 

--- a/mintpy/save_hdfeos5.py
+++ b/mintpy/save_hdfeos5.py
@@ -52,7 +52,7 @@ def create_parser():
                         help='Average spatial coherence file, i.e. avgSpatialCoh.h5')
     parser.add_argument('-m', '--mask', dest='mask_file', help='Mask file')
     parser.add_argument('-g', '--geometry', dest='geom_file', help='geometry file')
-    parser.add_argument('--suffix', dest='suffix', help='suffix to be appended to file name (e.g. PS)')
+    parser.add_argument('--suffix', dest='suffix', help='suffix to be appended to file name (e.g. PS).')
 
     parser.add_argument('--update', action='store_true',
                         help='Enable update mode, a.k.a. put XXXXXXXX as endDate in filename if endDate < 1 year')
@@ -264,7 +264,7 @@ def get_output_filename(metadata, suffix=None, update_mode=False, subset_mode=Fa
         print('Update mode is ON, put endDate as XXXXXXXX.')
         DATE2 = 'XXXXXXXX'
 
-    if suffix == None:
+    if not suffix:
        outName = SAT+'_'+SW+'_'+RELORB+'_'+FRAME+'_'+DATE1+'_'+DATE2+'.he5'
     else:
        outName = SAT+'_'+SW+'_'+RELORB+'_'+FRAME+'_'+DATE1+'_'+DATE2+'_'+suffix+'.he5'


### PR DESCRIPTION
**Description of proposed changes**

This  addition allows the creation of multiple, slightly differently names *he5 files, e.g. `S1_IW3_048_0081_0082_20160412_20220405_PS.he5` for a file just containing persistent scatterers. This is achieved using ` save_hdfeos5.py --suffix PS`. 

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
