### PR TITLE
ifg_inv: adjust default aux quality file for ionStack + bugs fix

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -859,6 +859,7 @@ def ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='u
 
     stack_obj = ifgramStack(ifgram_file)
     stack_obj.open(print_msg=False)
+    stack_dir, stack_base = os.path.split(ifgram_file)
 
     ## debug on a specific pixel
     #y, x = 555, 612
@@ -982,17 +983,26 @@ def ifgram_inversion_patch(ifgram_file, box=None, ref_phase=None, obs_ds_name='u
 
     # 1.3.3 Mask for zero quality measure (average spatial coherence/SNR)
     # usually due to lack of data in the processing
-    stack_quality_file = os.path.join(os.path.dirname(ifgram_file), '../avgSpatialCoh.h5')
-    inv_quality_name = 'temporalCoherence'
     if 'offset' in obs_ds_name.lower():
-        stack_quality_file = os.path.join(os.path.dirname(ifgram_file), '../avgSpatialSNR.h5')
         inv_quality_name = 'residual'
+        stack_quality_file = os.path.join(stack_dir, '../avgSpatialSNR.h5')
 
-    if stack_quality_file and os.path.isfile(stack_quality_file):
-        print('skip pixels with zero value in file: {}'.format(os.path.basename(stack_quality_file)))
-        quality = readfile.read(stack_quality_file, box=box)[0].flatten()
-        mask *= quality != 0.
-        del quality
+    elif stack_base.startswith('ion'):
+        inv_quality_name = 'temporalCoherence'
+        stack_quality_file = os.path.join(stack_dir, '../avgSpatialCohIon.h5')
+
+    else:
+        inv_quality_name = 'temporalCoherence'
+        stack_quality_file = os.path.join(stack_dir, '../avgSpatialCoh.h5')
+
+    if os.path.isfile(stack_quality_file):
+        atr_stack = readfile.read_attribute(stack_quality_file)
+        len_stack, wid_stack = int(atr_stack['LENGTH']), int(atr_stack['WIDTH'])
+        if (len_stack, wid_stack) == (stack_obj.length, stack_obj.width):
+            print('skip pixels with zero value in file: {}'.format(os.path.basename(stack_quality_file)))
+            quality = readfile.read(stack_quality_file, box=box)[0].flatten()
+            mask *= quality != 0.
+            del quality
 
     # invert pixels on mask 1+2
     num_pixel2inv = int(np.sum(mask))
@@ -1433,7 +1443,7 @@ def main(iargs=None):
         raise NotImplementedError('L1 norm minimization is not fully tested.')
         #ut.timeseries_inversion_L1(inps.ifgramStackFile, inps.tsFile)
 
-    return inps.outfile
+    return
 
 
 ################################################################################################

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -668,7 +668,7 @@ def run_or_skip(outFile, inObj, box, updateMode=True, xstep=1, ystep=1):
 
             outObj = ifgramStack(outFile)
             outObj.open(print_msg=False)
-            out_size = [outObj.length, outObj.width]
+            out_size = (outObj.length, outObj.width)
             out_dset_list = outObj.datasetNames
             out_date12_list = outObj.date12List
 
@@ -685,7 +685,7 @@ def run_or_skip(outFile, inObj, box, updateMode=True, xstep=1, ystep=1):
 
             outObj = geometry(outFile)
             outObj.open(print_msg=False)
-            out_size = [outObj.length, outObj.width]
+            out_size = (outObj.length, outObj.width)
             out_dset_list = outObj.datasetNames
 
             if (out_size == in_size

--- a/mintpy/multilook.py
+++ b/mintpy/multilook.py
@@ -48,7 +48,7 @@ def create_parser():
                         help='number of multilooking in azimuth/y direction (default: %(default)s).')
     parser.add_argument('-o', '--outfile',
                         help='Output file name. Disabled when more than 1 input files')
-    parser.add_argument('-m','--method', dest='method', type=str, default='average', choices=['average', 'nearest'],
+    parser.add_argument('-m','--method', dest='method', type=str, default='mean', choices=['mean', 'median', 'nearest'],
                         help='downsampling method (default: %(default)s) \n'
                              'e.g. nearest for geometry, average for observations')
     parser.add_argument('--margin', dest='margin', type=int, nargs=4, metavar=('TOP','BOTTOM','LEFT','RIGHT'),
@@ -186,7 +186,7 @@ def multilook_data(data, lks_y=1, lks_x=1, method='mean'):
     return coarse_data
 
 
-def multilook_file(infile, lks_y, lks_x, outfile=None, method='average', margin=[0,0,0,0], max_memory=4):
+def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,0,0,0], max_memory=4):
     """ Multilook input file
     Parameters: infile - str, path of input file to be multilooked.
                 lks_y  - int, number of looks in y / row direction.
@@ -279,7 +279,7 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='average', margin=
                                      box=box_i,
                                      print_msg=False)[0]
 
-                data = multilook_data(data, lks_y, lks_x)
+                data = multilook_data(data, lks_y, lks_x, method=method)
 
             # output block
             if data.ndim == 3:

--- a/mintpy/objects/cluster.py
+++ b/mintpy/objects/cluster.py
@@ -338,11 +338,13 @@ class DaskCluster:
     def close(self):
         """Close connections to dask client and cluster and moves dask output/error files. """
 
-        self.cluster.close()
-        print('close dask cluster')
-
+        # close client before cluster -> less likely to have the CancelledError
+        # https://github.com/dask/distributed/issues/2273
         self.client.close()
         print('close dask client')
+
+        self.cluster.close()
+        print('close dask cluster')
 
         # move *.o/.e files produced by dask in stdout/stderr
         self.move_dask_stdout_stderr_files()

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -183,6 +183,9 @@ def auto_figure_title(fname, datasetNames=[], inps_dict=None):
                 fig_title += '_unwCor'
         else:
             fig_title = datasetNames[0].split('-')[0]
+            # for ionStack.h5 file
+            if fbase.lower().startswith('ion'):
+                fig_title += '_ion'
 
     elif k in timeseriesKeyNames and len(datasetNames) == 1:
         if 'ref_date' in inps_dict.keys():


### PR DESCRIPTION
**Description of proposed changes**

+ ifgram_inversion.py: adjust the default stack quality file for ionStack, add size checking before using it for masking

+ load_data.run_or_skip(): bugfix for the in/out_size comparison introduced in #780, suggested by @olliestephenson.

+ cluster.DaskCluster.close(): reverse client/cluster.close() order to better avoid the CancelledError.

+ multilook: replace average with mean

+ utils.plot.auto_fig_title(): add extra suffix for ionStack.h5

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1222/workflows/7771e21a-37db-4d93-9d4e-70ae3486c926/jobs/1223) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.