### PR TITLE
load_data: add `mintpy.multilook.method` for mean/median

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -58,17 +58,17 @@ mintpy.load.azAngleFile     = auto  #[path of azimuth   angle file], optional
 mintpy.load.shadowMaskFile  = auto  #[path of shadow mask file], optional but recommended
 mintpy.load.waterMaskFile   = auto  #[path of water  mask file], optional but recommended
 mintpy.load.bperpFile       = auto  #[path pattern of 2D perpendicular baseline file], optional
-##---------multilook (optional):
-## multilook while loading data with the specified method, to reduce dataset size
-## nearest, mean and median methods are applicable to interferogram/ionosphere/offset stack(s), except for:
-## connected components and all geometry datasets, for which nearest is hardwired.
-mintpy.multilook.ystep      = auto    #[int >= 1], auto for 1 - no multilooking
-mintpy.multilook.xstep      = auto    #[int >= 1], auto for 1 - no multilooking
-mintpy.multilook.method     = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
 ##---------subset (optional):
 ## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
 mintpy.subset.yx            = auto    #[y0:y1,x0:x1 / no], auto for no
 mintpy.subset.lalo          = auto    #[S:N,W:E / no], auto for no
+##---------multilook (optional):
+## multilook while loading data with the specified method, to reduce dataset size
+## nearest, mean and median methods are applicable to interferogram/ionosphere/offset stack(s), except for:
+## connected components and all geometry datasets, for which nearest is hardwired.
+mintpy.multilook.method     = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
+mintpy.multilook.ystep      = auto    #[int >= 1], auto for 1 - no multilooking
+mintpy.multilook.xstep      = auto    #[int >= 1], auto for 1 - no multilooking
 
 
 ########## 2. modify_network

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -62,6 +62,7 @@ mintpy.load.bperpFile       = auto  #[path pattern of 2D perpendicular baseline 
 ## multilook while loading data with nearest interpolation, to reduce dataset size
 mintpy.load.ystep           = auto    #[int >= 1], auto for 1 - no multilooking
 mintpy.load.xstep           = auto    #[int >= 1], auto for 1 - no multilooking
+mintpy.load.stepMethod      = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
 ##---------subset (optional):
 ## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
 mintpy.subset.yx            = auto    #[y0:y1,x0:x1 / no], auto for no

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -64,8 +64,11 @@ mintpy.subset.yx            = auto    #[y0:y1,x0:x1 / no], auto for no
 mintpy.subset.lalo          = auto    #[S:N,W:E / no], auto for no
 ##---------multilook (optional):
 ## multilook while loading data with the specified method, to reduce dataset size
-## nearest, mean and median methods are applicable to interferogram/ionosphere/offset stack(s), except for:
-## connected components and all geometry datasets, for which nearest is hardwired.
+## method - nearest, mean and median methods are applicable to interferogram/ionosphere/offset stack(s), except for:
+##   connected components and all geometry datasets, for which nearest is hardwired.
+## Use mean / median method with caution! It could smoothen the noise for a better SNR, but it could also smoothen the
+##   unwrapping errors, breaking the integer 2pi relationship, which is used in the unwrapping error correction.
+##   If you really want to increase the SNR, consider re-generate your stack of interferograms with more looks instead.
 mintpy.multilook.method     = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
 mintpy.multilook.ystep      = auto    #[int >= 1], auto for 1 - no multilooking
 mintpy.multilook.xstep      = auto    #[int >= 1], auto for 1 - no multilooking

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -60,9 +60,9 @@ mintpy.load.waterMaskFile   = auto  #[path of water  mask file], optional but re
 mintpy.load.bperpFile       = auto  #[path pattern of 2D perpendicular baseline file], optional
 ##---------multilook (optional):
 ## multilook while loading data with nearest interpolation, to reduce dataset size
-mintpy.load.ystep           = auto    #[int >= 1], auto for 1 - no multilooking
-mintpy.load.xstep           = auto    #[int >= 1], auto for 1 - no multilooking
-mintpy.load.stepMethod      = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
+mintpy.multilook.ystep      = auto    #[int >= 1], auto for 1 - no multilooking
+mintpy.multilook.xstep      = auto    #[int >= 1], auto for 1 - no multilooking
+mintpy.multilook.method     = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
 ##---------subset (optional):
 ## if both yx and lalo are specified, use lalo option unless a) no lookup file AND b) dataset is in radar coord
 mintpy.subset.yx            = auto    #[y0:y1,x0:x1 / no], auto for no

--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -59,7 +59,9 @@ mintpy.load.shadowMaskFile  = auto  #[path of shadow mask file], optional but re
 mintpy.load.waterMaskFile   = auto  #[path of water  mask file], optional but recommended
 mintpy.load.bperpFile       = auto  #[path pattern of 2D perpendicular baseline file], optional
 ##---------multilook (optional):
-## multilook while loading data with nearest interpolation, to reduce dataset size
+## multilook while loading data with the specified method, to reduce dataset size
+## nearest, mean and median methods are applicable to interferogram/ionosphere/offset stack(s), except for:
+## connected components and all geometry datasets, for which nearest is hardwired.
 mintpy.multilook.ystep      = auto    #[int >= 1], auto for 1 - no multilooking
 mintpy.multilook.xstep      = auto    #[int >= 1], auto for 1 - no multilooking
 mintpy.multilook.method     = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -12,9 +12,9 @@ mintpy.load.autoPath     = no
 mintpy.load.updateMode   = yes
 mintpy.load.compression  = no
 ##---------multilook (optional):
-mintpy.load.ystep        = 1
-mintpy.load.xstep        = 1
-mintpy.load.stepMethod   = nearest
+mintpy.multilook.ystep   = 1
+mintpy.multilook.xstep   = 1
+mintpy.multilook.method  = nearest
 ##-------subset (optional)
 mintpy.subset.yx         = no
 mintpy.subset.lalo       = no

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -14,6 +14,7 @@ mintpy.load.compression  = no
 ##---------multilook (optional):
 mintpy.load.ystep        = 1
 mintpy.load.xstep        = 1
+mintpy.load.stepMethod   = nearest
 ##-------subset (optional)
 mintpy.subset.yx         = no
 mintpy.subset.lalo       = no

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -11,13 +11,13 @@ mintpy.load.processor    = isce
 mintpy.load.autoPath     = no
 mintpy.load.updateMode   = yes
 mintpy.load.compression  = no
-##---------multilook (optional):
-mintpy.multilook.ystep   = 1
-mintpy.multilook.xstep   = 1
-mintpy.multilook.method  = nearest
 ##-------subset (optional)
 mintpy.subset.yx         = no
 mintpy.subset.lalo       = no
+##---------multilook (optional):
+mintpy.multilook.method  = nearest
+mintpy.multilook.ystep   = 1
+mintpy.multilook.xstep   = 1
 
 
 ########## modify_network

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -191,10 +191,8 @@ def read_inps2dict(inps):
     key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
     for key in key_list:
         value = template[prefix+key]
-        if key in ['processor', 'autoPath', 'updateMode', 'compression', 'stepMethod']:
+        if key in ['processor', 'autoPath', 'updateMode', 'compression']:
             iDict[key] = template[prefix+key]
-        elif key in ['xstep', 'ystep']:
-            iDict[key] = int(template[prefix+key])
         elif value:
             iDict[prefix+key] = template[prefix+key]
     print('processor : {}'.format(iDict['processor']))
@@ -202,9 +200,16 @@ def read_inps2dict(inps):
     if iDict['compression'] == False:
         iDict['compression'] = None
 
-    iDict['xstep'] = iDict.get('xstep', 1)
-    iDict['ystep'] = iDict.get('ystep', 1)
-    iDict['stepMethod'] = iDict.get('stepMethod', 'nearest')
+    prefix = 'mintpy.multilook.'
+    key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
+    for key in key_list:
+        value = template[prefix+key]
+        if key in ['xstep', 'ystep', 'method']:
+            iDict[key] = template[prefix+key]
+
+    iDict['xstep']  = int(iDict.get('xstep', 1))
+    iDict['ystep']  = int(iDict.get('ystep', 1))
+    iDict['method'] = str(iDict.get('method', 'nearest'))
 
     # PROJECT_NAME --> PLATFORM
     if not iDict['PROJECT_NAME']:
@@ -896,7 +901,7 @@ def main(iargs=None):
     print('-'*50)
     print('updateMode : {}'.format(iDict['updateMode']))
     print('compression: {}'.format(iDict['compression']))
-    print('x/ystep: {}/{};  multilook method: {}'.format(iDict['xstep'], iDict['ystep'], iDict['stepMethod']))
+    print('x/ystep: {}/{};  multilook method: {}'.format(iDict['xstep'], iDict['ystep'], iDict['method']))
     kwargs = dict(updateMode=iDict['updateMode'], xstep=iDict['xstep'], ystep=iDict['ystep'])
 
     # read subset info [need the metadata from above]
@@ -958,7 +963,7 @@ def main(iargs=None):
                 box=iDict['box'],
                 xstep=iDict['xstep'],
                 ystep=iDict['ystep'],
-                ystep=iDict['stepMethod'],
+                method=iDict['method'],
                 compression=iDict['compression'],
                 extra_metadata=extraDict,
                 geom_obj=geom_obj)

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -191,7 +191,7 @@ def read_inps2dict(inps):
     key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
     for key in key_list:
         value = template[prefix+key]
-        if key in ['processor', 'autoPath', 'updateMode', 'compression']:
+        if key in ['processor', 'autoPath', 'updateMode', 'compression', 'stepMethod']:
             iDict[key] = template[prefix+key]
         elif key in ['xstep', 'ystep']:
             iDict[key] = int(template[prefix+key])
@@ -204,6 +204,7 @@ def read_inps2dict(inps):
 
     iDict['xstep'] = iDict.get('xstep', 1)
     iDict['ystep'] = iDict.get('ystep', 1)
+    iDict['stepMethod'] = iDict.get('stepMethod', 'nearest')
 
     # PROJECT_NAME --> PLATFORM
     if not iDict['PROJECT_NAME']:
@@ -895,13 +896,13 @@ def main(iargs=None):
     print('-'*50)
     print('updateMode : {}'.format(iDict['updateMode']))
     print('compression: {}'.format(iDict['compression']))
-    print('x/ystep: {}/{}'.format(iDict['xstep'], iDict['ystep']))
+    print('x/ystep: {}/{};  multilook method: {}'.format(iDict['xstep'], iDict['ystep'], iDict['stepMethod']))
     kwargs = dict(updateMode=iDict['updateMode'], xstep=iDict['xstep'], ystep=iDict['ystep'])
 
     # read subset info [need the metadata from above]
     iDict = read_subset_box(iDict)
 
-    # geometry in geo / radar coordinates 
+    # geometry in geo / radar coordinates
     geom_dset_name2template_key = {
         **GEOM_DSET_NAME2TEMPLATE_KEY,
         **IFG_DSET_NAME2TEMPLATE_KEY,
@@ -957,6 +958,7 @@ def main(iargs=None):
                 box=iDict['box'],
                 xstep=iDict['xstep'],
                 ystep=iDict['ystep'],
+                ystep=iDict['stepMethod'],
                 compression=iDict['compression'],
                 extra_metadata=extraDict,
                 geom_obj=geom_obj)

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -187,6 +187,7 @@ def read_inps2dict(inps):
     if 'processor' in template.keys():
         template['mintpy.load.processor'] = template['processor']
 
+    # group - load
     prefix = 'mintpy.load.'
     key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
     for key in key_list:
@@ -200,6 +201,7 @@ def read_inps2dict(inps):
     if iDict['compression'] == False:
         iDict['compression'] = None
 
+    # group - multilook
     prefix = 'mintpy.multilook.'
     key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
     for key in key_list:
@@ -901,7 +903,8 @@ def main(iargs=None):
     print('-'*50)
     print('updateMode : {}'.format(iDict['updateMode']))
     print('compression: {}'.format(iDict['compression']))
-    print('x/ystep: {}/{};  multilook method: {}'.format(iDict['xstep'], iDict['ystep'], iDict['method']))
+    print('multilook x/ystep: {}/{}'.format(iDict['xstep'], iDict['ystep']))
+    print('multilook method : {}'.format(iDict['method']))
     kwargs = dict(updateMode=iDict['updateMode'], xstep=iDict['xstep'], ystep=iDict['ystep'])
 
     # read subset info [need the metadata from above]
@@ -963,7 +966,7 @@ def main(iargs=None):
                 box=iDict['box'],
                 xstep=iDict['xstep'],
                 ystep=iDict['ystep'],
-                method=iDict['method'],
+                mli_method=iDict['method'],
                 compression=iDict['compression'],
                 extra_metadata=extraDict,
                 geom_obj=geom_obj)

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -28,7 +28,7 @@ from mintpy.utils import (
     utils0 as ut,
     attribute as attr,
 )
-from mintpy.multilook import multilook_data as mlk
+from mintpy.multilook import multilook_data
 
 ########################################################################################
 class ifgramStackDict:

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -140,11 +140,15 @@ class ifgramStackDict:
                 msg = 'lower resolution ionosphere file detected'
                 msg += f' --> resize from {ion_size} to {geom_size} via skimage.transform.resize ...'
                 print(msg)
+
+                # matrix shape for the original geometry size w/o subset/multilook
                 resize2shape = geom_size
-                length, width = self.get_size(box=box,
-                                              xstep=xstep,
-                                              ystep=ystep,
-                                              geom_obj=geom_obj)[1:]
+                # data size of the output HDF5 file w/ resize/subset/multilook
+                length, width = self.get_size(
+                    box=box,
+                    xstep=xstep,
+                    ystep=ystep,
+                    geom_obj=geom_obj)[1:]
 
         self.outputFile = outputFile
         with h5py.File(self.outputFile, access_mode) as f:

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -136,7 +136,7 @@ class ifgramStackDict:
                 msg += f' --> resize from {in_size} to {geom_size} via skimage.transform.resize ...'
                 print(msg)
                 resize2shape = geom_size
-                length, width = geom_size
+                length, width = geom_size[0]/ystep, geom_size[1]/xstep,
 
         self.outputFile = outputFile
         with h5py.File(self.outputFile, access_mode) as f:
@@ -151,9 +151,9 @@ class ifgramStackDict:
                 if dsName in ['connectComponent']:
                     dsDataType = np.int16
                     dsCompression = 'lzf'
-                    stepMethod = 'nearest'
+                    mlk_method = 'nearest'
                 else:
-                    stepMethod = str(method)
+                    mlk_method = str(method)
 
                 print(('create dataset /{d:<{w}} of {t:<25} in size of {s}'
                        ' with compression = {c}').format(d=dsName,
@@ -183,7 +183,7 @@ class ifgramStackDict:
                                           box=box,
                                           xstep=xstep,
                                           ystep=ystep,
-                                          method=stepMethod,
+                                          method=mlk_method,
                                           resize2shape=resize2shape)[0]
 
                     # special handling for offset covariance file

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -187,7 +187,7 @@ class ifgramStackDict:
 
                 # msg
                 if xstep * ystep > 1:
-                    print(f'apply {ystep} x {xstep} multilooking via {mli_method} ...')
+                    print(f'apply {xstep} x {ystep} multilooking/downsampling via {mli_method} ...')
 
                 prog_bar = ptime.progressBar(maxValue=numIfgram)
                 for i in range(numIfgram):

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -670,7 +670,8 @@ def main(iargs=None):
                            ampStack=inps.magFile,
                            box=box,
                            xstep=inps.xstep,
-                           ystep=inps.ystep)
+                           ystep=inps.ystep,
+                           mli_method=inps.method)
 
     ########## output file 2 - geometryGeo
     # define dataset structure for geometry

--- a/mintpy/prep_aria.py
+++ b/mintpy/prep_aria.py
@@ -56,14 +56,17 @@ TEMPLATE = """template options:
   mintpy.load.incAngleFile   = ../incidenceAngle/*.vrt
   mintpy.load.azAngleFile    = ../azimuthAngle/*.vrt
   mintpy.load.waterMaskFile  = ../mask/watermask.msk
-  ##---------multilook (optional):
-  ## multilook while loading data with nearest interpolation, to reduce dataset size
-  mintpy.load.ystep          = auto    #[int >= 1], auto for 1 - no multilooking
-  mintpy.load.xstep          = auto    #[int >= 1], auto for 1 - no multilooking
   ##---------subset (optional):
   ## if both yx and lalo are specified, use lalo option
   mintpy.subset.yx           = auto    #[y0:y1,x0:x1 / no], auto for no
   mintpy.subset.lalo         = auto    #[lat0:lat1,lon0:lon1 / no], auto for no
+  ##---------multilook (optional):
+  ## multilook while loading data with the specified method, to reduce dataset size
+  ## nearest, mean and median methods are applicable to interferogram/ionosphere/offset stack(s), except for:
+  ## connected components and all geometry datasets, for which nearest is hardwired.
+  mintpy.multilook.method    = auto    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
+  mintpy.multilook.ystep     = auto    #[int >= 1], auto for 1 - no multilooking
+  mintpy.multilook.xstep     = auto    #[int >= 1], auto for 1 - no multilooking
 """
 
 
@@ -189,18 +192,29 @@ def read_template2inps(template_file, inps=None):
             template.pop(key)
 
     # pass options from template to inps
+    # group - load
     key_prefix = 'mintpy.load.'
     keys = [i for i in list(iDict.keys()) if key_prefix+i in template.keys()]
     for key in keys:
         value = template[key_prefix+key]
         if key in ['updateMode', 'compression']:
             iDict[key] = value
-        elif key in ['xstep', 'ystep']:
-            iDict[key] = int(value)
         elif key in ['unwFile']:
             iDict['stackDir'] = os.path.dirname(value)
         elif value:
             iDict[key] = str(value)
+
+    # group - multilook
+    prefix = 'mintpy.multilook.'
+    key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
+    for key in key_list:
+        value = template[prefix+key]
+        if key in ['xstep', 'ystep', 'method']:
+            iDict[key] = template[prefix+key]
+
+    iDict['xstep']  = int(iDict.get('xstep', 1))
+    iDict['ystep']  = int(iDict.get('ystep', 1))
+    iDict['method'] = str(iDict.get('method', 'nearest'))
 
     return inps
 
@@ -481,7 +495,7 @@ def write_geometry(outfile, demFile, incAngleFile, azAngleFile=None, waterMaskFi
 
 
 def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack, ampStack=None,
-                       box=None, xstep=1, ystep=1):
+                       box=None, xstep=1, ystep=1, mli_method='nearest'):
     """Write ifgramStack HDF5 file from stack VRT files
     """
 
@@ -542,6 +556,11 @@ def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack, ampStack=None
     else:
         kwargs = dict()
 
+    if xstep * ystep > 1:
+        msg = f'apply {xstep} x {ystep} multilooking/downsampling via {mli_method} to: unwrapPhase, coherence'
+        msg += ', magnitude' if dsAmp is not None else ''
+        msg += f'\napply {xstep} x {ystep} multilooking/downsampling via nearest to: connectComponent'
+        print(msg)
     print('writing data to HDF5 file {} with a mode ...'.format(outfile))
     with h5py.File(outfile, "a") as f:
 
@@ -557,7 +576,7 @@ def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack, ampStack=None
 
             bnd = dsUnw.GetRasterBand(bndIdx)
             data = bnd.ReadAsArray(**kwargs)
-            data = multilook_data(data, ystep, xstep, method='nearest')
+            data = multilook_data(data, ystep, xstep, method=mli_method)
             data[data == noDataValueUnw] = 0      #assign pixel with no-data to 0
             data *= -1.0                          #date2_date1 -> date1_date2
             f["unwrapPhase"][ii,:,:] = data
@@ -568,7 +587,7 @@ def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack, ampStack=None
 
             bnd = dsCoh.GetRasterBand(bndIdx)
             data = bnd.ReadAsArray(**kwargs)
-            data = multilook_data(data, ystep, xstep, method='nearest')
+            data = multilook_data(data, ystep, xstep, method=mli_method)
             data[data == noDataValueCoh] = 0      #assign pixel with no-data to 0
             f["coherence"][ii,:,:] = data
 
@@ -581,7 +600,7 @@ def write_ifgram_stack(outfile, unwStack, cohStack, connCompStack, ampStack=None
             if dsAmp is not None:
                 bnd = dsAmp.GetRasterBand(bndIdx)
                 data = bnd.ReadAsArray(**kwargs)
-                data = multilook_data(data, ystep, xstep, method='nearest')
+                data = multilook_data(data, ystep, xstep, method=mli_method)
                 data[data == noDataValueAmp] = 0  #assign pixel with no-data to 0
                 f["magnitude"][ii,:,:] = data
 

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -228,7 +228,7 @@ def prepare_stack(obs_file, metadata=dict(), baseline_dict=dict(), update_mode=T
     keys = ['LENGTH', 'WIDTH']
     if all(x in meta.keys() for x in keys):
         atr = readfile.read_attribute(isce_files[0], metafile_ext='.xml')
-        if any(meta[x] != atr[x] for x in keys):
+        if any(int(meta[x]) != int(atr[x]) for x in keys):
             resize2shape = (int(atr['LENGTH']), int(atr['WIDTH']))
             meta = attr.update_attribute4resize(meta, resize2shape)
 

--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -228,9 +228,7 @@ def prepare_stack(obs_file, metadata=dict(), baseline_dict=dict(), update_mode=T
     keys = ['LENGTH', 'WIDTH']
     if all(x in meta.keys() for x in keys):
         atr = readfile.read_attribute(isce_files[0], metafile_ext='.xml')
-        yscale = int(meta['LENGTH']) / int(atr['LENGTH'])
-        xscale = int(meta['WIDTH']) / int(atr['WIDTH'])
-        if yscale != 1 or xscale != 1:
+        if any(meta[x] != atr[x] for x in keys):
             resize2shape = (int(atr['LENGTH']), int(atr['WIDTH']))
             meta = attr.update_attribute4resize(meta, resize2shape)
 

--- a/mintpy/utils/attribute.py
+++ b/mintpy/utils/attribute.py
@@ -15,6 +15,42 @@ from mintpy.utils import readfile
 
 
 
+def update_attribute4resize(atr_in, resize2shape, print_msg=True):
+    """update input dictionary of attributes due to resizing
+
+    Parameters: atr_in       - dict, input dictionary of attributes
+                resize2shape - tuple of 2 int, for the resized shape
+    Returns:    atr          - dict, updated dictionary of attributes
+    """
+    vprint = print if print_msg else lambda *args, **kwargs: None
+    # make a copy of original meta dict
+    atr = {**atr_in}
+
+    yscale = int(atr['LENGTH']) / resize2shape[0]
+    xscale = int(atr['WIDTH']) / resize2shape[1]
+    vprint('output data in size: {}, {}'.format(resize2shape[0], resize2shape[1]))
+
+    atr['LENGTH'] = resize2shape[0]
+    atr['WIDTH'] = resize2shape[1]
+    atr['ALOOKS'] = np.rint(int(atr.get('ALOOKS', 1)) * yscale).astype(int)
+    atr['RLOOKS'] = np.rint(int(atr.get('RLOOKS', 1)) * xscale).astype(int)
+    vprint('update LENGTH, WIDTH, Y/XMIN/MAX, A/RLOOKS')
+
+    if 'AZIMUTH_PIXEL_SIZE' in atr.keys():
+        atr['AZIMUTH_PIXEL_SIZE'] = float(atr['AZIMUTH_PIXEL_SIZE']) * yscale
+        vprint('update AZIMUTH_PIXEL_SIZE')
+
+    if 'RANGE_PIXEL_SIZE' in atr.keys():
+        atr['RANGE_PIXEL_SIZE'] = float(atr['RANGE_PIXEL_SIZE']) * xscale
+        vprint('update RANGE_PIXEL_SIZE')
+
+    if 'NCORRLOOKS' in atr.keys():
+        atr['NCORRLOOKS'] = float(atr['NCORRLOOKS']) * yscale * xscale
+        vprint('update NCORRLOOKS')
+
+    return atr
+
+
 def update_attribute4multilook(atr_in, lks_y, lks_x, box=None, print_msg=True):
     """update input dictionary of attributes due to multilooking
 
@@ -28,9 +64,7 @@ def update_attribute4multilook(atr_in, lks_y, lks_x, box=None, print_msg=True):
     vprint = print if print_msg else lambda *args, **kwargs: None
 
     # make a copy of original meta dict
-    atr = dict()
-    for key, value in iter(atr_in.items()):
-        atr[key] = str(value)
+    atr = {**atr_in}
 
     if box is None:
         box = (0, 0, int(atr['WIDTH']), int(atr['LENGTH']))
@@ -89,7 +123,7 @@ def update_attribute4geo2radar(atr_in, shape2d=None, res_obj=None, print_msg=Tru
     Returns:    atr     - dict, updated dictionary of attributes
     """
     # make a copy of original meta dict
-    atr = dict(atr_in)
+    atr = {**atr_in}
 
     # grab info from res_obj
     if res_obj is not None:
@@ -123,7 +157,7 @@ def update_attribute4radar2geo(atr_in, shape2d=None, lalo_step=None, SNWE=None, 
     Returns:    atr     - dict, updated dictionary of attributes
     """
     # make a copy of original meta dict
-    atr = dict(atr_in)
+    atr = {**atr_in}
 
     # grab info from res_obj
     if res_obj is not None:
@@ -189,7 +223,7 @@ def update_attribute4subset(atr_in, subset_box, print_msg=True):
     sub_y = [subset_box[1], subset_box[3]]
 
     # Update attribute variable
-    atr = dict(atr_in)
+    atr = {**atr_in}
     atr['LENGTH'] = str(sub_y[1]-sub_y[0])
     atr['WIDTH'] = str(sub_x[1]-sub_x[0])
     atr['YMAX'] = str(sub_y[1]-sub_y[0] - 1)

--- a/tests/configs/SanFranSenDT42.txt
+++ b/tests/configs/SanFranSenDT42.txt
@@ -2,8 +2,9 @@
 mintpy.compute.cluster  = local
 mintpy.load.processor   = aria  #[isce, aria, snap, gamma, roipac], auto for isce
 mintpy.load.autoPath    = yes
-mintpy.load.xstep       = 2
-mintpy.load.ystep       = 2
+
+mintpy.multilook.xstep  = 2
+mintpy.multilook.ystep  = 2
 
 mintpy.reference.lalo       = 37.69, -122.07
 mintpy.unwrapError.method   = bridging

--- a/tests/configs/WellsEnvD2T399.txt
+++ b/tests/configs/WellsEnvD2T399.txt
@@ -16,8 +16,8 @@ mintpy.load.azAngleFile    = None
 mintpy.load.shadowMaskFile = None
 mintpy.load.waterMaskFile  = None
 
-mintpy.load.xstep          = 2
-mintpy.load.ystep          = 2
+mintpy.multilook.xstep     = 2
+mintpy.multilook.ystep     = 2
 mintpy.subset.lalo         = 41.02:41.32, -115.10:-114.65
 
 mintpy.reference.lalo             = 41.03, -114.70

--- a/tests/configs/WellsEnvD2T399.txt
+++ b/tests/configs/WellsEnvD2T399.txt
@@ -16,9 +16,9 @@ mintpy.load.azAngleFile    = None
 mintpy.load.shadowMaskFile = None
 mintpy.load.waterMaskFile  = None
 
+mintpy.subset.lalo         = 41.02:41.32, -115.10:-114.65
 mintpy.multilook.xstep     = 2
 mintpy.multilook.ystep     = 2
-mintpy.subset.lalo         = 41.02:41.32, -115.10:-114.65
 
 mintpy.reference.lalo             = 41.03, -114.70
 mintpy.network.coherenceBased     = yes       #[yes / no], auto for yes, exclude interferograms with coherence < minCoherence


### PR DESCRIPTION
**Description of proposed changes**

Allow different options of multilook interpolation while loading data by parsing a method variable
+ 'nearest' method (default)
+ 'mean'    method
+ 'median'  method

This applies to multilook the `unwrapPhase`, `coherence`, `wrapPhase`. But not the `connectedComponent`.

Propagate the method variable from the template file named as `mintpy.load.stepMethod`
```
##---------multilook (optional):
## multilook while loading data with nearest interpolation, to reduce dataset size
mintpy.load.ystep          = 10    #[int >= 1], auto for 1 - no multilooking
mintpy.load.xstep          = 10    #[int >= 1], auto for 1 - no multilooking
mintpy.load.stepMethod     = mean    #[nearest, mean, median], auto for nearest - lines/rows skipping approach
```

By setting the multilook while loading data to mean or median, the noise in the loaded datasets is reduced. So this can be used for a smoother visualization of interferograms and the resulting time series, and the velocity.

Use with care. Because using mean or median multilook on the unwrapped phase can smoothen the integer of 2pi phase jumps (due to unwrapping error). This may result in issue in unwrapping error identification, correction, and also phase closure detection? So we better still use 'nearest' as the default setting. 

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
