### PR TITLE
load multiple stack files + resize ionosphere on the fly

### DIFF
--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -61,7 +61,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
     /utils
         plot          (objects/{stack, coord, colors}, utils/{ptime, utils0, readfile, network, map})
         utils         (objects/{stack, coord}, utils/{ptime, utils1, readfile})
-        isce_utils    (utils/{ptime, readfile, writefile, utils1})
+        isce_utils    (objects/{constants}, utils/{ptime, readfile, writefile, attribute, utils1})
 ------------------ level 6 --------------------
     /objects
         insar_vs_gps  (objects/{stack, giant}, utils/{readfile, gps, plot, utils})

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -26,46 +26,46 @@ mintpy.compute.config    = auto #[none / slurm / pbs / lsf ], auto for none (sam
 ## no   - save   0% disk usage, fast [default]
 ## lzf  - save ~57% disk usage, relative slow
 ## gzip - save ~62% disk usage, very slow [not recommend]
-mintpy.load.processor      = auto  #[isce, aria, hyp3, gmtsar, snap, gamma, roipac], auto for isce
-mintpy.load.autoPath       = auto  #[yes / no], auto for no, use pre-defined auto path
-mintpy.load.updateMode     = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
-mintpy.load.compression    = auto  #[gzip / lzf / no], auto for no.
+mintpy.load.processor       = auto  #[isce, aria, hyp3, gmtsar, snap, gamma, roipac], auto for isce
+mintpy.load.autoPath        = auto  #[yes / no], auto for no, use pre-defined auto path
+mintpy.load.updateMode      = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
+mintpy.load.compression     = auto  #[gzip / lzf / no], auto for no.
 ##---------for ISCE only:
-mintpy.load.metaFile       = auto  #[path of common metadata file for the stack], i.e.: ./reference/IW1.xml, ./referenceShelve/data.dat
-mintpy.load.baselineDir    = auto  #[path of the baseline dir], i.e.: ./baselines
+mintpy.load.metaFile        = auto  #[path of common metadata file for the stack], i.e.: ./reference/IW1.xml, ./referenceShelve/data.dat
+mintpy.load.baselineDir     = auto  #[path of the baseline dir], i.e.: ./baselines
 ##---------interferogram stack:
-mintpy.load.unwFile        = auto  #[path pattern of unwrapped interferogram files]
-mintpy.load.corFile        = auto  #[path pattern of spatial coherence       files]
-mintpy.load.connCompFile   = auto  #[path pattern of connected components    files], optional but recommended
-mintpy.load.intFile        = auto  #[path pattern of wrapped interferogram   files], optional
-mintpy.load.magFile        = auto  #[path pattern of interferogram magnitude files], optional
+mintpy.load.unwFile         = auto  #[path pattern of unwrapped interferogram files]
+mintpy.load.corFile         = auto  #[path pattern of spatial coherence       files]
+mintpy.load.connCompFile    = auto  #[path pattern of connected components    files], optional but recommended
+mintpy.load.intFile         = auto  #[path pattern of wrapped interferogram   files], optional
+mintpy.load.magFile         = auto  #[path pattern of interferogram magnitude files], optional
 ##---------ionosphere stack (optional):
-mintpy.load.ionUnwFile        = auto  #[path pattern of unwrapped interferogram files]
-mintpy.load.ionCorFile        = auto  #[path pattern of spatial coherence       files]
-mintpy.load.ionConnCompFile   = auto  #[path pattern of connected components    files], optional but recommended
+mintpy.load.ionUnwFile      = auto  #[path pattern of unwrapped interferogram files]
+mintpy.load.ionCorFile      = auto  #[path pattern of spatial coherence       files]
+mintpy.load.ionConnCompFile = auto  #[path pattern of connected components    files], optional but recommended
 ##---------offset stack (optional):
-mintpy.load.azOffFile      = auto  #[path pattern of azimuth offset file]
-mintpy.load.rgOffFile      = auto  #[path pattern of range   offset file]
-mintpy.load.azOffStdFile   = auto  #[path pattern of azimuth offset variance file], optional but recommended
-mintpy.load.rgOffStdFile   = auto  #[path pattern of range   offset variance file], optional but recommended
-mintpy.load.offSnrFile     = auto  #[path pattern of offset signal-to-noise ratio file], optional
+mintpy.load.azOffFile       = auto  #[path pattern of azimuth offset file]
+mintpy.load.rgOffFile       = auto  #[path pattern of range   offset file]
+mintpy.load.azOffStdFile    = auto  #[path pattern of azimuth offset variance file], optional but recommended
+mintpy.load.rgOffStdFile    = auto  #[path pattern of range   offset variance file], optional but recommended
+mintpy.load.offSnrFile      = auto  #[path pattern of offset signal-to-noise ratio file], optional
 ##---------geometry:
-mintpy.load.demFile        = auto  #[path of DEM file]
-mintpy.load.lookupYFile    = auto  #[path of latitude /row   /y coordinate file], not required for geocoded data
-mintpy.load.lookupXFile    = auto  #[path of longitude/column/x coordinate file], not required for geocoded data
-mintpy.load.incAngleFile   = auto  #[path of incidence angle file], optional but recommended
-mintpy.load.azAngleFile    = auto  #[path of azimuth   angle file], optional
-mintpy.load.shadowMaskFile = auto  #[path of shadow mask file], optional but recommended
-mintpy.load.waterMaskFile  = auto  #[path of water  mask file], optional but recommended
-mintpy.load.bperpFile      = auto  #[path pattern of 2D perpendicular baseline file], optional
+mintpy.load.demFile         = auto  #[path of DEM file]
+mintpy.load.lookupYFile     = auto  #[path of latitude /row   /y coordinate file], not required for geocoded data
+mintpy.load.lookupXFile     = auto  #[path of longitude/column/x coordinate file], not required for geocoded data
+mintpy.load.incAngleFile    = auto  #[path of incidence angle file], optional but recommended
+mintpy.load.azAngleFile     = auto  #[path of azimuth   angle file], optional
+mintpy.load.shadowMaskFile  = auto  #[path of shadow mask file], optional but recommended
+mintpy.load.waterMaskFile   = auto  #[path of water  mask file], optional but recommended
+mintpy.load.bperpFile       = auto  #[path pattern of 2D perpendicular baseline file], optional
 ##---------multilook (optional):
 ## multilook while loading data with nearest interpolation, to reduce dataset size
-mintpy.load.ystep          = auto    #[int >= 1], auto for 1 - no multilooking
-mintpy.load.xstep          = auto    #[int >= 1], auto for 1 - no multilooking
+mintpy.load.ystep           = auto    #[int >= 1], auto for 1 - no multilooking
+mintpy.load.xstep           = auto    #[int >= 1], auto for 1 - no multilooking
 ##---------subset (optional):
 ## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
-mintpy.subset.yx           = auto    #[y0:y1,x0:x1 / no], auto for no
-mintpy.subset.lalo         = auto    #[S:N,W:E / no], auto for no
+mintpy.subset.yx            = auto    #[y0:y1,x0:x1 / no], auto for no
+mintpy.subset.lalo          = auto    #[S:N,W:E / no], auto for no
 
 
 ########## 2. modify_network

--- a/mintpy/diff.py
+++ b/mintpy/diff.py
@@ -42,9 +42,9 @@ def create_parser():
 
     parser.add_argument('file1', help='file to be subtracted.')
     parser.add_argument('file2', nargs='+', help='file used to subtract')
-    parser.add_argument('-o', '--output', dest='outfile',
+    parser.add_argument('-o', '--output', dest='out_file',
                         help='output file name, default is file1_diff_file2.h5')
-    parser.add_argument('--force', action='store_true',
+    parser.add_argument('--force','--force-diff', dest='force_diff', action='store_true',
                         help='Enforce the differencing for the shared dates only for time-series files')
     return parser
 
@@ -53,11 +53,20 @@ def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
 
-    # for timeseries and ifgramStack, only two files differencing is supported
-    atr = readfile.read_attribute(inps.file1)
-    if atr['FILE_TYPE'] in ['timeseries', 'ifgramStack']:
+    # ONLY TWO files differencing is supported for timeseries and ifgramStack types
+    ftype = readfile.read_attribute(inps.file1)['FILE_TYPE']
+    if ftype in ['timeseries', 'ifgramStack']:
         if len(inps.file2) > 1:
-            raise SystemExit('ERROR: only one file2 is inputed for {} type'.format(atr['FILE_TYPE']))
+            raise SystemExit(f'ERROR: ONLY ONE file2 is inputed for {ftype} type!')
+
+    # --output
+    if not inps.out_file:
+        if len(inps.file2) > 1:
+            raise ValueError('--output is required for >=2 files!')
+        fbase1, fext = os.path.splitext(inps.file1)
+        fbase2 = os.path.splitext(os.path.basename(inps.file2[0]))[0]
+        inps.out_file = f'{fbase1}_diff_{fbase2}{fext}'
+
     return inps
 
 
@@ -95,22 +104,15 @@ def check_reference(atr1, atr2):
     return ref_date, ref_y, ref_x
 
 
-def diff_file(file1, file2, out_file=None, force=False, max_num_pixel=2e8):
+def diff_file(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
     """calculate/write file1 - file2
 
-    Parameters: file1    - str, path of file1
-                file2    - list of str, path of file2(s)
-                out_file - str, path of output file
-                force    - bool, overwrite existing output file
+    Parameters: file1         - str, path of file1
+                file2         - list(str), path of file2(s)
+                out_file      - str, path of output file
+                force_diff    - bool, overwrite existing output file
                 max_num_pixel - float, maximum number of pixels for each block
     """
-    start_time = time.time()
-
-    if not out_file:
-        fbase, fext = os.path.splitext(file1)
-        if len(file2) > 1:
-            raise ValueError('Output file name is needed for more than 2 files input.')
-        out_file = '{}_diff_{}{}'.format(fbase, os.path.splitext(os.path.basename(file2[0]))[0], fext)
     print('{} - {} --> {}'.format(file1, file2, out_file))
 
     # Read basic info
@@ -142,7 +144,7 @@ def diff_file(file1, file2, out_file=None, force=False, max_num_pixel=2e8):
         dateShared = np.ones((len(dateList1)), dtype=np.bool_)
         if dateListShared != dateList1:
             print('WARNING: {} does not contain all dates in {}'.format(file2, file1))
-            if force:
+            if force_diff:
                 dateListEx = list(set(dateList1) - set(dateListShared))
                 print('Continue and enforce the differencing for their shared dates only.')
                 print('\twith following dates are ignored for differencing:\n{}'.format(dateListEx))
@@ -275,18 +277,23 @@ def diff_file(file1, file2, out_file=None, force=False, max_num_pixel=2e8):
         print('use metadata from the 1st file: {}'.format(file1))
         writefile.write(dsDict, out_file=out_file, metadata=atr1, ref_file=file1)
 
-    m, s = divmod(time.time()-start_time, 60)
-    print('time used: {:02.0f} mins {:02.1f} secs'.format(m, s))
-
     return out_file
 
 
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
+    start_time = time.time()
 
-    inps.outfile = diff_file(inps.file1, inps.file2, inps.outfile, force=inps.force)
+    diff_file(file1=inps.file1,
+              file2=inps.file2,
+              out_file=inps.out_file,
+              force_diff=inps.force_diff)
 
-    return inps.outfile
+    # used time
+    m, s = divmod(time.time()-start_time, 60)
+    print('time used: {:02.0f} mins {:02.1f} secs'.format(m, s))
+
+    return
 
 
 #####################################################################################

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -15,10 +15,7 @@ import time
 import warnings
 import h5py
 import numpy as np
-try:
-    from skimage.transform import resize
-except ImportError:
-    raise ImportError('Could not import skimage!')
+from skimage.transform import resize
 
 from mintpy.objects import (
     dataTypeDict,
@@ -55,24 +52,26 @@ class ifgramStackDict:
         self.pairsDict = pairsDict
         self.dsName0 = dsName0        #reference dataset name, unwrapPhase OR azimuthOffset OR rangeOffset
 
-    def get_size(self, box=None, xstep=1, ystep=1):
-        self.numIfgram = len(self.pairsDict)
+    def get_size(self, box=None, xstep=1, ystep=1, geom_obj=None):
+        """Get size in 3D"""
+        num_ifgram = len(self.pairsDict)
         ifgramObj = [v for v in self.pairsDict.values()][0]
-        self.length, ifgramObj.width = ifgramObj.get_size(family=self.dsName0)
+        length, width = ifgramObj.get_size(family=self.dsName0)
+
+        # use the reference geometry obj size
+        # for low-reso ionosphere from isce2/topsStack
+        if geom_obj:
+            length, width = geom_obj.get_size()
 
         # update due to subset
         if box:
-            self.length = box[3] - box[1]
-            self.width = box[2] - box[0]
-        else:
-            self.length = ifgramObj.length
-            self.width = ifgramObj.width
+            length, width = box[3] - box[1], box[2] - box[0]
 
         # update due to multilook
-        self.length = self.length // ystep
-        self.width = self.width // xstep
+        length = length // ystep
+        width = width // xstep
 
-        return self.numIfgram, self.length, self.width
+        return num_ifgram, length, width
 
     def get_date12_list(self):
         pairs = [pair for pair in self.pairsDict.keys()]
@@ -99,7 +98,7 @@ class ifgramStackDict:
         return dataType
 
     def write2hdf5(self, outputFile='ifgramStack.h5', access_mode='w', box=None, xstep=1, ystep=1,
-                   compression=None, extra_metadata=None):
+                   compression=None, extra_metadata=None, geom_obj=None):
         """Save/write an ifgramStackDict object into an HDF5 file with the structure defined in:
 
         https://mintpy.readthedocs.io/en/latest/api/data_structure/#ifgramstack
@@ -110,14 +109,34 @@ class ifgramStackDict:
                     extra_metadata : dict, extra metadata to be added into output file
         Returns:    outputFile
         """
+        print('-'*50)
+
+        # output directory
+        output_dir = os.path.dirname(outputFile)
+        if not os.path.isdir(output_dir):
+            os.makedirs(output_dir)
+            print(f'create directory: {output_dir}')
 
         self.pairs = sorted([pair for pair in self.pairsDict.keys()])
         self.dsNames = list(self.pairsDict[self.pairs[0]].datasetDict.keys())
         self.dsNames = [i for i in ifgramDatasetNames if i in self.dsNames]
         maxDigit = max([len(i) for i in self.dsNames])
-        self.get_size(box=box,
-                      xstep=xstep,
-                      ystep=ystep)
+        numIfgram, length, width = self.get_size(
+            box=box,
+            xstep=xstep,
+            ystep=ystep)
+
+        # check if resize is needed for a lower resolution stack, e.g. ionosphere from isce2/topsStack
+        resize2shape = None
+        if geom_obj and os.path.basename(outputFile).startswith('ion'):
+            in_size = self.get_size()[1:]
+            geom_size = geom_obj.get_size()
+            if in_size != geom_size:
+                msg = f'lower resolution ionosphere file detected'
+                msg += f' --> resize from {in_size} to {geom_size} via skimage.transform.resize ...'
+                print(msg)
+                resize2shape = geom_size
+                length, width = geom_size
 
         self.outputFile = outputFile
         with h5py.File(self.outputFile, access_mode) as f:
@@ -126,7 +145,7 @@ class ifgramStackDict:
             ###############################
             # 3D datasets containing unwrapPhase, magnitude, coherence, connectComponent, wrapPhase, etc.
             for dsName in self.dsNames:
-                dsShape = (self.numIfgram, self.length, self.width)
+                dsShape = (numIfgram, length, width)
                 dsDataType = np.float32
                 dsCompression = compression
                 if dsName in ['connectComponent']:
@@ -153,16 +172,17 @@ class ifgramStackDict:
                     if dsFile.endswith('cov.bip'):
                         print('convert variance to standard deviation.')
 
-                prog_bar = ptime.progressBar(maxValue=self.numIfgram)
-                for i in range(self.numIfgram):
-                    # read
+                prog_bar = ptime.progressBar(maxValue=numIfgram)
+                for i in range(numIfgram):
+                    # read and/or resize
                     ifgramObj = self.pairsDict[self.pairs[i]]
                     data = ifgramObj.read(dsName,
                                           box=box,
                                           xstep=xstep,
-                                          ystep=ystep)[0]
+                                          ystep=ystep,
+                                          resize2shape=resize2shape)[0]
 
-                    # special handling to offset covariance file
+                    # special handling for offset covariance file
                     if dsName.endswith('OffsetStd'):
                         # set no-data value to np.nan
                         data[data == 99.] = np.nan
@@ -183,7 +203,7 @@ class ifgramStackDict:
             # 2D dataset containing reference and secondary dates of all pairs
             dsName = 'date'
             dsDataType = np.string_
-            dsShape = (self.numIfgram, 2)
+            dsShape = (numIfgram, 2)
             print('create dataset /{d:<{w}} of {t:<25} in size of {s}'.format(d=dsName,
                                                                               w=maxDigit,
                                                                               t=str(dsDataType),
@@ -195,14 +215,14 @@ class ifgramStackDict:
             # 1D dataset containing perpendicular baseline of all pairs
             dsName = 'bperp'
             dsDataType = np.float32
-            dsShape = (self.numIfgram,)
+            dsShape = (numIfgram,)
             print('create dataset /{d:<{w}} of {t:<25} in size of {s}'.format(d=dsName,
                                                                               w=maxDigit,
                                                                               t=str(dsDataType),
                                                                               s=dsShape))
             # get bperp
-            data = np.zeros(self.numIfgram, dtype=dsDataType)
-            for i in range(self.numIfgram):
+            data = np.zeros(numIfgram, dtype=dsDataType)
+            for i in range(numIfgram):
                 ifgramObj = self.pairsDict[self.pairs[i]]
                 data[i] = ifgramObj.get_perp_baseline(family=self.dsName0)
             # write
@@ -212,7 +232,7 @@ class ifgramStackDict:
             # 1D dataset containing bool value of dropping the interferograms or not
             dsName = 'dropIfgram'
             dsDataType = np.bool_
-            dsShape = (self.numIfgram,)
+            dsShape = (numIfgram,)
             print('create dataset /{d:<{w}} of {t:<25} in size of {s}'.format(d=dsName,
                                                                               w=maxDigit,
                                                                               t=str(dsDataType),
@@ -272,21 +292,61 @@ class ifgramDict:
             for key, value in metadata.items():
                 setattr(self, key, value)
 
-    def read(self, family, box=None, xstep=1, ystep=1):
+    def read(self, family, box=None, xstep=1, ystep=1, resize2shape=None):
+        """Read data for the given dataset name.
+
+        Parameters: self         - ifgramDict object
+                    family       - str, dataset name
+                    box          -  tuple of 4 int, in (x0, y0, x1, y1) with respect to the full resolution
+                    x/ystep      - int, number of pixels to skip, with respect to the full resolution
+                    resize2shape - tuple of 2 int, resize the native matrix to the given shape
+                                   Set to None for not resizing
+        Returns:    data         - 2D np.ndarray
+                    meta         - dict, metadata
+        """
         self.file = self.datasetDict[family]
-        data, metadata = readfile.read(self.file,
-                                       datasetName=family,
-                                       box=box,
-                                       xstep=xstep,
-                                       ystep=ystep)
-        return data, metadata
+        box2read = None if resize2shape else box
+
+        # read input file
+        data, meta = readfile.read(self.file,
+                                   datasetName=family,
+                                   box=box2read,
+                                   xstep=1,
+                                   ystep=1)
+
+        # resize
+        if resize2shape:
+            # link: https://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.resize
+            data = resize(data,
+                          output_shape=resize2shape,
+                          order=1,
+                          mode='constant',
+                          anti_aliasing=True,
+                          preserve_range=True)
+
+            # subset by box
+            if box:
+                data = data[box[1]:box[3],
+                            box[0]:box[2]]
+
+        # multilook - nearest resampling
+        if xstep * ystep > 1:
+            # output data size
+            xsize = int(data.shape[1] / xstep)
+            ysize = int(data.shape[0] / ystep)
+            # sampling
+            data = data[int(ystep/2)::ystep,
+                        int(xstep/2)::xstep]
+            data = data[:ysize, :xsize]
+
+        return data, meta
 
     def get_size(self, family=ifgramDatasetNames[0]):
         self.file = self.datasetDict[family]
         metadata = readfile.read_attribute(self.file)
-        self.length = int(metadata['LENGTH'])
-        self.width = int(metadata['WIDTH'])
-        return self.length, self.width
+        length = int(metadata['LENGTH'])
+        width = int(metadata['WIDTH'])
+        return length, width
 
     def get_perp_baseline(self, family=ifgramDatasetNames[0]):
         self.file = self.datasetDict[family]
@@ -301,23 +361,6 @@ class ifgramDict:
         self.metadata = readfile.read_attribute(self.file)
         self.length = int(self.metadata['LENGTH'])
         self.width = int(self.metadata['WIDTH'])
-
-        # if self.processor is None:
-        #    ext = self.file.split('.')[-1]
-        #    if 'PROCESSOR' in self.metadata.keys():
-        #        self.processor = self.metadata['PROCESSOR']
-        #    elif os.path.exists(self.file+'.xml'):
-        #        self.processor = 'isce'
-        #    elif os.path.exists(self.file+'.rsc'):
-        #        self.processor = 'roipac'
-        #    elif os.path.exists(self.file+'.par'):
-        #        self.processor = 'gamma'
-        #    elif ext == 'grd':
-        #        self.processor = 'gmtsar'
-        #    #what for DORIS/SNAP
-        #    else:
-        #        self.processor = 'isce'
-        #self.metadata['PROCESSOR'] = self.processor
 
         if self.track:
             self.metadata['TRACK'] = self.track
@@ -522,22 +565,6 @@ class geometryDict:
         if 'UNIT' in self.metadata.keys():
             self.metadata.pop('UNIT')
 
-        # if self.processor is None:
-        #    ext = self.file.split('.')[-1]
-        #    if 'PROCESSOR' in self.metadata.keys():
-        #        self.processor = self.metadata['PROCESSOR']
-        #    elif os.path.exists(self.file+'.xml'):
-        #        self.processor = 'isce'
-        #    elif os.path.exists(self.file+'.rsc'):
-        #        self.processor = 'roipac'
-        #    elif os.path.exists(self.file+'.par'):
-        #        self.processor = 'gamma'
-        #    elif ext == 'grd':
-        #        self.processor = 'gmtsar'
-        #    #what for DORIS/SNAP
-        #    else:
-        #        self.processor = 'isce'
-        #self.metadata['PROCESSOR'] = self.processor
         return self.metadata
 
     def write2hdf5(self, outputFile='geometryRadar.h5', access_mode='w', box=None, xstep=1, ystep=1,
@@ -545,9 +572,16 @@ class geometryDict:
         """Save/write to HDF5 file with structure defined in:
             https://mintpy.readthedocs.io/en/latest/api/data_structure/#geometry
         """
+        print('-'*50)
         if len(self.datasetDict) == 0:
             print('No dataset file path in the object, skip HDF5 file writing.')
             return None
+
+        # output directory
+        output_dir = os.path.dirname(outputFile)
+        if not os.path.isdir(output_dir):
+            os.makedirs(output_dir)
+            print(f'create directory: {output_dir}')
 
         maxDigit = max([len(i) for i in geometryDatasetNames])
         length, width = self.get_size(box=box, xstep=xstep, ystep=ystep)
@@ -707,12 +741,12 @@ class geometryDict:
 
 ########################################################################################
 def read_isce_bperp_file(fname, full_shape, box=None, xstep=1, ystep=1):
-    """Read ISCE coarse grid perpendicular baseline file, and project it to full size
-    Parameters: self : geometry object,
-                fname : str, bperp file name
-                outShape : tuple of 2int, shape of file in full resolution
-                box : tuple of 4 int, subset range in (x0, y0, x1, y1) with respect to full resolution
-    Returns:    data : 2D array of float32
+    """Read ISCE-2 coarse grid perpendicular baseline file, and project it to full size
+    Parameters: fname      - str, bperp file name
+                full_shape - tuple of 2 int, shape of file in full resolution
+                box        - tuple of 4 int, subset range in (x0, y0, x1, y1) with respect to full resolution
+                x/ystep    - int, number of pixels to pick/multilook for each output pixel
+    Returns:    data       - 2D array of float32
     Example:    fname = '$PROJECT_DIR/merged/baselines/20160418/bperp'
                 data = self.read_sice_bperp_file(fname, (3600,2200), box=(200,400,1000,1000))
     """

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -132,7 +132,7 @@ class ifgramStackDict:
             in_size = self.get_size()[1:]
             geom_size = geom_obj.get_size()
             if in_size != geom_size:
-                msg = f'lower resolution ionosphere file detected'
+                msg = 'lower resolution ionosphere file detected'
                 msg += f' --> resize from {in_size} to {geom_size} via skimage.transform.resize ...'
                 print(msg)
                 resize2shape = geom_size

--- a/mintpy/prep_fringe.py
+++ b/mintpy/prep_fringe.py
@@ -162,15 +162,6 @@ def prepare_metadata(meta_file, geom_src_dir, box=None, nlks_x=1, nlks_y=1):
                                                 box=box,
                                                 fext_list=[geom_ext])
 
-    # add LENGTH / WIDTH
-    atr = readfile.read_attribute(os.path.join(geom_src_dir, 'lat{}'.format(geom_ext)))
-    meta['LENGTH'] = atr['LENGTH']
-    meta['WIDTH'] = atr['WIDTH']
-
-    ## update metadata due to subset
-    print('update metadata due to subset with bounding box')
-    meta = attr.update_attribute4subset(meta, box)
-
     # apply optional user multilooking
     if nlks_x > 1:
         meta['RANGE_PIXEL_SIZE'] = str(float(meta['RANGE_PIXEL_SIZE']) * nlks_x)

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -181,12 +181,12 @@ def prepare_geometry(geom_dir, geom_files=[], metadata=dict(), processor='tops',
     return
 
 
-def gen_random_baseline_timeseries(dset_files, max_bperp=10):
+def gen_random_baseline_timeseries(obs_file, max_bperp=10):
     """Generate a baseline time series with random values
-    with date12 values grabbed from the directory names of the given dset_files.
+    with date12 values grabbed from the directory names of the given path pattern from obs_file.
     """
     # list of dates
-    date12s = sorted([os.path.basename(os.path.dirname(x)) for x in glob.glob(obs_files[0])])
+    date12s = sorted([os.path.basename(os.path.dirname(x)) for x in glob.glob(obs_file)])
     date1s = [x.split('_')[0] for x in date12s]
     date2s = [x.split('_')[1] for x in date12s]
     date_list = sorted(list(set(date1s + date2s)))
@@ -289,7 +289,7 @@ def main(iargs=None):
     baseline_dict = {}
     if inps.baseline_dir:
         if inps.baseline_dir.startswith('rand') and inps.obs_files:
-            baseline_dict = gen_random_baseline_timeseries(inps.obs_files)
+            baseline_dict = gen_random_baseline_timeseries(inps.obs_files[0])
         else:
             baseline_dict = isce_utils.read_baseline_timeseries(
                 inps.baseline_dir,

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -19,18 +19,30 @@ from mintpy.utils import ptime, readfile, writefile, isce_utils
 GEOMETRY_PREFIXS = ['hgt', 'lat', 'lon', 'los', 'shadowMask', 'waterMask', 'incLocal']
 
 EXAMPLE = """example:
-  # interferogram stack
-  prep_isce.py -d ./merged/interferograms -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference       #for topsStack
-  prep_isce.py -d ./Igrams -m ./referenceShelve/data.dat -b ./baselines -g ./geom_reference                      #for stripmapStack
-  prep_isce.py -m 20120507_slc_crop.xml -g ./geometry                                                            #for stripmapApp
-  prep_isce.py -d "pairs/*-*/insar" -m "pairs/*-*/150408.track.xml" -b baseline -g dates_resampled/150408/insar  #for alosStack w/ 150408 as ref date
+  ## topsStack
+  prep_isce.py -f "./merged/interferograms/*/filt_*.unw" -m ./reference/IW1.xml -b ./baselines/ -g ./merged/geom_reference/
 
-  # ionosphere stack
-  prep_isce.py -d ./ion -f ion_cal/filt.ion -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference     #for topsStack ionospheric files
+  # topsStack with ionosphere
+  prep_isce.py -f "./merged/interferograms/*/filt_*.unw" "./ion/*/ion_cal/filt.ion" -m ./reference/IW1.xml -b ./baselines/ -g ./merged/geom_reference/
 
-  # offset stack
-  prep_isce.py -d ./offsets -f *Off*.bip -m ./../reference/IW1.xml -b ./../baselines -g ./offsets/geom_reference #for topsStack
-  prep_isce.py -d ./offsets -f *Off*.bip -m ./SLC/*/data.dat       -b random         -g ./geometry               #for UAVSAR coregStack
+  # topsStack for offset
+  prep_isce.py -f "./merged/offsets/*/*Off*.bip" -m ./reference/IW1.xml -b ./baselines/ -g ./merged/geom_reference/
+
+  ## stripmapStack
+  prep_isce.py -f "./Igrams/*/filt_*.unw" -m ./referenceShelve/data.dat -b ./baselines/ -g ./geom_reference/
+
+  # stripmapApp
+  prep_isce.py -m 20120507_slc_crop.xml -g ./geometry 
+
+  ## alosStack
+  # where 150408 is the reference date
+  prep_isce.py -f "./pairs/*/insar/filt_*.unw" -m "pairs/150408-*/150408.track.xml" -b ./baselines/ -g ./dates_resampled/150408/insar/
+
+  ## UAVSAR
+  prep_isce.py -f "./Igrams/*/filt_*.unw" -m ./referenceShelve/data.dat -b ./baselines/ -g ./geometry/
+
+  # UAVSAR for offset
+  prep_isce.py -f "./offsets/*/*Off*.bip" -m "SLC/*/data.dat" -b random -g ./geometry/
 """
 
 def create_parser():
@@ -38,31 +50,31 @@ def create_parser():
     parser = argparse.ArgumentParser(description='Prepare ISCE metadata files.',
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=EXAMPLE)
-    # interferograms
-    parser.add_argument('-d', '--ds-dir', '--dset-dir', dest='dsetDir', type=str, default=None, required=True,
-                        help='The directory which contains all pairs\n'
-                             'e.g.: $PROJECT_DIR/merged/interferograms OR \n'
-                             '      $PROJECT_DIR/pairs/*-*/insar OR \n'
-                             '      $PROJECT_DIR/merged/offsets')
-    parser.add_argument('-f', '--file-pattern', nargs = '+', dest='dsetFiles', type=str, default=['filt_*.unw'],
-                        help='List of observation file basenames, e.g.: filt_fine.unw OR filtAz*.off')
+    # observations
+    parser.add_argument('-f', dest='obs_files', type=str, nargs='+', default='./merged/interferograms/*/filt_*.unw',
+                        help='Wildcard path pattern for the primary observation files.\n'
+                             'E.g.: topsStack          : {dset_dir}/merged/interferograms/*/filt_*.unw\n'
+                             '      topsStack / iono   : {dset_dir}/ion/*/ion_cal/filt.ion\n'
+                             '      topsStack / offset : {dset_dir}/merged/offsets/*/*Off*.bip\n'
+                             '      stripmapStack      : {dset_dir}/Igrams/*_*/filt_*.unw\n'
+                             '      alosStack          : {dset_dir}/pairs/*/insar/filt_*.unw\n'
+                             '      UAVSAR / offset    : {dset_dir}/offsets/*/*Off*.bip')
 
     # metadata
-    parser.add_argument('-m', '--meta-file', dest='metaFile', type=str, default=None, required=True,
-                        help='Metadata file to extract common metada for the stack:\n'
-                             'e.g.: for ISCE/topsStack    : reference/IW3.xml;\n'
-                             '      for ISCE/stripmapStack: referenceShelve/data.dat;\n'
-                             '      for ISCE/alosStack    : pairs/150408-150701/150408.track.xml\n'
-                             '          where 150408 is the reference date of stack processing')
+    parser.add_argument('-m', '--meta-file', dest='meta_file', type=str, default=None, required=True,
+                        help='Metadata file to extract common metada for the stack.\n'
+                             'E.g.: topsStack     : reference/IW3.xml\n'
+                             '      stripmapStack : referenceShelve/data.dat\n'
+                             '      alosStack     : pairs/{ref_date}-*/{ref_date}.track.xml\n'
+                             '      UAVSAR        : SLC/*/data.dat')
 
     # geometry
-    parser.add_argument('-b', '--baseline-dir', dest='baselineDir', type=str, default=None,
-                        help='Directory with baselines.'
-                             'Set "random" to generate baseline with random value from [-10,10].'
-                             'Set "random-100" to generate baseline with random value from [-100,100].')
-    parser.add_argument('-g', '--geometry-dir', dest='geometryDir', type=str, default=None, required=True,
+    parser.add_argument('-b', '--baseline-dir', dest='baseline_dir', type=str, default=None,
+                        help='Directory with baselines. '
+                             'Set "random" to generate baseline with random value from [-10,10].')
+    parser.add_argument('-g', '--geometry-dir', dest='geom_dir', type=str, default=None, required=True,
                         help='Directory with geometry files ')
-    parser.add_argument('--geom-files', dest='geometryFiles', type=str, nargs='*',
+    parser.add_argument('--geom-files', dest='geom_files', type=str, nargs='*',
                         default=['{}.rdr'.format(i) for i in GEOMETRY_PREFIXS],
                         help='List of geometry file basenames. Default: %(default)s.\n'
                              'All geometry files need to be in the same directory.')
@@ -76,17 +88,13 @@ def cmd_line_parse(iargs = None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
 
-    # translate wildcard in metaFile
-    if "*" in inps.metaFile:
-        fnames = glob.glob(inps.metaFile)
+    # translate wildcard in meta_file
+    if "*" in inps.meta_file:
+        fnames = glob.glob(inps.meta_file)
         if len(fnames) > 0:
-            inps.metaFile = fnames[0]
+            inps.meta_file = fnames[0]
         else:
-            raise FileNotFoundError(inps.metaFile)
-
-    # random baseline input checking
-    if inps.baselineDir.lower().startswith('rand'):
-        inps.baselineDir = inps.baselineDir.lower().replace('_','-')
+            raise FileNotFoundError(inps.meta_file)
 
     return inps
 
@@ -117,7 +125,13 @@ def add_ifgram_metadata(metadata_in, dates=[], baseline_dict={}):
 
 
 def prepare_geometry(geom_dir, geom_files=[], metadata=dict(), processor='tops', update_mode=True):
-    """Prepare and extract metadata from geometry files"""
+    """Prepare and extract metadata from geometry files.
+
+    Parameters: geom_dir   - str, path to the directorry for the geometry data files
+                geom_files - list(str), basenames of geometry data files
+                metadata   - dict, common metadata for the stack
+                processor  - str, isce-2 stack processor
+    """
 
     print('preparing RSC file for geometry files')
     geom_dir = os.path.abspath(geom_dir)
@@ -153,26 +167,26 @@ def prepare_geometry(geom_dir, geom_files=[], metadata=dict(), processor='tops',
     # write rsc file for each file
     for geom_file in geom_files:
         # prepare metadata for current file
+        geom_meta = {**metadata}
         if os.path.isfile(geom_file+'.xml'):
-            geom_metadata = readfile.read_attribute(geom_file, metafile_ext='.xml')
+            geom_meta.update(readfile.read_attribute(geom_file, metafile_ext='.xml'))
         else:
-            geom_metadata = readfile.read_attribute(geom_file)
-        geom_metadata.update(metadata)
+            geom_meta.update(readfile.read_attribute(geom_file))
 
         # write .rsc file
         rsc_file = geom_file+'.rsc'
-        writefile.write_roipac_rsc(geom_metadata, rsc_file,
+        writefile.write_roipac_rsc(geom_meta, rsc_file,
                                    update_mode=update_mode,
                                    print_msg=True)
     return
 
 
-def gen_random_baseline_timeseries(dset_dir, dset_file, max_bperp=10):
-    """Generate a baseline time series with random values.
+def gen_random_baseline_timeseries(dset_files, max_bperp=10):
+    """Generate a baseline time series with random values
+    with date12 values grabbed from the directory names of the given dset_files.
     """
     # list of dates
-    fnames = glob.glob(os.path.join(dset_dir, '*', dset_file))
-    date12s = sorted([os.path.basename(os.path.dirname(x)) for x in fnames])
+    date12s = sorted([os.path.basename(os.path.dirname(x)) for x in glob.glob(obs_files[0])])
     date1s = [x.split('_')[0] for x in date12s]
     date2s = [x.split('_')[1] for x in date12s]
     date_list = sorted(list(set(date1s + date2s)))
@@ -188,17 +202,17 @@ def gen_random_baseline_timeseries(dset_dir, dset_file, max_bperp=10):
     return bDict
 
 
-def prepare_stack(inputDir, filePattern, metadata=dict(), baseline_dict=dict(), processor='tops', update_mode=True):
-    print(f'preparing RSC file for: {filePattern}')
-    if processor in ['tops', 'stripmap']:
-        isce_files = sorted(glob.glob(os.path.join(os.path.abspath(inputDir), '*', filePattern)))
-    elif processor == 'alosStack':
-        isce_files = sorted(glob.glob(os.path.join(os.path.abspath(inputDir), filePattern)))
-    else:
-        raise ValueError('Un-recognized ISCE stack processor: {}'.format(processor))
+def prepare_stack(obs_file, metadata=dict(), baseline_dict=dict(), update_mode=True):
+    """Prepare metadata for a stack of observation data files.
 
+    Parameters: obs_file     : path pattern with wildcards for the primary observation files, e.g. *.unw file.
+                metadata     : dict, common metadata for the stack
+                baseline_dir : dict, baseline time series
+    """
+    print(f'preparing RSC file for: {obs_file}')
+    isce_files = sorted(glob.glob(obs_file))
     if len(isce_files) == 0:
-        raise FileNotFoundError('no file found in pattern: {}'.format(filePattern))
+        raise FileNotFoundError('NO file found with path pattern: {}'.format(obs_file))
 
     # make a copy
     meta = {**metadata}
@@ -225,7 +239,8 @@ def prepare_stack(inputDir, filePattern, metadata=dict(), baseline_dict=dict(), 
 
     # write .rsc file for each interferogram file
     num_file = len(isce_files)
-    prog_bar = ptime.progressBar(maxValue=num_file)
+    print_msg = True if num_file > 5 else False   # do not print progress bar for <=5 files
+    prog_bar = ptime.progressBar(maxValue=num_file, print_msg=print_msg)
     for i, isce_file in enumerate(isce_files):
         # get date1/2
         date12 = ptime.get_date12_from_path(isce_file)
@@ -249,50 +264,46 @@ def prepare_stack(inputDir, filePattern, metadata=dict(), baseline_dict=dict(), 
 #########################################################################
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
-    inps.processor = isce_utils.get_processor(inps.metaFile)
+    inps.processor = isce_utils.get_processor(inps.meta_file)
 
     # read common metadata
     metadata = {}
-    if inps.metaFile:
-        rsc_file = os.path.join(os.path.dirname(inps.metaFile), 'data.rsc')
-        metadata = isce_utils.extract_isce_metadata(inps.metaFile,
-                                                    geom_dir=inps.geometryDir,
-                                                    rsc_file=rsc_file,
-                                                    update_mode=inps.update_mode)[0]
+    if inps.meta_file:
+        rsc_file = os.path.join(os.path.dirname(inps.meta_file), 'data.rsc')
+        metadata = isce_utils.extract_isce_metadata(
+            inps.meta_file,
+            geom_dir=inps.geom_dir,
+            rsc_file=rsc_file,
+            update_mode=inps.update_mode)[0]
 
     # prepare metadata for geometry file
-    if inps.geometryDir:
-        prepare_geometry(inps.geometryDir,
-                         geom_files=inps.geometryFiles,
-                         metadata=metadata,
-                         processor=inps.processor,
-                         update_mode=inps.update_mode)
+    if inps.geom_dir:
+        prepare_geometry(
+            inps.geom_dir,
+            geom_files=inps.geom_files,
+            metadata=metadata,
+            processor=inps.processor,
+            update_mode=inps.update_mode)
 
     # read baseline info
     baseline_dict = {}
-    if inps.baselineDir:
-        if inps.baselineDir.startswith('rand') and inps.dsetDir and inps.dsetFiles:
-            if '-' in inps.baselineDir:
-                max_bperp = float(inps.baselineDir.split('-')[1])
-            else:
-                max_bperp = 10
-            baseline_dict = gen_random_baseline_timeseries(dset_dir=inps.dsetDir,
-                                                           dset_file=inps.dsetFiles[0],
-                                                           max_bperp=max_bperp)
-
+    if inps.baseline_dir:
+        if inps.baseline_dir.startswith('rand') and inps.obs_files:
+            baseline_dict = gen_random_baseline_timeseries(inps.obs_files)
         else:
-            baseline_dict = isce_utils.read_baseline_timeseries(inps.baselineDir,
-                                                                processor=inps.processor)
+            baseline_dict = isce_utils.read_baseline_timeseries(
+                inps.baseline_dir,
+                processor=inps.processor)
 
     # prepare metadata for ifgram file
-    if inps.dsetDir and inps.dsetFiles:
-        for namePattern in inps.dsetFiles:
-            prepare_stack(inps.dsetDir,
-                          namePattern,
-                          metadata=metadata,
-                          baseline_dict=baseline_dict,
-                          processor=inps.processor,
-                          update_mode=inps.update_mode)
+    if inps.obs_files:
+        for obs_file in inps.obs_files:
+            prepare_stack(
+                obs_file,
+                metadata=metadata,
+                baseline_dict=baseline_dict,
+                update_mode=inps.update_mode)
+
     print('Done.')
     return
 

--- a/mintpy/utils/attribute.py
+++ b/mintpy/utils/attribute.py
@@ -25,6 +25,7 @@ def update_attribute4multilook(atr_in, lks_y, lks_x, box=None, print_msg=True):
                          if --margin option is used in multilook.py
     Returns:    atr    - dict, updated dictionary of attributes
     """
+    vprint = print if print_msg else lambda *args, **kwargs: None
 
     # make a copy of original meta dict
     atr = dict()
@@ -37,7 +38,7 @@ def update_attribute4multilook(atr_in, lks_y, lks_x, box=None, print_msg=True):
 
     length_mli = length // lks_y
     width_mli = width // lks_x
-    print('output data in size: {}, {}'.format(length_mli, width_mli))
+    vprint('output data in size: {}, {}'.format(length_mli, width_mli))
 
     # Update attributes
     atr['LENGTH'] = str(length_mli)
@@ -48,38 +49,32 @@ def update_attribute4multilook(atr_in, lks_y, lks_x, box=None, print_msg=True):
     atr['YMAX'] = str(length_mli - 1 + box[1])
     atr['RLOOKS'] = str(int(atr.get('RLOOKS', '1')) * lks_x)
     atr['ALOOKS'] = str(int(atr.get('ALOOKS', '1')) * lks_y)
-    if print_msg:
-        print('update LENGTH, WIDTH, Y/XMIN/MAX, A/RLOOKS')
+    vprint('update LENGTH, WIDTH, Y/XMIN/MAX, A/RLOOKS')
 
     if 'Y_STEP' in atr.keys():
         atr['Y_STEP'] = str(lks_y * float(atr['Y_STEP']))
         atr['X_STEP'] = str(lks_x * float(atr['X_STEP']))
-        if print_msg:
-            print('update Y/X_STEP')
+        vprint('update Y/X_STEP')
 
     if 'AZIMUTH_PIXEL_SIZE' in atr.keys():
         atr['AZIMUTH_PIXEL_SIZE'] = str(lks_y * float(atr['AZIMUTH_PIXEL_SIZE']))
-        if print_msg:
-            print('update AZIMUTH_PIXEL_SIZE')
+        vprint('update AZIMUTH_PIXEL_SIZE')
 
     if 'RANGE_PIXEL_SIZE' in atr.keys():
         atr['RANGE_PIXEL_SIZE'] = str(lks_x * float(atr['RANGE_PIXEL_SIZE']))
-        if print_msg:
-            print('update RANGE_PIXEL_SIZE')
+        vprint('update RANGE_PIXEL_SIZE')
 
     if 'REF_Y' in atr.keys():
         atr['REF_Y'] = str( (int(atr['REF_Y']) - box[1]) // lks_y )
         atr['REF_X'] = str( (int(atr['REF_X']) - box[0]) // lks_x )
-        if print_msg:
-            print('update REF_Y/X')
+        vprint('update REF_Y/X')
 
     if 'SUBSET_XMIN' in atr.keys():
         atr['SUBSET_YMIN'] = str( (int(atr['SUBSET_YMIN']) - box[1]) // lks_y )
         atr['SUBSET_YMAX'] = str( (int(atr['SUBSET_YMAX']) - box[1]) // lks_y )
         atr['SUBSET_XMIN'] = str( (int(atr['SUBSET_XMIN']) - box[0]) // lks_x )
         atr['SUBSET_XMAX'] = str( (int(atr['SUBSET_XMAX']) - box[0]) // lks_x )
-        if print_msg:
-            print('update SUBSET_XMIN/XMAX/YMIN/YMAX')
+        vprint('update SUBSET_XMIN/XMAX/YMIN/YMAX')
     return atr
 
 
@@ -185,6 +180,8 @@ def update_attribute4subset(atr_in, subset_box, print_msg=True):
                 subset_box - 4-tuple of int, subset box defined in (x0, y0, x1, y1)
     Returns:    atr        - dict, updated data attributes
     """
+    vprint = print if print_msg else lambda *args, **kwargs: None
+
     if subset_box is None:
         return atr_in
 
@@ -197,44 +194,38 @@ def update_attribute4subset(atr_in, subset_box, print_msg=True):
     atr['WIDTH'] = str(sub_x[1]-sub_x[0])
     atr['YMAX'] = str(sub_y[1]-sub_y[0] - 1)
     atr['XMAX'] = str(sub_x[1]-sub_x[0] - 1)
-    if print_msg:
-        print('update LENGTH, WIDTH, Y/XMAX')
+    vprint('update LENGTH, WIDTH, Y/XMAX')
 
     # Subset atribute
     atr['SUBSET_YMAX'] = str(sub_y[1] + int(atr_in.get('SUBSET_YMIN', '0')))
     atr['SUBSET_YMIN'] = str(sub_y[0] + int(atr_in.get('SUBSET_YMIN', '0')))
     atr['SUBSET_XMAX'] = str(sub_x[1] + int(atr_in.get('SUBSET_XMIN', '0')))
     atr['SUBSET_XMIN'] = str(sub_x[0] + int(atr_in.get('SUBSET_XMIN', '0')))
-    if print_msg:
-        print(('update/add SUBSET_XMIN/YMIN/XMAX/YMAX: '
-               '{x0}/{y0}/{x1}/{y1}').format(x0=atr['SUBSET_XMIN'],
-                                             y0=atr['SUBSET_YMIN'],
-                                             x1=atr['SUBSET_XMAX'],
-                                             y1=atr['SUBSET_YMAX']))
+    vprint(('update/add SUBSET_XMIN/YMIN/XMAX/YMAX: '
+            '{x0}/{y0}/{x1}/{y1}').format(x0=atr['SUBSET_XMIN'],
+                                          y0=atr['SUBSET_YMIN'],
+                                          x1=atr['SUBSET_XMAX'],
+                                          y1=atr['SUBSET_YMAX']))
 
     # Geo coord
     if 'Y_FIRST' in atr.keys():
         atr['Y_FIRST'] = str(float(atr['Y_FIRST']) + sub_y[0]*float(atr['Y_STEP']))
         atr['X_FIRST'] = str(float(atr['X_FIRST']) + sub_x[0]*float(atr['X_STEP']))
-        if print_msg:
-            print('update Y/X_FIRST')
+        vprint('update Y/X_FIRST')
 
     # Reference in space
     if 'REF_Y' in atr.keys():
         atr['REF_Y'] = str(int(atr['REF_Y']) - sub_y[0])
         atr['REF_X'] = str(int(atr['REF_X']) - sub_x[0])
-        if print_msg:
-            print('update REF_Y/X')
+        vprint('update REF_Y/X')
 
     # Starting Range for file in radar coord
     if 'Y_FIRST' not in atr_in.keys():
         try:
             atr['STARTING_RANGE'] = float(atr['STARTING_RANGE'])
             atr['STARTING_RANGE'] += float(atr['RANGE_PIXEL_SIZE'])*sub_x[0]
-            if print_msg:
-                print('update STARTING_RANGE')
+            vprint('update STARTING_RANGE')
         except:
             pass
 
     return atr
-


### PR DESCRIPTION
**Description of proposed changes**

This PR supports loading multiple stack files in one command line, to simplify its usage, e.g.:
+ `ifgramStack.h5` for regular interferograms
+ `ionStack.h5` for ionosphere estimate
+ `offsetStack.h5` for range/azimuth offsets

It also resizes the low-resolution ionosphere, such as provided by isce2/topsStack, to the same spatial extent as the regular interferograms during the loading process, to simplify the operations afterward.

Changes / simplications in the following scripts are made to support the above capability:
+ `objects/stackDict.py`
+ `prep_isce.py`
+ `load_data.py`

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1256/workflows/0c8b2780-da73-4da6-b106-4333922e3bc0/jobs/1257) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.