### PR TITLE
use `sh` instead of `bash` in `load_data_aoi.sh`

### DIFF
--- a/mintpy/sh/load_data_aoi.sh
+++ b/mintpy/sh/load_data_aoi.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # Extract input datasets in mintpy/inputs for an area of interest (AOI) from the one of the whole frame
 # Parameters: SNWE : string for the AOI
 #             step : string/number, output resolution in degree


### PR DESCRIPTION
**Use the correct shell in the shebang string**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

The `mintpy/sh/load_data_aoi.sh` script is supposed to work with a standard unix `sh` shell but it actually contain some statements using a `bash` specific syntax.

```
$ sh -n mintpy/sh/load_data_aoi.sh 
mintpy/sh/load_data_aoi.sh: 49: Syntax error: redirection unexpected
```

**Reminders**

- [ ] Fix #xxxx
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
