### PR TITLE
load ionosphere stack from isce2/topsStack

### DIFF
--- a/docs/api/data_structure.md
+++ b/docs/api/data_structure.md
@@ -75,7 +75,6 @@ Attributes         Dictionary for metadata
 /unwrapPhase       3D array of float32 in size of (m, l, w) in radian.
 /coherence         3D array of float32 in size of (m, l, w).
 /connectComponent  3D array of int16   in size of (m, l, w).
-/ionoPhase         3D array of float32 in size of (m, l, w) in radian.
 /wrapPhase         3D array of float32 in size of (m, l, w) in radian.
 /azimuthOffset     3D array of float32 in size of (m, l, w) in pixel number.
 /azimuthOffsetStd  3D array of float32 in size of (m, l, w) in pixel number.

--- a/mintpy/defaults/auto_path.py
+++ b/mintpy/defaults/auto_path.py
@@ -16,90 +16,92 @@ import numpy as np
 
 # Default path of data files from different InSAR processors to be loaded into MintPy
 AUTO_PATH_ISCE_TOPS = '''##----------Default file path of ISCE/topsStack products
-mintpy.load.processor      = isce
-mintpy.load.metaFile       = ../reference/IW*.xml
-mintpy.load.baselineDir    = ../baselines
+mintpy.load.processor       = isce
+mintpy.load.metaFile        = ../reference/IW*.xml
+mintpy.load.baselineDir     = ../baselines
 
-mintpy.load.unwFile        = ../merged/interferograms/*/filt*.unw
-mintpy.load.corFile        = ../merged/interferograms/*/filt*.cor
-mintpy.load.connCompFile   = ../merged/interferograms/*/filt*.unw.conncomp
-mintpy.load.ionoFile       = None
-mintpy.load.intFile        = None
+mintpy.load.unwFile         = ../merged/interferograms/*/filt*.unw
+mintpy.load.corFile         = ../merged/interferograms/*/filt*.cor
+mintpy.load.connCompFile    = ../merged/interferograms/*/filt*.unw.conncomp
+mintpy.load.intFile         = None
 
-mintpy.load.demFile        = ../merged/geom_reference/hgt.rdr
-mintpy.load.lookupYFile    = ../merged/geom_reference/lat.rdr
-mintpy.load.lookupXFile    = ../merged/geom_reference/lon.rdr
-mintpy.load.incAngleFile   = ../merged/geom_reference/los.rdr
-mintpy.load.azAngleFile    = ../merged/geom_reference/los.rdr
-mintpy.load.shadowMaskFile = ../merged/geom_reference/shadowMask.rdr
-mintpy.load.waterMaskFile  = ../merged/geom_reference/waterMask.rdr
-mintpy.load.bperpFile      = None
+mintpy.load.ionUnwFile      = ../ion/*/ion_cal/filt.ion
+mintpy.load.ionCorFile      = ../ion/*/ion_cal/raw_no_projection.cor
+mintpy.load.ionConnCompFile = None
+
+mintpy.load.demFile         = ../merged/geom_reference/hgt.rdr
+mintpy.load.lookupYFile     = ../merged/geom_reference/lat.rdr
+mintpy.load.lookupXFile     = ../merged/geom_reference/lon.rdr
+mintpy.load.incAngleFile    = ../merged/geom_reference/los.rdr
+mintpy.load.azAngleFile     = ../merged/geom_reference/los.rdr
+mintpy.load.shadowMaskFile  = ../merged/geom_reference/shadowMask.rdr
+mintpy.load.waterMaskFile   = ../merged/geom_reference/waterMask.rdr
+mintpy.load.bperpFile       = None
 '''
 
 AUTO_PATH_ISCE_STRIPMAP = '''##----------Default file path of ISCE/stripmapStack products
-mintpy.load.processor      = isce
-mintpy.load.metaFile       = ${m_shelve}/data.dat
-mintpy.load.baselineDir    = ../baselines
+mintpy.load.processor       = isce
+mintpy.load.metaFile        = ${m_shelve}/data.dat
+mintpy.load.baselineDir     = ../baselines
 
-mintpy.load.unwFile        = ../Igrams/*/filt*.unw
-mintpy.load.corFile        = ../Igrams/*/filt*.cor
-mintpy.load.connCompFile   = ../Igrams/*/filt*.unw.conncomp
-mintpy.load.ionoFile       = None
-mintpy.load.intFile        = None
+mintpy.load.unwFile         = ../Igrams/*/filt*.unw
+mintpy.load.corFile         = ../Igrams/*/filt*.cor
+mintpy.load.connCompFile    = ../Igrams/*/filt*.unw.conncomp
+mintpy.load.intFile         = None
 
-mintpy.load.demFile        = ../geom_reference/hgt.rdr
-mintpy.load.lookupYFile    = ../geom_reference/lat.rdr
-mintpy.load.lookupXFile    = ../geom_reference/lon.rdr
-mintpy.load.incAngleFile   = ../geom_reference/los.rdr
-mintpy.load.azAngleFile    = ../geom_reference/los.rdr
-mintpy.load.shadowMaskFile = ../geom_reference/shadowMask.rdr
-mintpy.load.waterMaskFile  = ../geom_reference/waterMask.rdr
-mintpy.load.bperpFile      = None
+mintpy.load.demFile         = ../geom_reference/hgt.rdr
+mintpy.load.lookupYFile     = ../geom_reference/lat.rdr
+mintpy.load.lookupXFile     = ../geom_reference/lon.rdr
+mintpy.load.incAngleFile    = ../geom_reference/los.rdr
+mintpy.load.azAngleFile     = ../geom_reference/los.rdr
+mintpy.load.shadowMaskFile  = ../geom_reference/shadowMask.rdr
+mintpy.load.waterMaskFile   = ../geom_reference/waterMask.rdr
+mintpy.load.bperpFile       = None
 '''
 
 AUTO_PATH_ROIPAC = '''##----------Default file path of ROI_PAC products
-mintpy.load.processor      = roipac
-mintpy.load.unwFile        = ../PROCESS/DONE/IFG*/filt*.unw
-mintpy.load.corFile        = ../PROCESS/DONE/IFG*/filt*.cor
-mintpy.load.connCompFile   = ../PROCESS/DONE/IFG*/filt*snap_connect.byt
+mintpy.load.processor       = roipac
+mintpy.load.unwFile         = ../PROCESS/DONE/IFG*/filt*.unw
+mintpy.load.corFile         = ../PROCESS/DONE/IFG*/filt*.cor
+mintpy.load.connCompFile    = ../PROCESS/DONE/IFG*/filt*snap_connect.byt
 
-mintpy.load.demFile        = ../PROCESS/DONE/*${m_date12}*/radar_*rlks.hgt
-mintpy.load.lookupYFile    = ../PROCESS/GEO/geo_${m_date12}/geomap_*rlks.trans
-mintpy.load.lookupXFile    = ../PROCESS/GEO/geo_${m_date12}/geomap_*rlks.trans
-mintpy.load.incAngleFile   = None
-mintpy.load.azAngleFile    = None
-mintpy.load.shadowMaskFile = None
-mintpy.load.bperpFile      = None
+mintpy.load.demFile         = ../PROCESS/DONE/*${m_date12}*/radar_*rlks.hgt
+mintpy.load.lookupYFile     = ../PROCESS/GEO/geo_${m_date12}/geomap_*rlks.trans
+mintpy.load.lookupXFile     = ../PROCESS/GEO/geo_${m_date12}/geomap_*rlks.trans
+mintpy.load.incAngleFile    = None
+mintpy.load.azAngleFile     = None
+mintpy.load.shadowMaskFile  = None
+mintpy.load.bperpFile       = None
 '''
 
 AUTO_PATH_GAMMA = '''##----------Default file path of GAMMA products
-mintpy.load.processor      = gamma
-mintpy.load.unwFile        = ../PROCESS/DONE/IFG*/diff*rlks.unw
-mintpy.load.corFile        = ../PROCESS/DONE/IFG*/*filt*rlks.cor
-mintpy.load.connCompFile   = None
+mintpy.load.processor       = gamma
+mintpy.load.unwFile         = ../PROCESS/DONE/IFG*/diff*rlks.unw
+mintpy.load.corFile         = ../PROCESS/DONE/IFG*/*filt*rlks.cor
+mintpy.load.connCompFile    = None
 
-mintpy.load.demFile        = ../PROCESS/SIM/sim_${m_date12}/sim*.hgt_sim
-mintpy.load.lookupYFile    = ../PROCESS/SIM/sim_${m_date12}/sim*.UTM_TO_RDC
-mintpy.load.lookupXFile    = ../PROCESS/SIM/sim_${m_date12}/sim*.UTM_TO_RDC
-mintpy.load.incAngleFile   = None
-mintpy.load.azAngleFile    = None
-mintpy.load.shadowMaskFile = None
-mintpy.load.bperpFile      = ../merged/baselines/*/*.base_perp
+mintpy.load.demFile         = ../PROCESS/SIM/sim_${m_date12}/sim*.hgt_sim
+mintpy.load.lookupYFile     = ../PROCESS/SIM/sim_${m_date12}/sim*.UTM_TO_RDC
+mintpy.load.lookupXFile     = ../PROCESS/SIM/sim_${m_date12}/sim*.UTM_TO_RDC
+mintpy.load.incAngleFile    = None
+mintpy.load.azAngleFile     = None
+mintpy.load.shadowMaskFile  = None
+mintpy.load.bperpFile       = ../merged/baselines/*/*.base_perp
 '''
 
 AUTO_PATH_ARIA = '''##----------Default file path of ARIA products
-mintpy.load.processor      = aria
-mintpy.load.unwFile        = ../stack/unwrapStack.vrt
-mintpy.load.corFile        = ../stack/cohStack.vrt
-mintpy.load.connCompFile   = ../stack/connCompStack.vrt
+mintpy.load.processor       = aria
+mintpy.load.unwFile         = ../stack/unwrapStack.vrt
+mintpy.load.corFile         = ../stack/cohStack.vrt
+mintpy.load.connCompFile    = ../stack/connCompStack.vrt
 
-mintpy.load.demFile        = ../DEM/*.dem
-mintpy.load.lookupYFile    = None
-mintpy.load.lookupXFile    = None
-mintpy.load.incAngleFile   = ../incidenceAngle/*.vrt
-mintpy.load.azAngleFile    = ../azimuthAngle/*.vrt
-mintpy.load.shadowMaskFile = None
-mintpy.load.waterMaskFile  = ../mask/watermask.msk
+mintpy.load.demFile         = ../DEM/*.dem
+mintpy.load.lookupYFile     = None
+mintpy.load.lookupXFile     = None
+mintpy.load.incAngleFile    = ../incidenceAngle/*.vrt
+mintpy.load.azAngleFile     = ../azimuthAngle/*.vrt
+mintpy.load.shadowMaskFile  = None
+mintpy.load.waterMaskFile   = ../mask/watermask.msk
 '''
 
 

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -33,20 +33,23 @@ mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
 ##---------for ISCE only:
 mintpy.load.metaFile       = auto  #[path of common metadata file for the stack], i.e.: ./reference/IW1.xml, ./referenceShelve/data.dat
 mintpy.load.baselineDir    = auto  #[path of the baseline dir], i.e.: ./baselines
-##---------interferogram datasets:
+##---------interferogram stack:
 mintpy.load.unwFile        = auto  #[path pattern of unwrapped interferogram files]
 mintpy.load.corFile        = auto  #[path pattern of spatial coherence       files]
 mintpy.load.connCompFile   = auto  #[path pattern of connected components    files], optional but recommended
 mintpy.load.intFile        = auto  #[path pattern of wrapped interferogram   files], optional
-mintpy.load.ionoFile       = auto  #[path pattern of ionospheric delay       files], optional
 mintpy.load.magFile        = auto  #[path pattern of interferogram magnitude files], optional
-##---------offset datasets (optional):
-mintpy.load.azOffFile      = auto  #[path pattern of azimuth offset file], optional
-mintpy.load.rgOffFile      = auto  #[path pattern of range   offset file], optional
-mintpy.load.azOffStdFile   = auto  #[path pattern of azimuth offset variance file], optional
-mintpy.load.rgOffStdFile   = auto  #[path pattern of range   offset variance file], optional
+##---------ionosphere stack (optional):
+mintpy.load.ionUnwFile        = auto  #[path pattern of unwrapped interferogram files]
+mintpy.load.ionCorFile        = auto  #[path pattern of spatial coherence       files]
+mintpy.load.ionConnCompFile   = auto  #[path pattern of connected components    files], optional but recommended
+##---------offset stack (optional):
+mintpy.load.azOffFile      = auto  #[path pattern of azimuth offset file]
+mintpy.load.rgOffFile      = auto  #[path pattern of range   offset file]
+mintpy.load.azOffStdFile   = auto  #[path pattern of azimuth offset variance file], optional but recommended
+mintpy.load.rgOffStdFile   = auto  #[path pattern of range   offset variance file], optional but recommended
 mintpy.load.offSnrFile     = auto  #[path pattern of offset signal-to-noise ratio file], optional
-##---------geometry datasets:
+##---------geometry:
 mintpy.load.demFile        = auto  #[path of DEM file]
 mintpy.load.lookupYFile    = auto  #[path of latitude /row   /y coordinate file], not required for geocoded data
 mintpy.load.lookupXFile    = auto  #[path of longitude/column/x coordinate file], not required for geocoded data

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -187,16 +187,18 @@ def cmd_line_parse(iargs=None):
     # --output option
     if not inps.outfile:
         if inps.obsDatasetName.startswith('unwrapPhase'):
-            inps.outfile = ['timeseries.h5', 'temporalCoherence.h5', 'numInvIfgram.h5']
+            if os.path.basename(inps.ifgramStackFile).startswith('ion'):
+                inps.outfile = ['ion.h5', 'temporalCoherence_ion.h5', 'numInv_ion.h5']
+                for i in range(len(inps.outfile)):
+                    inps.outfile[i] = os.path.join(os.path.dirname(inps.ifgramStackFile), inps.outfile[i])
+            else:
+                inps.outfile = ['timeseries.h5', 'temporalCoherence.h5', 'numInvIfgram.h5']
 
         elif inps.obsDatasetName.startswith('azimuthOffset'):
             inps.outfile = ['timeseriesAz.h5', 'residualInvAz.h5', 'numInvOffAz.h5']
 
         elif inps.obsDatasetName.startswith('rangeOffset'):
             inps.outfile = ['timeseriesRg.h5', 'residualInvRg.h5', 'numInvOffRg.h5']
-
-        elif inps.obsDatasetName.startswith('ion'):
-            inps.outfile = ['timeseriesIon.h5', 'temporalCoherenceIon.h5', 'numInvIon.h5']
 
         else:
             raise ValueError('un-recognized input observation dataset name: {}'.format(inps.obsDatasetName))

--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -188,9 +188,7 @@ def cmd_line_parse(iargs=None):
     if not inps.outfile:
         if inps.obsDatasetName.startswith('unwrapPhase'):
             if os.path.basename(inps.ifgramStackFile).startswith('ion'):
-                inps.outfile = ['ion.h5', 'temporalCoherence_ion.h5', 'numInv_ion.h5']
-                for i in range(len(inps.outfile)):
-                    inps.outfile[i] = os.path.join(os.path.dirname(inps.ifgramStackFile), inps.outfile[i])
+                inps.outfile = ['timeseriesIon.h5', 'temporalCoherenceIon.h5', 'numInvIon.h5']
             else:
                 inps.outfile = ['timeseries.h5', 'temporalCoherence.h5', 'numInvIfgram.h5']
 

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -239,15 +239,14 @@ def read_inps2dict(inps):
 
     # copy dset_name2template_key info into iDict
     if inps.only_load_ionosphere:
-        dset_name2template_key = ION_DSET_NAME2TEMPLATE_KEY
+        iDict['dset_name2template_key'] = {
+            **ION_DSET_NAME2TEMPLATE_KEY,
+            **GEOMETRY_DSET_NAME2TEMPLATE_KEY}
     else:
-        dset_name2template_key = IFGRAM_DSET_NAME2TEMPLATE_KEY
-    dset_name2template_key = {
-        **dset_name2template_key,
-        **OFFSET_DSET_NAME2TEMPLATE_KEY,
-        **GEOMETRY_DSET_NAME2TEMPLATE_KEY,
-    }
-    iDict['dset_name2template_key'] = dset_name2template_key
+        iDict['dset_name2template_key'] = {
+            **IFGRAM_DSET_NAME2TEMPLATE_KEY,
+            **OFFSET_DSET_NAME2TEMPLATE_KEY,
+            **GEOMETRY_DSET_NAME2TEMPLATE_KEY}
 
     return iDict
 
@@ -746,10 +745,9 @@ def prepare_metadata(iDict):
         geom_dir = os.path.dirname(iDict['mintpy.load.demFile'])
 
         # --dset-dir / --file-pattern
-        obs_keys = ['mintpy.load.unwFile', 'mintpy.load.rgOffFile', 'mintpy.load.azOffFile']
-        if iDict['only_load_ionosphere']:
-            obs_keys = ['mintpy.load.ionUnwFile']
-        obs_keys = [i for i in obs_keys if i in iDict.keys()]
+        obs_keys = ['mintpy.load.unwFile', 'mintpy.load.ionUnwFile',
+                    'mintpy.load.rgOffFile', 'mintpy.load.azOffFile']
+        obs_keys = [i for i in obs_keys if i in iDict['dset_name2template_key'].values()]
         obs_paths = [iDict[key] for key in obs_keys if iDict[key].lower() != 'auto']
         if len(obs_paths) > 0:
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -64,7 +64,9 @@ ifgramDatasetNames = [
     'coherence',
     'connectComponent',
     'wrapPhase',
-    'ionoPhase',
+    'ionUnwrapPhase',
+    'ionCoherence',
+    'ionConnectComponent',
     'magnitude',
     'azimuthOffset',
     'azimuthOffsetStd',
@@ -80,7 +82,9 @@ datasetUnitDict = {
     'coherence'        : '1',
     'connectComponent' : '1',
     'wrapPhase'        : 'radian',
-    'ionoPhase'        : 'radian',
+    'ionUnwrapPhase'   : 'radian',
+    'ionCoherence'     : '1',
+    'ionConnectComponent' : '1',
     'magnitude'        : '1',
 
     # offset

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -57,6 +57,7 @@ geometryDatasetNames = [
 ]
 
 ifgramDatasetNames = [
+    # interferogram
     'unwrapPhase',
     'unwrapPhase_bridging_phaseClosure',
     'unwrapPhase_bridging',
@@ -64,10 +65,8 @@ ifgramDatasetNames = [
     'coherence',
     'connectComponent',
     'wrapPhase',
-    'ionUnwrapPhase',
-    'ionCoherence',
-    'ionConnectComponent',
     'magnitude',
+    # offset
     'azimuthOffset',
     'azimuthOffsetStd',
     'rangeOffset',
@@ -82,9 +81,6 @@ datasetUnitDict = {
     'coherence'        : '1',
     'connectComponent' : '1',
     'wrapPhase'        : 'radian',
-    'ionUnwrapPhase'   : 'radian',
-    'ionCoherence'     : '1',
-    'ionConnectComponent' : '1',
     'magnitude'        : '1',
 
     # offset

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -79,6 +79,11 @@ class ifgramStackDict:
         self.date12List = ['{}_{}'.format(i[0], i[1]) for i in pairs]
         return self.date12List
 
+    def get_dataset_list(self):
+        ifgramObj = [x for x in self.pairsDict.values()][0]
+        dsetList = [x for x in ifgramObj.datasetDict.keys()]
+        return dsetList
+
     def get_metadata(self):
         ifgramObj = [v for v in self.pairsDict.values()][0]
         self.metadata = ifgramObj.get_metadata(family=self.dsName0)

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -792,8 +792,8 @@ class platformTrack:
         for pair in pairs:
             length.append(self.pairs[pair].length)
             width.append(self.pairs[pair].width)
-        self.length = median(length)
-        self.width = median(width)
+        self.length = np.median(length)
+        self.width = np.median(width)
 
     def getDatasetNames(self):
         # extract the name of the datasets which are actually the keys of

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -240,7 +240,7 @@ class ifgramStackDict:
 class ifgramDict:
     """
     Ifgram object for a single InSAR pair of interferogram. It includes dataset name (family) of:
-        'unwrapPhase','coherence','connectComponent','wrapPhase','ionoPhase','rangeOffset','azimuthOffset', etc.
+        'unwrapPhase','coherence','connectComponent','wrapPhase','rangeOffset','azimuthOffset', etc.
 
     Example:
         from mintpy.objects.insarobj import ifgramDict
@@ -248,7 +248,6 @@ class ifgramDict:
                        'coherence'       :'$PROJECT_DIR/merged/interferograms/20151220_20160206/filt_fine.cor',
                        'connectComponent':'$PROJECT_DIR/merged/interferograms/20151220_20160206/filt_fine.unw.conncomp',
                        'wrapPhase'       :'$PROJECT_DIR/merged/interferograms/20151220_20160206/filt_fine.int',
-                       'ionoPhase'       :'$PROJECT_DIR/merged/ionosphere/20151220_20160206/iono.bil.unwCor.filt',
                        'magnitude'       :'$PROJECT_DIR/merged/interferograms/20151220_20160206/filt_fine.unw',
                        ...
                       }

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -182,9 +182,10 @@ def read_network_info(inps):
             inps.cohList = stack_obj.tbaseIfgram.tolist()
 
         else:
-            inps.cohList = [0.7] * stack_obj.get_size()[0]
-            print(f'{inps.dsetName} NOT found in file: {inps.file}! Fill 0.7 as dummy!')
-            #raise ValueError(f'{inps.dsetName} NOT found in file: {inps.file}!')
+            inps.cohList = None
+            msg = f'{inps.dsetName} NOT found in file: {inps.file}! '
+            msg += 'Disable the color coding and continue'
+            print(msg)
 
     elif ext == '.txt':
         inps.date12List = np.loadtxt(inps.file, dtype=bytes).astype(str)[:,0].tolist()
@@ -267,22 +268,26 @@ def main(iargs=None):
 
     # Plot settings
     inps = check_colormap(inps)
+    ext = '.pdf'
     if os.path.basename(inps.file).startswith('ion'):
-        ext = '_ion.pdf'
-    else:
-        ext = '.pdf'
+        ext = f'_ion{ext}'
+    kwargs = dict(bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+
     if inps.dsetName == 'coherence':
         fig_names = [i+ext for i in ['pbaseHistory', 'coherenceHistory', 'coherenceMatrix', 'network']]
         inps.ds_name = 'Coherence'
         inps.cbar_label = 'Average Spatial Coherence'
+
     elif inps.dsetName == 'offsetSNR':
         fig_names = [i+ext for i in ['pbaseHistory', 'SNRHistory', 'SNRMatrix', 'network']]
         inps.ds_name = 'SNR'
         inps.cbar_label = 'Average Spatial SNR'
+
     elif inps.dsetName == 'tbase':
         fig_names = [i+ext for i in ['pbaseHistory', 'tbaseHistory', 'tbaseMatrix', 'network']]
         inps.ds_name = 'Temporal Baseline'
         inps.cbar_label = 'Temporal Baseline [day]'
+
     elif inps.dsetName == 'pbase':
         fig_names = [i+ext for i in ['pbaseHistory', 'pbaseRangeHistory', 'pbaseMatrix', 'network']]
         inps.ds_name = 'Perp Baseline'
@@ -296,7 +301,7 @@ def main(iargs=None):
                                     vars(inps),
                                     inps.dateList_drop)
     if inps.save_fig:
-        fig.savefig(fig_names[0], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+        fig.savefig(fig_names[0], **kwargs)
         print('save figure to {}'.format(fig_names[0]))
 
     if inps.cohList is not None:
@@ -307,7 +312,7 @@ def main(iargs=None):
                                        inps.cohList,
                                        p_dict=vars(inps))
         if inps.save_fig:
-            fig.savefig(fig_names[1], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+            fig.savefig(fig_names[1], **kwargs)
             print('save figure to {}'.format(fig_names[2]))
 
         # Fig 3 - Coherence Matrix
@@ -318,7 +323,7 @@ def main(iargs=None):
                                       inps.date12List_drop,
                                       p_dict=vars(inps))[0]
         if inps.save_fig:
-            fig.savefig(fig_names[2], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+            fig.savefig(fig_names[2], **kwargs)
             print('save figure to {}'.format(fig_names[1]))
 
     # Fig 4 - Interferogram Network
@@ -330,7 +335,7 @@ def main(iargs=None):
                          vars(inps),
                          inps.date12List_drop)
     if inps.save_fig:
-        fig.savefig(fig_names[3], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
+        fig.savefig(fig_names[3], **kwargs)
         print('save figure to {}'.format(fig_names[3]))
 
     if inps.disp_fig:

--- a/mintpy/plot_network.py
+++ b/mintpy/plot_network.py
@@ -182,7 +182,9 @@ def read_network_info(inps):
             inps.cohList = stack_obj.tbaseIfgram.tolist()
 
         else:
-            raise ValueError(f'{inps.dsetName} NOT found in file: {inps.file}!')
+            inps.cohList = [0.7] * stack_obj.get_size()[0]
+            print(f'{inps.dsetName} NOT found in file: {inps.file}! Fill 0.7 as dummy!')
+            #raise ValueError(f'{inps.dsetName} NOT found in file: {inps.file}!')
 
     elif ext == '.txt':
         inps.date12List = np.loadtxt(inps.file, dtype=bytes).astype(str)[:,0].tolist()
@@ -265,20 +267,24 @@ def main(iargs=None):
 
     # Plot settings
     inps = check_colormap(inps)
+    if os.path.basename(inps.file).startswith('ion'):
+        ext = '_ion.pdf'
+    else:
+        ext = '.pdf'
     if inps.dsetName == 'coherence':
-        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'coherenceHistory', 'coherenceMatrix', 'network']]
+        fig_names = [i+ext for i in ['pbaseHistory', 'coherenceHistory', 'coherenceMatrix', 'network']]
         inps.ds_name = 'Coherence'
         inps.cbar_label = 'Average Spatial Coherence'
     elif inps.dsetName == 'offsetSNR':
-        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'SNRHistory', 'SNRMatrix', 'network']]
+        fig_names = [i+ext for i in ['pbaseHistory', 'SNRHistory', 'SNRMatrix', 'network']]
         inps.ds_name = 'SNR'
         inps.cbar_label = 'Average Spatial SNR'
     elif inps.dsetName == 'tbase':
-        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'tbaseHistory', 'tbaseMatrix', 'network']]
+        fig_names = [i+ext for i in ['pbaseHistory', 'tbaseHistory', 'tbaseMatrix', 'network']]
         inps.ds_name = 'Temporal Baseline'
         inps.cbar_label = 'Temporal Baseline [day]'
     elif inps.dsetName == 'pbase':
-        fig_names = [i+'.pdf' for i in ['pbaseHistory', 'pbaseRangeHistory', 'pbaseMatrix', 'network']]
+        fig_names = [i+ext for i in ['pbaseHistory', 'pbaseRangeHistory', 'pbaseMatrix', 'network']]
         inps.ds_name = 'Perp Baseline'
         inps.cbar_label = 'Perp Baseline [m]'
 

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -25,6 +25,9 @@ EXAMPLE = """example:
   prep_isce.py -m 20120507_slc_crop.xml -g ./geometry                                                           #for stripmapApp
   prep_isce.py -d "pairs/*-*/insar" -m "pairs/*-*/150408.track.xml" -b baseline -g dates_resampled/150408/insar #for alosStack with 150408 as ref date
 
+  # ionosphere stack
+  prep_isce.py -d ./ion -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference -f ion_cal/filt.ion    #for topsStack ionospheric files
+
   # offset stack
   prep_isce.py -d ./offsets -f *Off*.bip -m ./../reference/IW1.xml -b ./../baselines -g ./offsets/geom_reference  #for topsStack
   prep_isce.py -d ./offsets -f *Off*.bip -m ./SLC/*/data.dat       -b random         -g ./geometry                #for UAVSAR coregStack
@@ -203,7 +206,11 @@ def prepare_stack(inputDir, filePattern, metadata=dict(), baseline_dict=dict(), 
     for i, isce_file in enumerate(isce_files):
         # get date1/2
         if processor in ['tops', 'stripmap']:
-            dates = os.path.basename(os.path.dirname(isce_file)).split('_')  # to modify to YYYYMMDDTHHMMSS
+            if filePattern.startswith('ion_cal'):
+                # handel topsStack iono file path patterns
+                dates = os.path.basename(os.path.dirname(os.path.dirname(isce_file))).split('_')  # to modify to YYYYMMDDTHHMMSS
+            else:
+                dates = os.path.basename(os.path.dirname(isce_file)).split('_')  # to modify to YYYYMMDDTHHMMSS
         elif processor == 'alosStack':
             dates = os.path.basename(os.path.dirname(os.path.dirname(isce_file))).split('-')  # to modify to YYYYMMDDTHHMMSS
             dates = ptime.yyyymmdd(dates)

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -26,11 +26,11 @@ EXAMPLE = """example:
   prep_isce.py -d "pairs/*-*/insar" -m "pairs/*-*/150408.track.xml" -b baseline -g dates_resampled/150408/insar  #for alosStack w/ 150408 as ref date
 
   # ionosphere stack
-  prep_isce.py -d ./ion -f ion_cal/filt.ion -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference      #for topsStack ionospheric files
+  prep_isce.py -d ./ion -f ion_cal/filt.ion -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference     #for topsStack ionospheric files
 
   # offset stack
-  prep_isce.py -d ./offsets -f *Off*.bip -m ./../reference/IW1.xml -b ./../baselines -g ./offsets/geom_reference  #for topsStack
-  prep_isce.py -d ./offsets -f *Off*.bip -m ./SLC/*/data.dat       -b random         -g ./geometry                #for UAVSAR coregStack
+  prep_isce.py -d ./offsets -f *Off*.bip -m ./../reference/IW1.xml -b ./../baselines -g ./offsets/geom_reference #for topsStack
+  prep_isce.py -d ./offsets -f *Off*.bip -m ./SLC/*/data.dat       -b random         -g ./geometry               #for UAVSAR coregStack
 """
 
 def create_parser():

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -20,13 +20,13 @@ GEOMETRY_PREFIXS = ['hgt', 'lat', 'lon', 'los', 'shadowMask', 'waterMask', 'incL
 
 EXAMPLE = """example:
   # interferogram stack
-  prep_isce.py -d ./merged/interferograms -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference      #for topsStack
-  prep_isce.py -d ./Igrams -m ./referenceShelve/data.dat -b ./baselines -g ./geom_reference                     #for stripmapStack
-  prep_isce.py -m 20120507_slc_crop.xml -g ./geometry                                                           #for stripmapApp
-  prep_isce.py -d "pairs/*-*/insar" -m "pairs/*-*/150408.track.xml" -b baseline -g dates_resampled/150408/insar #for alosStack with 150408 as ref date
+  prep_isce.py -d ./merged/interferograms -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference       #for topsStack
+  prep_isce.py -d ./Igrams -m ./referenceShelve/data.dat -b ./baselines -g ./geom_reference                      #for stripmapStack
+  prep_isce.py -m 20120507_slc_crop.xml -g ./geometry                                                            #for stripmapApp
+  prep_isce.py -d "pairs/*-*/insar" -m "pairs/*-*/150408.track.xml" -b baseline -g dates_resampled/150408/insar  #for alosStack w/ 150408 as ref date
 
   # ionosphere stack
-  prep_isce.py -d ./ion -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference -f ion_cal/filt.ion    #for topsStack ionospheric files
+  prep_isce.py -d ./ion -f ion_cal/filt.ion -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference      #for topsStack ionospheric files
 
   # offset stack
   prep_isce.py -d ./offsets -f *Off*.bip -m ./../reference/IW1.xml -b ./../baselines -g ./offsets/geom_reference  #for topsStack
@@ -205,17 +205,8 @@ def prepare_stack(inputDir, filePattern, metadata=dict(), baseline_dict=dict(), 
     prog_bar = ptime.progressBar(maxValue=num_file)
     for i, isce_file in enumerate(isce_files):
         # get date1/2
-        if processor in ['tops', 'stripmap']:
-            if filePattern.startswith('ion_cal'):
-                # handel topsStack iono file path patterns
-                dates = os.path.basename(os.path.dirname(os.path.dirname(isce_file))).split('_')  # to modify to YYYYMMDDTHHMMSS
-            else:
-                dates = os.path.basename(os.path.dirname(isce_file)).split('_')  # to modify to YYYYMMDDTHHMMSS
-        elif processor == 'alosStack':
-            dates = os.path.basename(os.path.dirname(os.path.dirname(isce_file))).split('-')  # to modify to YYYYMMDDTHHMMSS
-            dates = ptime.yyyymmdd(dates)
-        else:
-            raise ValueError('Un-recognized ISCE stack processor: {}'.format(processor))
+        date12 = ptime.get_date12_from_path(isce_file)
+        dates = ptime.yyyymmdd(date12.replace('-','_').split('_'))
         prog_bar.update(i+1, suffix='{}_{}'.format(dates[0], dates[1]))
 
         # merge metadata from: data.rsc, *.unw.xml and DATE12/P_BASELINE_TOP/BOTTOM_HDR

--- a/mintpy/reference_point.py
+++ b/mintpy/reference_point.py
@@ -23,7 +23,7 @@ TEMPLATE = get_template_content('reference_point')
 NOTE = """note: Reference value cannot be nan, thus, all selected reference point must be:
   a. non zero in mask, if mask is given
   b. non nan  in data (stack)
-  
+
   Priority:
       input reference_lat/lon
       input reference_y/x
@@ -180,8 +180,8 @@ def reference_file(inps):
     atr = readfile.read_attribute(inps.file)
 
     # update_mode
-    if (not inps.force 
-            and inps.ref_y is not None and inps.ref_y == int(atr.get('REF_Y', -999)) 
+    if (not inps.force
+            and inps.ref_y is not None and inps.ref_y == int(atr.get('REF_Y', -999))
             and inps.ref_x is not None and inps.ref_x == int(atr.get('REF_X', -999))):
         print('SAME reference pixel is already selected/saved in file, skip updating.')
         return inps.file
@@ -464,9 +464,9 @@ def read_reference_input(inps):
         print('no input reference y/x.')
         if not inps.method:
             # Use existing REF_Y/X if 1) no ref_y/x input and 2) no method input and 3) ref_yx is in coverage
-            if (not inps.force 
+            if (not inps.force
                     and 'REF_X' in atr.keys()
-                    and 0 <= float(atr['REF_Y']) <= length 
+                    and 0 <= float(atr['REF_Y']) <= length
                     and 0 <= float(atr['REF_X']) <= width):
                 print('REF_Y/X exists in input file, skip updating.')
                 print('REF_Y: '+atr['REF_Y'])

--- a/mintpy/utils/ptime.py
+++ b/mintpy/utils/ptime.py
@@ -14,6 +14,7 @@ import numpy as np
 from mintpy.objects.progress import progressBar
 
 
+
 ################################################################
 def get_compact_isoformat(date_str):
     """Get the "compact-looking" isoformat of the input datetime string.
@@ -56,7 +57,7 @@ def get_date_str_format(date_str):
     elif len(re.findall('\d{4}-\d{2}-\d{2}T\d{2}', date_str)) > 0:
         date_str_format = '%Y-%m-%dT%H'
 
-    elif len(re.findall('\d{4}-\d{2}-\d{2}T', date_str)) > 0:
+    elif len(re.findall('\d{4}-\d{2}-\d{2}', date_str)) > 0:
         date_str_format = '%Y-%m-%d'
 
     elif len(re.findall('\d{8}T\d{6}', date_str)) > 0:
@@ -78,6 +79,39 @@ def get_date_str_format(date_str):
         raise ValueError('un-recognized date string format for "{}"!'.format(date_str))
 
     return date_str_format
+
+
+def get_date12_from_path(file_path):
+    """Get date12 str from a given file path.
+
+    Parameters: file_path  - str, path to a file that contains date1/2 info
+    Returns:    date12_str - str, date12 in (YY)YYMMDD(THHMM)[-_](YY)YYMMDD(THHMM) format
+    """
+
+    # support date string format
+    date12_fmts = [
+        '\d{8}T\d{4}[-_]\d{8}T\d{4}',   # %Y%m%dT%H%M
+        '\d{8}[-_]\d{8}',               # %Y%m%d
+        '\d{6}[-_]\d{6}',               # %y%m%d
+    ]
+
+    # search date12 pattern part by part in the file path
+    date12_str = None
+    parts = file_path.split(os.sep)[::-1]
+    for part in parts:
+        for date12_fmt in date12_fmts:
+            if len(re.findall(date12_fmt, part)) > 0:
+                date12_str = re.findall(date12_fmt, part)[0]
+                break
+
+        # exit remaining parts searching
+        if date12_str:
+            break
+
+    if not date12_str:
+        raise ValueError(f'NO date12 str found in path: {file_path}!')
+
+    return date12_str
 
 
 def round_seconds(datetime_obj):
@@ -340,7 +374,6 @@ def read_date_list(date_list_in, date_list_all=None):
     return date_list_out
 
 
-################################################################
 def date_list2tbase(date_list):
     """Get temporal Baseline in days with respect to the 1st date
     Parameters: date_list - list of string, date in YYYYMMDD or YYMMDD format
@@ -367,7 +400,6 @@ def date_list2tbase(date_list):
     return tbase, dateDict
 
 
-################################################################
 def date_list2vector(date_list):
     """Get time in datetime format: datetime.datetime(2006, 5, 26, 0, 0)
     Parameters: date_list  - list of string, date in YYYYMMDD or YYMMDD format

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -752,7 +752,7 @@ def get_slice_list(fname, no_complex=False):
             # isce los file
             slice_list = ['incidenceAngle', 'azimuthAngle']
 
-        elif fext in ['.unw']:
+        elif fext in ['.unw', '.ion']:
             slice_list = ['magnitude', 'phase']
 
         elif fext in ['.int', '.slc']:

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -510,7 +510,7 @@ def read_binary_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
             data_type = dataTypeDict[data_type]
 
         k = atr['FILE_TYPE'].lower().replace('.', '')
-        if k in ['unw', 'cor']:
+        if k in ['unw', 'cor', 'ion']:
             band = min(2, num_band)
             if datasetName and datasetName in ['band1','intensity','magnitude']:
                 band = 1
@@ -1694,7 +1694,7 @@ def read_snap_dim(fname):
     # radar_frequency is in the unit of MHz
     dim_dict['WAVELENGTH'] = SPEED_OF_LIGHT / (float(dim_dict['radar_frequency']) * 1e6)
 
-    # x/y_first/step_unit 
+    # x/y_first/step_unit
     transform = root.find("Geoposition/IMAGE_TO_MODEL_TRANSFORM").text.split(',')
     transform = [str(float(i)) for i in transform]     # Convert 3.333e-4 to 0.0003333
     dim_dict["X_STEP"]  = transform[0]


### PR DESCRIPTION
In these updates, the attempt is to load the ionosphere datasets from topsStack processor into MintPy as an independent `ionoStack.h5`. Thus, it can be inverted separately to a time series for ionosphere correction in the time-series domain.


+ load ionosphere files (phase, coherence) from topsStack
+ create an independent ionoStack.h5 for iono datasets
+ handle xstep/10, ystep/10 for ionoStack.h5 (topStack iono was further multilook)
+ add an option to allow load_data.py to load only the geometry files
+ when creating stack file, fill nan for missing pairs (remove it)
+ add identidyable datasetName 'ionoPhase', 'ionoCoherence' in several codes (just be consistent with ifgramStack)
+ trailing whitespaces removed in several places

New functionalities in `load_data.py`:
`load_data.py --help`
```
  --geom                Only write the geometry files
  --ionostack           Switch to load the ionospheric pairs into an independent stack
                        (define paths in the template file)
```

The general workflow with ionospheric correction could be:

```bash
cd ${mintpy_work_dir}/

# 1. Regular time series analysis w/o iono correction, until network inversion
smallbaselineApp.py ${config} --dostep invert_network

# 2.1 Load the iono stack separately
load_data.py -t ${config} --project AqabaSenAT087 --ionostack

# 2.2 Remember to reference the ionoStack
reference_point.py inputs/ionoStack.h5 -t ${config}

# 2.3 We can plot the iono network (change four file names)
cd inputs && plot_network.py ionoStack.h5 -d ionoCoherence -t ${config} --nodisplay --cmap-vlist 0.2 0.7 1.0

# 2.4 Invert the ionoStack separately with no weighting, move the files if you want (lets' change to iono.h5 saved in inputs/)
ifgram_inversion.py inputs/ionoStack.h5 -i ionoPhase -m waterMask.h5 -w no --update && mv *ion.h5 inputs/

# 3. Phase corrections: since the iono correction is not integrated into the smallbaselineApp.py yet,
# one needs to run the stand-alone scripts for each correction.
diff.py timeseries.h5 inputs/ion.h5 -o timeseries_ion.h5
tropo_pyaps3.py timeseries_ion.h5 -g inputs/geometryRadar.h5 -o timeseries_ion_ERA5.h5
...
```

You will need to have a template configuration file containing the following:
```
##---------interferogram datasets:
mintpy.load.unwFile        = ../submit_arrays/merged/interferograms/*_*/filt_fine.unw  #[path pattern of unwrapped interferogram files]
mintpy.load.corFile        = ../submit_arrays/merged/interferograms/*_*/filt_fine.cor  #[path pattern of spatial coherence       files]
mintpy.load.connCompFile   = ../submit_arrays/merged/interferograms/*_*/filt_fine.unw.conncomp  #[path pattern of connected components    files], optional but recommended
mintpy.load.intFile        = ../submit_arrays/merged/interferograms/*_*/filt_fine.int  #[path pattern of wrapped interferogram   files], optional
mintpy.load.ionoFile       = ../submit_arrays/ion/*_*/ion_cal/filt.ion                 #[path pattern of ionospheric delay       files], optional
mintpy.load.ionocorFile    = ../submit_arrays/ion/*_*/ion_cal/raw_no_projection.cor    #[path pattern of ionospheric coherence   files], optional !!!THIS IS THE NEW STUFF!!!
```

We better set downsampling here, so it downsample the regular InSAR files 10 times:
```
##---------multilook (optional):
## multilook while loading data with nearest interpolation, to reduce dataset size
mintpy.load.ystep          = 10    #[int >= 1], auto for 1 - no multilooking
mintpy.load.xstep          = 10    #[int >= 1], auto for 1 - no multilooking
```

Since topStack generated iono files are already 10 times less in size, in my code it will divide this {xstep, ystep} by 10 (10/10=1, thus no further down sampling for the iono) to handle that factor. Thus, after loading, the ionoStack and regular InSAR stack (ifgramStack) will have the same dimension.
But if you have {xstep, ystep}<10 here, then the downsampling for iono will be less than 1. The code will just skip downsampling the iono files. Then your iono stack and regular InSAR stack will have different size. You will need to sample them by yourself later on when you want to difference them. So unless you already sample the topsStack products using gdal externally, just always set {xstep, ystep} = {10,10} to save hassle.



**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.