### PR TITLE
Create prep_hyp3_crop.py

### DIFF
--- a/mintpy/prep_hyp3_crop.py
+++ b/mintpy/prep_hyp3_crop.py
@@ -162,7 +162,10 @@ def unzip_crop(workdir: str, geo_box, target_dir):
 
     # do the clip for transformed but clipped via hyp3lib.cutFiles
     files = []
-    wk1_dir = workdir + '_clip'
+    if target_dir == '':
+        wk1_dir = workdir + '_clip'
+    else:
+        wk1_dir = target_dir
 
     print("current path:  " + workdir)
     if os.path.exists(wk1_dir):
@@ -176,6 +179,7 @@ def unzip_crop(workdir: str, geo_box, target_dir):
         print("There are " + str(len(files)) + " satisfied files")
         # Generate
         cutFiles(files)
+        print('The crop process has finished')
     # generate _clip.tif.rsc
     for i in files:
         if target_extent == (-181, -91, 181, 91):
@@ -302,7 +306,7 @@ def main():
     # edge = n,s,w,e
 
     try:
-        asf_crop(work_dir=args.i, geobox=[args.n, args.s, args.w, args.e], crop_state=args.c, output_path=args.o)
+        asf_crop(work_dir=args.i, geobox=[args.n, args.s, args.w, args.e], crop_state=args.c, out_path=args.o)
     except Exception as e:
         print("Something wrong")
         print(e)


### PR DESCRIPTION
Provide a script for processing hyp3_product.
Including crop, transfer all images from WGS84 UTM into WGS84 lat/lon to avoid the 

Co-Authored-By: Lei <24300896+leixie-steven@users.noreply.github.com>

**Description of proposed changes**

The projection of hyp3 product is WGS84 UTM, however, It may lead a distortion when processing from vel.h5 into *.kmz

We reprojected the GTiff from hyp3, and provide a choice to crop the image into a small scale to save RAM memory and improve speed. For future update, we plan to add more choices to improve the selecting of original hyp3-gamma product.

This is my first time to pull a request, I dont know what means in **Reminders**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
