### PR TITLE
a new "narrow" slider for `tsview.py`

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -145,7 +145,7 @@ mintpy.unwrapError.connCompMinArea = auto  #[1-inf], auto for 2.5e3, discard reg
 ##     are used for all pixels within this common conn. comp.
 mintpy.unwrapError.numSample       = auto  #[int>1], auto for 100, number of samples to invert for common conn. comp.
 
-## briding options:
+## bridging options:
 ## ramp - a phase ramp could be estimated based on the largest reliable region, removed from the entire interferogram
 ##     before estimating the phase difference between reliable regions and added back after the correction.
 ## bridgePtsRadius - half size of the window used to calculate the median value of phase difference
@@ -191,7 +191,7 @@ mintpy.networkInversion.shadowMask  = auto #[yes / no], auto for yes [if shadowM
 
 ########## correct_SET
 ## Solid Earth tides (SET) correction [need to install insarlab/PySolid]
-## reference: Milbert (2018); Fattahi et al. (2020, AGU)
+## reference: Milbert (2018); Yunjun et al. (2022, IEEE-TGRS)
 mintpy.solidEarthTides = auto #[yes / no], auto for no
 
 
@@ -258,7 +258,7 @@ mintpy.topographicResidual.pixelwiseGeometry = auto  #[yes / no], auto for yes, 
 ########## 9.1 residual_RMS (root mean squares for noise evaluation)
 ## Calculate the Root Mean Square (RMS) of residual phase time-series for each acquisition
 ## reference: Yunjun et al. (2019, section 4.9 and 5.4)
-## To get rid of long wavelength component in space, a ramp is removed for each acquisition
+## To get rid of long spatial wavelength component, a ramp is removed for each acquisition
 ## Set optimal reference date to date with min RMS
 ## Set exclude dates (outliers) to dates with RMS > cutoff * median RMS (Median Absolute Deviation)
 mintpy.residualRMS.maskFile = auto  #[file name / no], auto for maskTempCoh.h5, mask for ramp estimation
@@ -289,8 +289,8 @@ mintpy.velocity.bootstrapCount = auto   #[int>1], auto for 400, number of iterat
 ########## 11.1 geocode (post-processing)
 # for input dataset in radar coordinates only
 # commonly used resolution in meters and in degrees (on equator)
-# 100,         60,          50,          30,          20,          10
-# 0.000925926, 0.000555556, 0.000462963, 0.000277778, 0.000185185, 0.000092593
+# 100,         90,          60,          50,          30,          20,          10
+# 0.000925926, 0.000833334, 0.000555556, 0.000462963, 0.000277778, 0.000185185, 0.000092593
 mintpy.geocode              = auto  #[yes / no], auto for yes
 mintpy.geocode.SNWE         = auto  #[-1.2,0.5,-92,-91 / none ], auto for none, output extent in degree
 mintpy.geocode.laloStep     = auto  #[-0.000555556,0.000555556 / None], auto for None, output resolution in degree

--- a/mintpy/iono_tec.py
+++ b/mintpy/iono_tec.py
@@ -25,8 +25,9 @@ SPEED_OF_LIGHT = 299792458 # m/s
 
 #####################################################################################
 REFERENCE = """references:
-  Yunjun, Z., Fattahi, H., Pi, X., Rosen, P., Simons, M., Agram, P., & Aoki, Y. (2022). Range Geolocation Accuracy
-    of C/L-band SAR and its Implications for Operational Stack Coregistration. IEEE Trans. Geosci. Remote Sens. 
+  Yunjun, Z., Fattahi, H., Pi, X., Rosen, P., Simons, M., Agram, P., & Aoki, Y. (2022). Range
+    Geolocation Accuracy of C/L-band SAR and its Implications for Operational Stack Coregistration.
+    IEEE Trans. Geosci. Remote Sens., doi:10.1109/TGRS.2022.3168509. 
   Schaer, S., Gurtner, W., & Feltens, J. (1998). IONEX: The ionosphere map exchange format version 1.1. 
     Paper presented at the Proceedings of the IGS AC workshop, Darmstadt, Germany, Darmstadt, Germany.
 """

--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -159,6 +159,16 @@ def get_gps_los_obs(meta, obs_type, site_names, start_date, end_date, gps_comp='
         fc = np.genfromtxt(csv_file, dtype=col_types, delimiter=',', names=True)
         site_obs = fc[col_names[obs_ind]]
 
+        # get obs for the input site names only
+        # in case the site_names are not consistent with the CSV file.
+        if num_row != num_site:
+            temp_names = fc[col_names[0]]
+            temp_obs = np.array(site_obs, dtype=np.float32)
+            site_obs = np.zeros(num_site, dtype=np.float32) * np.nan
+            for i, site_name in enumerate(site_names):
+                if site_name in temp_names:
+                    site_obs[i] = temp_obs[temp_names == site_name][0]
+
     else:
         # calculate and save to CSV file
         data_list = []

--- a/mintpy/objects/sensor.py
+++ b/mintpy/objects/sensor.py
@@ -16,7 +16,7 @@ SENSOR_NAME_VARIATION = {
     'csk'   : ['csk', 'csk1', 'csk2', 'csk3', 'csk4', 'cos', 'cosmo', 'cosmoskymed'],
     'env'   : ['env', 'envisat', 'asar'],
     'ers'   : ['ers', 'ers1', 'ers2', 'ers12'],
-    'gfen3' : ['gfen3', 'gaofen3', 'g3', 'gaofen'],
+    'gf3'   : ['gfen3', 'gaofen3', 'g3', 'gaofen'],
     'jers'  : ['jers', 'jers1'],
     'ksat5' : ['ksat5', 'kompsat5', 'kompsat', 'kmps5'],
     'ni'    : ['ni', 'nisar'],
@@ -281,6 +281,15 @@ RSAT2 = {
     'sampling_frequency'         : 112.68e6,  # Hz
     'azimuth_pixel_size'         : 2.2,       # m
     'ground_range_pixel_size'    : 2.1,       # m
+}
+
+# GaoFen-3 
+# Table 2 & 6 in https://directory.eoportal.org/web/eoportal/satellite-missions/g/gaofen-3
+GF3 = {
+    'carrier_frequency'          : 5.4e9,     # Hz
+    'altitude'                   : 755e3,     # m
+    'antenna_length'             : 15,        # m
+    'sampling_frequency'         : 533.33e6,  # Hz
 }
 
 # Sentinel-1 Interferometric Wide (IW / TOPS) swath mode

--- a/mintpy/plot_coherence_matrix.py
+++ b/mintpy/plot_coherence_matrix.py
@@ -269,7 +269,9 @@ class coherenceMatrixViewer():
             msg += 'temporal coherence: {:.2f}'.format(tcoh)
         vprint(msg)
 
-        self.fig.canvas.draw()
+        # update figure
+        self.fig.canvas.draw_idle()
+        self.fig.canvas.flush_events()
         return
 
     def update_coherence_matrix(self, event):

--- a/mintpy/save_kmz.py
+++ b/mintpy/save_kmz.py
@@ -574,7 +574,7 @@ def main(iargs=None):
     # disp min/max and colormap
     cmap_lut = 256
     if not inps.vlim:
-        cmap_lut, inps.vlim = pp.auto_adjust_colormap_lut_and_disp_limit(data)
+        cmap_lut, inps.vlim = pp.auto_adjust_colormap_lut_and_disp_limit(data)[:2]
     inps.colormap = pp.auto_colormap_name(atr, inps.colormap)
     inps.colormap = pp.ColormapExt(inps.colormap, cmap_lut).colormap
     inps.norm = colors.Normalize(vmin=inps.vlim[0], vmax=inps.vlim[1])

--- a/mintpy/simulation/iono.py
+++ b/mintpy/simulation/iono.py
@@ -47,8 +47,9 @@ SAR_BAND = {
 
 ######################## Ionospheric Mapping Functions #########################
 # Reference:
-#   Yunjun, Z., Fattahi, H., Pi, X., Rosen, P., Simons, M., Agram, P., & Aoki, Y. (2022). Range Geolocation Accuracy
-#     of C/L-band SAR and its Implications for Operational Stack Coregistration. IEEE Trans. Geosci. Remote Sens. 
+#   Yunjun, Z., Fattahi, H., Pi, X., Rosen, P., Simons, M., Agram, P., & Aoki, Y. (2022). Range
+#     Geolocation Accuracy of C/L-band SAR and its Implications for Operational Stack Coregistration.
+#     IEEE Trans. Geosci. Remote Sens., doi:10.1109/TGRS.2022.3168509.
 #   Schaer, S., Gurtner, W., & Feltens, J. (1998). IONEX: The ionosphere map exchange format version 1.1. 
 #     Paper presented at the Proceedings of the IGS AC workshop, Darmstadt, Germany, Darmstadt, Germany.
 

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -46,9 +46,11 @@ EXAMPLE = """example:
 """
 
 REFERENCE = """reference:
-  Milbert, D., Solid Earth Tide, http://geodesyworld.github.io/SOFTS/solid.htm, Accessd 2020 September 6.
-  Fattahi, H., Z. Yunjun, X. Pi, P. S. Agram, P. Rosen, and Y. Aoki (2020), Absolute geolocation of SAR 
-    Big-Data: The first step for operational InSAR time-series analysis, AGU Fall Meeting 2020, 1-17 Dec 2020.
+  Milbert, D. (2018), "solid: Solid Earth Tide", [Online]. Available: http://geodesyworld.github.io/
+    SOFTS/solid.htm. Accessd on: 2020-09-06.
+  Yunjun, Z., Fattahi, H., Pi, X., Rosen, P., Simons, M., Agram, P., & Aoki, Y. (2022). Range 
+    Geolocation Accuracy of C/L-band SAR and its Implications for Operational Stack Coregistration.
+    IEEE Trans. Geosci. Remote Sens., doi:10.1109/TGRS.2022.3168509.
 """
 
 def create_parser():
@@ -308,7 +310,7 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
 
     # loop for calc
     print('\n'+'-'*50)
-    print('calculating solid Earth tides using solid.for (D. Milbert, 2018) ...')
+    print('calculating solid Earth tides using PySolid (Milbert, 2018; Yunjun et al., 2022) ...')
     prog_bar = ptime.progressBar(maxValue=num_date, print_msg=not verbose)
     for i, dt_obj in enumerate(dt_objs):
         # calculate tide in ENU direction

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -45,22 +45,34 @@ def create_parser():
                              'i.e.: timeseries_ERA5_ramp_demErr.h5 (MintPy)\n'
                              '      LS-PARAMS.h5 (GIAnT)\n'
                              '      S1_IW12_128_0593_0597_20141213_20180619.he5 (HDF-EOS5)')
-    parser.add_argument('--label', dest='file_label', nargs='*', help='labels to display for multiple input files')
-    parser.add_argument('--ylim', dest='ylim', nargs=2, metavar=('YMIN', 'YMAX'), type=float, help='Y limits for point plotting.')
-    parser.add_argument('--tick-right', dest='tick_right', action='store_true', help='set tick and tick label to the right')
-    parser.add_argument('-l','--lookup', dest='lookup_file', type=str, help='lookup table file')
+    parser.add_argument('--label', dest='file_label', nargs='*',
+                        help='labels to display for multiple input files')
+    parser.add_argument('--ylim', dest='ylim', nargs=2, metavar=('YMIN', 'YMAX'), type=float,
+                        help='Y limits for point plotting.')
+    parser.add_argument('--tick-right', dest='tick_right', action='store_true',
+                        help='set tick and tick label to the right')
+    parser.add_argument('-l','--lookup', dest='lookup_file', type=str,
+                        help='lookup table file')
 
-    parser.add_argument('-n', dest='idx', metavar='NUM', type=int, help='Epoch/slice number for initial display.')
-    parser.add_argument('--error', dest='error_file', help='txt file with error for each date.')
+    parser.add_argument('-n', dest='idx', metavar='NUM', type=int,
+                        help='Epoch/slice number for initial display.')
+    parser.add_argument('--error', dest='error_file',
+                        help='txt file with error for each date.')
 
     # time info
-    parser.add_argument('--start-date', dest='start_date', type=str, help='start date of displacement to display')
-    parser.add_argument('--end-date', dest='end_date', type=str, help='end date of displacement to display')
-    parser.add_argument('--exclude', '--ex', dest='ex_date_list', nargs='*', default=['exclude_date.txt'], help='Exclude date shown as gray.')
-    parser.add_argument('--zf', '--zero-first', dest='zero_first', action='store_true', help='Set displacement at first acquisition to zero.')
-    parser.add_argument('--off','--offset', dest='offset', type=float, help='Offset for each timeseries file.')
+    parser.add_argument('--start-date', dest='start_date', type=str,
+                        help='start date of displacement to display')
+    parser.add_argument('--end-date', dest='end_date', type=str,
+                        help='end date of displacement to display')
+    parser.add_argument('--exclude', '--ex', dest='ex_date_list', nargs='*', default=['exclude_date.txt'],
+                        help='Exclude date shown as gray.')
+    parser.add_argument('--zf', '--zero-first', dest='zero_first', action='store_true',
+                        help='Set displacement at first acquisition to zero.')
+    parser.add_argument('--off','--offset', dest='offset', type=float,
+                        help='Offset for each timeseries file.')
 
-    parser.add_argument('--noverbose', dest='print_msg', action='store_false', help='Disable the verbose message printing.')
+    parser.add_argument('--noverbose', dest='print_msg', action='store_false',
+                        help='Disable the verbose message printing.')
 
     # temporal model fitting
     parser.add_argument('--nomodel', '--nofit', dest='plot_model', action='store_false',
@@ -68,19 +80,26 @@ def create_parser():
     parser.add_argument('--plot-model-conf-int', '--plot-fit-conf-int', dest='plot_model_conf_int', action='store_true',
                         help='Plot the time function prediction confidence intervals.\n'
                              '[!-- Preliminary feature alert! --!]\n'
-                             '[!-- This feature is NOT throughly checked. Read the code before use. Interpret at your own risk! --!]')
+                             '[!-- This feature is NOT throughly checked. '
+                             'Read the code before use. Interpret at your own risk! --!]')
 
     parser = arg_group.add_timefunc_argument(parser)
 
     # pixel of interest
     pixel = parser.add_argument_group('Pixel Input')
-    pixel.add_argument('--yx', type=int, metavar=('Y', 'X'), nargs=2, help='initial pixel to plot in Y/X coord')
-    pixel.add_argument('--lalo', type=float, metavar=('LAT', 'LON'), nargs=2, help='initial pixel to plot in lat/lon coord')
+    pixel.add_argument('--yx', type=int, metavar=('Y', 'X'), nargs=2,
+                       help='initial pixel to plot in Y/X coord')
+    pixel.add_argument('--lalo', type=float, metavar=('LAT', 'LON'), nargs=2,
+                       help='initial pixel to plot in lat/lon coord')
 
-    pixel.add_argument('--marker', type=str, default='o', help='marker style (default: %(default)s).')
-    pixel.add_argument('--ms', '--markersize', dest='marker_size', type=float, default=6.0, help='marker size (default: %(default)s).')
-    pixel.add_argument('--lw', '--linewidth', dest='linewidth', type=float, default=0, help='line width (default: %(default)s).')
-    pixel.add_argument('--ew', '--edgewidth', dest='edge_width', type=float, default=1.0, help='Edge width for the error bar (default: %(default)s)')
+    pixel.add_argument('--marker', type=str, default='o',
+                       help='marker style (default: %(default)s).')
+    pixel.add_argument('--ms', '--markersize', dest='marker_size', type=float, default=6.0,
+                       help='marker size (default: %(default)s).')
+    pixel.add_argument('--lw', '--linewidth', dest='linewidth', type=float, default=0,
+                       help='line width (default: %(default)s).')
+    pixel.add_argument('--ew', '--edgewidth', dest='edge_width', type=float, default=1.0,
+                       help='Edge width for the error bar (default: %(default)s)')
 
     # other groups
     parser = arg_group.add_data_disp_argument(parser)
@@ -778,7 +797,7 @@ class timeseriesViewer():
         self.plot_init_image(img_data)
 
         # Figure 1 - Axes 2 - Time Slider
-        self.ax_tslider = self.fig_img.add_axes([0.125, 0.1, 0.75, 0.07])
+        self.ax_tslider = self.fig_img.add_axes([0.125, 0.05, 0.75, 0.15])
         self.plot_init_time_slider(init_idx=self.idx, ref_idx=self.ref_idx)
         self.tslider.on_changed(self.update_time_slider)
 
@@ -792,8 +811,8 @@ class timeseriesViewer():
                 save_ts_data_and_plot(self.yx, d_ts, m_strs, self)
 
         # Final linking of the canvas to the plots.
-        self.fig_img.canvas.mpl_connect('button_press_event', self.update_plot_timeseries)
-        self.fig_img.canvas.mpl_connect('key_press_event', self.on_key_event)
+        self.fig_img.canvas.mpl_connect('button_press_event', self.update_point_timeseries)
+        self.fig_img.canvas.mpl_connect('key_press_event', self.update_image)
         if self.disp_fig:
             vprint('showing ...')
             msg = '\n------------------------------------------------------------------------'
@@ -806,6 +825,78 @@ class timeseriesViewer():
         return
 
 
+    ##---------- event functions
+    def update_point_timeseries(self, event):
+        """Event function to get y/x from button press"""
+        if event.inaxes == self.ax_img:
+            # get row/col number
+            if self.fig_coord == 'geo':
+                y, x = self.coord.geo2radar(event.ydata, event.xdata, print_msg=False)[0:2]
+            else:
+                y, x = int(event.ydata+0.5), int(event.xdata+0.5)
+
+            # plot time-series displacement
+            self.plot_point_timeseries((y, x))
+        return
+
+
+    def update_image(self, event):
+        """Slide images with left/right key on keyboard"""
+        if event.inaxes and event.inaxes.figure == self.fig_img:
+            idx = None
+            if event.key == 'left':
+                idx = max(self.idx - 1, 0)
+            elif event.key == 'right':
+                idx = min(self.idx + 1, self.num_date - 1)
+
+            if idx is not None and idx != self.idx:
+                # update title
+                disp_date = self.dates[idx].strftime('%Y-%m-%d')
+                sub_title = 'N = {n}, Time = {t}'.format(n=idx, t=disp_date)
+                self.ax_img.set_title(sub_title, fontsize=self.font_size)
+
+                # read data
+                data_img = np.array(self.ts_data[0][idx, :, :])
+                data_img[self.mask == 0] = np.nan
+                if self.wrap:
+                    if self.disp_unit_img == 'radian':
+                        data_img *= self.range2phase
+                    data_img = ut.wrap(data_img, wrap_range=self.wrap_range)
+
+                # update
+                self.tslider.set_val(self.yearList[idx]) # update slider
+                self.img.set_data(data_img)              # update image
+                self.idx = idx
+                self.fig_img.canvas.draw_idle()
+                self.fig_img.canvas.flush_events()
+        return
+
+
+    def update_time_slider(self, val):
+        """Update Displacement Map using Slider"""
+        idx = np.argmin(np.abs(np.array(self.yearList) - self.tslider.val))
+        # update title
+        disp_date = self.dates[idx].strftime('%Y-%m-%d')
+        sub_title = 'N = {n}, Time = {t}'.format(n=idx, t=disp_date)
+        self.ax_img.set_title(sub_title, fontsize=self.font_size)
+
+        # read data
+        data_img = np.array(self.ts_data[0][idx, :, :])
+        data_img[self.mask == 0] = np.nan
+        if self.wrap:
+            if self.disp_unit_img == 'radian':
+                data_img *= self.range2phase
+            data_img = ut.wrap(data_img, wrap_range=self.wrap_range)
+
+        # update data
+        self.img.set_data(data_img)
+        self.idx = idx
+        self.fig_img.canvas.draw_idle()
+        self.fig_img.canvas.flush_events()
+        return
+
+
+    ##---------- plot functions
     def plot_init_image(self, img_data):
         # prepare data
         if self.wrap:
@@ -841,48 +932,27 @@ class timeseriesViewer():
             valinit=self.yearList[init_idx],
             valmin=val_min,
             valmax=val_max,
-            valstep=val_step)
+            valstep=np.array(self.yearList),
+        )
 
-        bar_width = val_step / 4.
-        datex = np.array(self.yearList) - bar_width / 2.
-        self.tslider.ax.bar(datex, np.ones(len(datex)), bar_width, facecolor='black', ecolor=None)
-        if ref_idx is not None:
-            self.tslider.ax.bar(datex[ref_idx], 1., bar_width*3, facecolor='crimson', ecolor=None)
+        # plot vertical lines to mark the acquisition times
+        bar_width = val_step / 6.
+        num_val = len(self.yearList)
+        if num_val <= 100:
+            ymin, ymax = 0.25, 0.5
+            kwargs = dict(bottom=ymin, ecolor=None)
+            xdate = np.array(self.yearList)
+            self.tslider.ax.bar(xdate, np.ones(num_val)*ymax, width=bar_width, facecolor='black', **kwargs)
+            if ref_idx is not None:
+                self.tslider.ax.bar(xdate[ref_idx], ymax, width=bar_width*3, facecolor='crimson', **kwargs)
 
-        # xaxis tick format
-        if np.floor(val_max) == np.floor(val_min):
-            digit = 10.
-        else:
-            digit = 1.
-        self.tslider.ax.set_xticks(np.round(np.linspace(val_min, val_max, num=5) * digit) / digit)
-        self.tslider.ax.xaxis.set_minor_locator(ticker.MultipleLocator(1./12.))
-        self.tslider.ax.set_xlim([val_min, val_max])
+        # axis format
+        self.tslider.ax.set_xlim([val_min - bar_width / 2, val_max + bar_width / 2])
+        self.tslider.ax.set_ylim([0, 1])
         self.tslider.ax.set_yticks([])
         self.tslider.valtext.set_visible(False)   #hide slider values
         return self.tslider
 
-
-    def update_time_slider(self, val):
-        """Update Displacement Map using Slider"""
-        idx = np.argmin(np.abs(np.array(self.yearList) - self.tslider.val))
-        # update title
-        disp_date = self.dates[idx].strftime('%Y-%m-%d')
-        sub_title = 'N = {n}, Time = {t}'.format(n=idx, t=disp_date)
-        self.ax_img.set_title(sub_title, fontsize=self.font_size)
-
-        # read data
-        data_img = np.array(self.ts_data[0][idx, :, :])
-        data_img[self.mask == 0] = np.nan
-        if self.wrap:
-            if self.disp_unit_img == 'radian':
-                data_img *= self.range2phase
-            data_img = ut.wrap(data_img, wrap_range=self.wrap_range)
-
-        # update data
-        self.img.set_data(data_img)
-        self.idx = idx
-        self.fig_img.canvas.draw()
-        return
 
     def plot_point_timeseries(self, yx):
         """Plot point displacement time-series at pixel [y, x]
@@ -987,54 +1057,12 @@ class timeseriesViewer():
                 vprint(f'    {m_str}')
 
             # update figure
-            self.fig_pts.canvas.draw()
+            # use fig.canvas.draw_idel() instead of fig.canvas.draw()
+            # reference: https://stackoverflow.com/questions/64789437
+            self.fig_pts.canvas.draw_idle()
+            self.fig_pts.canvas.flush_events()
 
         return ts_dis, m_strs
-
-
-    def update_plot_timeseries(self, event):
-        """Event function to get y/x from button press"""
-        if event.inaxes == self.ax_img:
-            # get row/col number
-            if self.fig_coord == 'geo':
-                y, x = self.coord.geo2radar(event.ydata, event.xdata, print_msg=False)[0:2]
-            else:
-                y, x = int(event.ydata+0.5), int(event.xdata+0.5)
-
-            # plot time-series displacement
-            self.plot_point_timeseries((y, x))
-        return
-
-
-    def on_key_event(self, event):
-        """Slide images with left/right key on keyboard"""
-        if event.inaxes and event.inaxes.figure == self.fig_img:
-            idx = None
-            if event.key == 'left':
-                idx = max(self.idx - 1, 0)
-            elif event.key == 'right':
-                idx = min(self.idx + 1, self.num_date - 1)
-
-            if idx is not None and idx != self.idx:
-                # update title
-                disp_date = self.dates[idx].strftime('%Y-%m-%d')
-                sub_title = 'N = {n}, Time = {t}'.format(n=idx, t=disp_date)
-                self.ax_img.set_title(sub_title, fontsize=self.font_size)
-
-                # read data
-                data_img = np.array(self.ts_data[0][idx, :, :])
-                data_img[self.mask == 0] = np.nan
-                if self.wrap:
-                    if self.disp_unit_img == 'radian':
-                        data_img *= self.range2phase
-                    data_img = ut.wrap(data_img, wrap_range=self.wrap_range)
-
-                # update
-                self.tslider.set_val(self.yearList[idx]) # update slider
-                self.img.set_data(data_img)              # update image
-                self.idx = idx
-                self.fig_img.canvas.draw()
-        return
 
 
 ###########################################################################################

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -447,7 +447,7 @@ def read_timeseries_data(inps):
     if not inps.vlim:
         inps.cmap_lut, inps.vlim = pp.auto_adjust_colormap_lut_and_disp_limit(ts_data[0],
                                                                               num_multilook=10,
-                                                                              print_msg=inps.print_msg)
+                                                                              print_msg=inps.print_msg)[:2]
     vprint('data    range: {} {}'.format(inps.dlim, inps.disp_unit))
     vprint('display range: {} {}'.format(inps.vlim, inps.disp_unit))
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -124,7 +124,7 @@ def add_inner_title(ax, title, loc, prop=None, **kwargs):
 
 
 def auto_figure_size(ds_shape, scale=1.0, disp_cbar=False, disp_slider=False,
-                     cbar_ratio=0.25, slider_ratio=0.30, print_msg=True):
+                     cbar_ratio=0.25, slider_ratio=0.15, print_msg=True):
     """Get auto figure size based on input data shape
     Adjust if display colobar on the right and/or slider on the bottom
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -1117,6 +1117,44 @@ def plot_colorbar(inps, im, cax):
     return inps, cbar
 
 
+def add_arrow(line, position=None, direction='right', size=15, color=None):
+    """Add an arrow to a line.
+
+    Link: https://stackoverflow.com/questions/34017866
+
+    Parameters: line      - Line2D object
+                position  - x-position of the arrow. If None, mean of xdata is taken
+                direction - 'left' or 'right'
+                size      - size of the arrow in fontsize points
+                color     - if None, line color is taken.
+    Returns:    ann       - matplotlib.text.Annotation object
+    """
+    if color is None:
+        color = line.get_color()
+
+    xdata = line.get_xdata()
+    ydata = line.get_ydata()
+
+    if position is None:
+        position = xdata.mean()
+
+    # find closest index
+    start_ind = np.argmin(np.absolute(xdata - position))
+    if direction == 'right':
+        end_ind = start_ind + 1
+    else:
+        end_ind = start_ind - 1
+
+    ann = line.axes.annotate('',
+        xytext=(xdata[start_ind], ydata[start_ind]),
+        xy=(xdata[end_ind], ydata[end_ind]),
+        arrowprops=dict(arrowstyle="->", color=color, linestyle='--'),
+        size=size,
+    )
+
+    return ann
+
+
 
 ##################### Data Scale based on Unit and Wrap Range ##################
 def check_disp_unit_and_wrap(metadata, disp_unit=None, wrap=False, wrap_range=[-1.*np.pi, np.pi], print_msg=True):

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -15,6 +15,20 @@ from mintpy.objects.progress import progressBar
 
 
 ################################################################
+def get_compact_isoformat(date_str):
+    """Get the "compact-looking" isoformat of the input datetime string.
+    Parameters: date_str   - str, an example date string
+    Returns:    iso_format - str, date string in "compact" iso format
+    """
+    date_str = date_str[0] if isinstance(date_str, list) else date_str
+    iso_format = get_date_str_format(date_str)
+    iso_format = iso_format.replace('y', 'Y')
+    iso_format = iso_format.replace('%Y%m%d', '%Y-%m-%d')
+    iso_format = iso_format.replace('%H%M%S', '%H:%M:%S')
+    iso_format = iso_format.replace('%H%M',   '%H:%M')
+    return iso_format
+
+
 def get_date_str_format(date_str):
     """Get the datetime string format as defined in:
     https://docs.python.org/3.7/library/datetime.html#strftime-and-strptime-behavior
@@ -25,8 +39,7 @@ def get_date_str_format(date_str):
                             YYMMDD
     Returns:    date_str_format - str, datetime string format
     """
-    if isinstance(date_str, list):
-        date_str = date_str[0]
+    date_str = date_str[0] if isinstance(date_str, list) else date_str
 
     try:
         date_str = date_str.decode('utf8')

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -228,10 +228,10 @@ def read_timeseries_yx(y, x, ts_file, ref_y=None, ref_x=None, zero_first=True,
         pass
     elif unit == 'cm':
         dis *= 100.
-        dis_std *= 100.
+        dis_std = None if dis_std is None else dis_std * 100.
     elif unit == 'mm':
         dis *= 1000.
-        dis_std *= 1000.
+        dis_std = None if dis_std is None else dis_std * 1000.
     else:
         raise ValueError('un-supported output unit: {}'.format(unit))
 

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -488,7 +488,9 @@ def update_data_with_plot_inps(data, metadata, inps):
     # 4. update display min/max
     inps.dlim = [np.nanmin(data), np.nanmax(data)]
     if not inps.vlim: # and data.ndim < 3:
-        inps.cmap_lut, inps.vlim = pp.auto_adjust_colormap_lut_and_disp_limit(data, print_msg=inps.print_msg)
+        (inps.cmap_lut,
+         inps.vlim,
+         inps.unique_values) = pp.auto_adjust_colormap_lut_and_disp_limit(data, print_msg=inps.print_msg)
     vprint('data    range: {} {}'.format(inps.dlim, inps.disp_unit))
     vprint('display range: {} {}'.format(inps.vlim, inps.disp_unit))
 
@@ -1146,9 +1148,11 @@ def read_data4figure(i_start, i_end, inps, metadata):
             and all(arg not in inps.argv for arg in ['-v', '--vlim', '--wrap'])
             and not (inps.dsetFamilyList[0].startswith('unwrap') and not inps.file_ref_yx)
             and inps.dsetFamilyList[0] not in ['bperp']):
-        inps.cmap_lut, inps.vlim = pp.auto_adjust_colormap_lut_and_disp_limit(data,
-                                                                              num_multilook=10,
-                                                                              print_msg=False)
+        (inps.cmap_lut,
+         inps.vlim,
+         inps.unique_values) = pp.auto_adjust_colormap_lut_and_disp_limit(data,
+                                                                          num_multilook=10,
+                                                                          print_msg=False)
 
     return data
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds two changes to `tsview.py`:

+ replace fig.canvas.draw() with "fig.canvas.draw_idle()" and "fig.canvas.flush_events()", as recommended by matplotlib (https://matplotlib.org/stable/users/explain/interactive_guide.html). This fixed the non-resposive point TS plot, with the latest version of matplotlib version 3.5.1. It's unknown since which version of matplotlib that this behavior change started to happen.

+ switch to a new "narrow-looking" slider in tsview.py, as shown below

<img width="800" alt="Screen Shot 2022-04-22 at 2 47 40 PM" src="https://user-images.githubusercontent.com/13143710/164816031-a8a728b9-8380-445a-98e8-59fe6ca55d88.png">

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1082/workflows/85e9c625-7c8c-4aa3-bcf4-8f057d781cd4/jobs/1082) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.