### PR TITLE
prep_isce: typo fix in alosStack example usage

### DIFF
--- a/mintpy/prep_isce.py
+++ b/mintpy/prep_isce.py
@@ -42,7 +42,7 @@ EXAMPLE = """example:
 
   ## alosStack
   # where 150408 is the reference date
-  prep_isce.py -f "./pairs/*/insar/filt_*.unw" -m "pairs/150408-*/150408.track.xml" -b ./baselines/ -g ./dates_resampled/150408/insar/
+  prep_isce.py -f "./pairs/*/insar/filt_*.unw" -m "pairs/150408-*/150408.track.xml" -b ./baseline/ -g ./dates_resampled/150408/insar/
 
   ## UAVSAR
   prep_isce.py -f "./Igrams/*/filt_*.unw" -m ./referenceShelve/data.dat -b ./baselines/ -g ./geometry/


### PR DESCRIPTION
**Description of proposed changes**

Changed the folder "baselines" to "baseline" in the example provided for alosStack in prep_isce.py.

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
