### PR TITLE
plate_motion: supp radar-coord geometry & ITRF14 as default fname

### DIFF
--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -60,7 +60,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
 ------------------ level 5 --------------------
     /utils
         plot          (objects/{stack, coord, colors}, utils/{ptime, utils0, readfile, network, map})
-        utils         (objects/{stack, coord}, utils/{ptime, utils1, readfile})
+        utils         (objects/{stack, coord, resample}, utils/{ptime, attribute, utils1, readfile})
         isce_utils    (objects/{constants}, utils/{ptime, readfile, writefile, attribute, utils1})
 ------------------ level 6 --------------------
     /objects

--- a/mintpy/bulk_plate_motion.py
+++ b/mintpy/bulk_plate_motion.py
@@ -2,7 +2,7 @@
 ############################################################
 # Program is part of MintPy                                #
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
-# Author: Yuan-Kai Liu, May 2022                           #
+# Author: Yuan-Kai Liu, Zhang Yunjun, May 2022             #
 ############################################################
 #
 # Extra dependency:
@@ -16,27 +16,22 @@
 #
 # To-Do List (updated 2022.5.30 Yuan-Kai Liu):
 #   + Potentially, we can make built-in PMM tables/dictionaries for easier user string input of the plate name
-#   + Replace scipy.interpolate with alternatives for efficiency. E.g.:
-#       skimage.resize
-#           https://scikit-image.org/docs/stable/auto_examples/transform/plot_rescale.html
-#       check mintpy usage
-#           https://github.com/insarlab/MintPy/blob/7adb3a11f875b832488a0c8e44c174d98b1df254/mintpy/tropo_gacos.py#L129
 #   + Calculate Euler rotation to multi-points ENU motion is slow (called by pmm2enu_at() here)
 #       In `platemotion` package, use array operation rather than for loops
 #           https://github.com/lcx366/PlateTectonic/blob/main/platemotion/classes/plate.py#L153
 #   + Replace platemotion package by equations of Euler trasnformation to relax this dependency at all?
 
+
 import os
 import sys
 import scipy
-import pyproj
 import argparse
 import numpy as np
+from skimage.transform import resize
 
+from mintpy.objects.resample import resample
 from mintpy.utils import readfile, writefile, utils as ut
 from mintpy.diff import diff_file
-from mintpy.save_gmt import get_geo_lat_lon
-from mintpy.solid_earth_tides import prepare_los_geometry
 
 # https://docs.astropy.org/en/stable/units/index.html
 try:
@@ -59,11 +54,13 @@ REFERENCE = """reference:
     https://sentinels.copernicus.eu/documents/247904/3372484/Sentinels-POD-Product-Handbook-1.19.pdf
 
   # list of no-net-rotation (NNR) plate motion models (PMMs):
-  ITRF2014-PMM - Table 1 of Altamimi et al. (2017) - 11 plates
+  # ONLY ITRF14 should be used, as Sentinel-1's orbit is in ITRF2014 reference frame.
+  # Other values, e.g. MORVEL56, should be converted into ITR2014 before use.
+  ITRF14 - Table 1 of Altamimi et al. (2017) - 11 plates
     Altamimi, Z., Métivier, L., Rebischung, P., Rouby, H., & Collilieux, X. (2017).
     ITRF2014 plate motion model. Geophysical Journal International, 209(3), 1906-1912.
     doi:10.1093/gji/ggx136
-  NNR-MORVEL56 - Table 1 of Argus et al. (2011) - 56 plates
+  MORVEL56 - Table 1 of Argus et al. (2011) - 56 plates
     Argus, D. F., Gordon, R. G., & DeMets, C. (2011). Geologically current motion of 56
     plates relative to the no-net-rotation reference frame. Geochemistry, Geophysics, Geosystems, 12(11).
     doi:10.1029/2011GC003751
@@ -72,11 +69,8 @@ REFERENCE = """reference:
 EXAMPLE = """example:
   # Cartesian form of Euler pole rotation in [wx, wy, wz] in unit of mas/year [milli arc second per year]
   # e.g., Arabia plate in ITRF14-PMM (Table 1 in Altamimi et al., 2017)
-  bulk_plate_motion.py -g inputs/geometryGeo.h5 --om-cart 1.154 -0.136  1.444 -v velocity.h5
-
-  # Spherical form of Euler pole rotation in [lat, lon, w] in unit of deg, deg, deg/Ma
-  # e.g., Eurasia plate in NNR-MORVEL56 (Table 1 in Argus et al., 2011)
-  bulk_plate_motion.py -g inputs/geometryGeo.h5 --om-sph  48.85 -106.50 0.223 -v velocity.h5
+  bulk_plate_motion.py -g inputs/geometryGeo.h5   --om-cart 1.154 -0.136  1.444 -v velocity.h5
+  bulk_plate_motion.py -g inputs/geometryRadar.h5 --om-cart 1.154 -0.136  1.444
 
   # Simple constant local ENU translation (based on one GNSS vector) in [ve, vn, vu] in unit of m/year
   #   E.g., https://www.unavco.org/software/visualization/GPS-Velocity-Viewer/GPS-Velocity-Viewer.html
@@ -104,19 +98,19 @@ def create_parser():
     parser.add_argument('-v', '--velo', dest='vel_file', type=str,
                         help='Input velocity file to be corrected.')
     parser.add_argument('-o', '--output', dest='cor_vel_file', type=str,
-                        help='Output velocity file after the correction, default: add "_BPM" suffix.')
+                        help='Output velocity file after the correction, default: add "_ITRF14" suffix.')
 
     # plate motion configurations
     pmm = parser.add_mutually_exclusive_group(required=True)
     pmm.add_argument('--om-cart', dest='omega_cart', type=float, nargs=3, metavar=('WX', 'WY', 'WZ'), default=None,
-                     help='Cartesian form of Euler Pole rotation; [wx, wy, wz] (unit: mas/yr) (default: %(default)s).')
+                     help='Cartesian form of Euler Pole rotation (unit: mas/yr) (default: %(default)s).')
     pmm.add_argument('--om-sph', dest='omega_sph', type=float, nargs=3, metavar=('LAT', 'LON', 'W'), default=None,
-                     help='Spherical form of Euler Pole rotation; [lat, lon, w] (unit: deg, deg, deg/Ma) (default: %(default)s).')
+                     help='Spherical form of Euler Pole rotation (unit: deg, deg, deg/Ma) (default: %(default)s).')
     pmm.add_argument('--enu', dest='const_vel_enu', type=float, nargs=3, metavar=('VE', 'VN', 'VU'), default=None,
-                     help='Simple constant local ENU translation of ground [ve, vn, vu] unit: meter/year (default: %(default)s).')
+                     help='Constant local ground translation (unit: m/year) (default: %(default)s).')
 
-    parser.add_argument('--reso','--pmm-reso', dest='pmm_reso', type=float, default=10.,
-                        help='Ground resolution for computing Plate rotation to ENU velocity (unit: km) (default: %(default)s).')
+    parser.add_argument('--step','--pmm-step', dest='pmm_step', type=float, default=10.,
+                        help='Ground step/resolution in km for computing PMM to ENU velocity (default: %(default)s).')
 
     return parser
 
@@ -127,12 +121,12 @@ def cmd_line_parse(iargs=None):
 
     # default output filenames
     geom_dir = os.path.dirname(inps.geom_file)
-    inps.bpm_enu_file = os.path.join(geom_dir, 'BulkPlateMotion3D.h5')
-    inps.bpm_los_file = os.path.join(geom_dir, 'BulkPlateMotion.h5')
+    inps.pmm_enu_file = os.path.join(geom_dir, 'ITRF14ENU.h5')
+    inps.pmm_los_file = os.path.join(geom_dir, 'ITRF14.h5')
 
     if inps.vel_file and not inps.cor_vel_file:
         vbase = os.path.splitext(inps.vel_file)[0]
-        inps.cor_vel_file = os.path.abspath(f'{vbase}_BPM.h5')
+        inps.cor_vel_file = os.path.abspath(f'{vbase}_ITRF14.h5')
 
     return inps
 
@@ -145,192 +139,176 @@ def build_plate_motion_model(omega_cart=None, omega_sph=None):
                 omega_cart - list or np.array, Cartesian representation [wx, wy, wz] (mas/yr)
     Returns:    plate      - platemotion.Plate object
     """
+    # Check input variables
+    if (omega_cart is None) and (omega_sph is None):
+        raise ValueError('Neither omega_cart (wxyz) nor omega_sph (Euler Pole) are given! At least one is required.')
 
     # Set a NaN moment of inertia (to get class Plate running)
     iner_null = np.zeros([3,3]) * np.nan * (u.kg * u.km**2)
 
     # Create an instrance of class Plate from `platemotion` pkg
     plate = Plate(info={'inertia_tensor': iner_null})
-
-    # Check input variables
-    if (omega_cart is None) and (omega_sph is None):
-        raise ValueError('Neither omega_cart (wxyz) nor omega_sph (Euler Pole) are given! At least one is required.')
-
-    elif omega_cart is not None:
-        print('your input: omega_cartesian; [wx, wy, wz] (mas/yr)')
+    if omega_cart is not None:
+        print('input omega_cartesian in [wx, wy, wz] (mas/yr)')
         omega = np.array(omega_cart) * u.mas/u.yr
         plate.set_omega(omega, 'cartesian')
-
     else:
-        print('your input: omega_spherical; Euler pole; [lat, lon, w] (deg, deg, deg/Ma)')
+        print('input omega_spherical in [lat, lon, w] (deg, deg, deg/Ma)')
         omega = [omega_sph[0]*u.deg,
                  omega_sph[1]*u.deg,
                  omega_sph[2]*u.deg/u.Ma]
-        plate.set_omega(omega,'spherical')
+        plate.set_omega(omega, 'spherical')
 
-    print('--- Euler Pole and rotation vector ---')
-    print('\nSpherical representation:')
-    print(' Latitude:      {:.4f} deg'.format(plate.omega_spherical[0].degree))
-    print(' Longitude:     {:.4f} deg'.format(plate.omega_spherical[1].degree))
-    print(' Rotation rate: {:.4f}  \n'.format(plate.omega_spherical[2].to(u.deg/u.Ma)))
-    print('\nCartesian representation:')
-    print(' wx:            {:.4f}'.format(plate.omega_cartesian[0]))
-    print(' wy:            {:.4f}'.format(plate.omega_cartesian[1]))
-    print(' wz:            {:.4f}'.format(plate.omega_cartesian[2]))
-    print('--------------------------------------')
+    print('\n--------------------------------------')
+    print('Euler Pole and Rotation Vector')
+    print('in spherical coordinates:')
+    print('  Pole Latitude : {:10.4f} deg'.format(plate.omega_spherical[0].degree))
+    print('  Pole Longitude: {:10.4f} deg'.format(plate.omega_spherical[1].degree))
+    print('  Rotation rate : {:10.4f}  \n'.format(plate.omega_spherical[2].to(u.deg/u.Ma)))
+    print('in Cartesian coordinates:')
+    print('  wx: {:10.4f}'.format(plate.omega_cartesian[0]))
+    print('  wy: {:10.4f}'.format(plate.omega_cartesian[1]))
+    print('  wz: {:10.4f}'.format(plate.omega_cartesian[2]))
+    print('--------------------------------------\n')
     return plate
 
 
-def interp_2d3l(data, X, Y, nx, ny, kind):
-    """Interpolate 3-layer 2D arrays individually
-    can be very slow
-    skimage.resize: https://scikit-image.org/docs/stable/auto_examples/transform/plot_rescale.html
-    check mintpy: https://github.com/insarlab/MintPy/blob/7adb3a11f875b832488a0c8e44c174d98b1df254/mintpy/tropo_gacos.py#L129
+def pmm2enu_at(pmm_obj, lats, lons):
+    """Evaluate the PMM at given lats/lons for the motion in ENU.
+
+    Parameters: pmm_obj - plate motion model instance
+                lats    - 0/1/2D array in float32, latitudes
+                lons    - 0/1/2D array in float32, longitudes
+    Returns:    ve/n/u  - 0/1/2D array in float32, plate motion in east / north / up
+                          in meter/year.
     """
-    # Check and flip Y array if needed
-    if Y[0,0] > Y[-1,0]:
-        Y = np.flipud(Y)
+    if isinstance(lats, float) or isinstance(lats, int):
+        loc = np.array([lats, lons, 0])
+        v = pmm_obj.velocity_at(loc,'geodetic')
+        ve = v.en[0]
+        vn = v.en[1]
+        vu = 0
 
-    f0 = scipy.interpolate.interp2d(X, Y, data[:,:,0], kind=kind)
-    f1 = scipy.interpolate.interp2d(X, Y, data[:,:,1], kind=kind)
-    f2 = scipy.interpolate.interp2d(X, Y, data[:,:,2], kind=kind)
+    elif len(lats.shape) == 1:
+        # prepare locations as array in size of (3, num_pts)
+        elev = np.zeros_like(lats)
+        locs = np.vstack((
+            lats.flatten(),
+            lons.flatten(),
+            elev.flatten(),
+        ))
+        # run PMM
+        v = pmm_obj.velocity_at(locs, 'geodetic')
+        ve = v.en[:, 0]
+        vn = v.en[:, 1]
+        vu = np.zeros(ve.shape, dtype=np.float32)
 
-    y_new = np.linspace(np.min(Y), np.max(Y), ny)
-    x_new = np.linspace(np.min(X), np.max(X), nx)
-
-    data_new = np.empty([len(y_new), len(x_new), 3])
-    data_new[:,:,0] = f0(x_new, y_new)
-    data_new[:,:,1] = f1(x_new, y_new)
-    data_new[:,:,2] = f2(x_new, y_new)
-
-    return data_new
-
-
-def pmm2enu_at(pmm, Lats, Lons):
-    """
-    Input:
-        pmm     plate motion model instance
-        Lats    2D array of latitudes;                 dim = (length, width)
-        Lons    2D array of longitudes;                dim = (length, width)
-
-    Output:
-        enu     3D array of {east, north, up} motions; dim = (length, width, 3)
-    """
-    if isinstance(Lats, float) or isinstance(Lats, int):
-        print('Single location')
-        loc = np.array([Lats, Lons, 0])
-        v   = pmm.velocity_at(loc,'geodetic')   # default: mm/yr
-        en  = np.array(v.en)
-        enu = np.concatenate((en, [0]))
-
-    elif len(Lats.shape) == 1:
-        print('1D array locations: {}'.format(len(Lats)))
-        ele  = np.zeros_like(Lats)
-        locs = np.dstack((Lats, Lons, ele))[0].T
-        v    = pmm.velocity_at(locs,'geodetic')   # default: mm/yr
-        en   = np.array(v.en).reshape([-1,2])
-        enu  = np.concatenate((en, np.zeros([en.shape[0],1])),1)
-
-    elif len(Lats.shape) > 1:
-        print('2D array locations: {}'.format(Lats.size))
-        length, width = Lats.shape
-        ele  = np.zeros_like(Lats)
-        locs = np.dstack((Lats, Lons, ele))
-        locs = locs.reshape([-1, 3]).T
-        v    = pmm.velocity_at(locs,'geodetic')   # default: mm/yr
-        en   = np.array(v.en).reshape([-1,2])
-        enu  = np.concatenate((en, np.zeros([en.shape[0],1])),1)
-        enu  = enu.reshape([length, width, -1])
+    elif len(lats.shape) > 1:
+        # prepare locations as array in size of (3, num_pts)
+        length, width = lats.shape
+        elev = np.zeros_like(lats)
+        locs = np.vstack((
+            lats.flatten(),
+            lons.flatten(),
+            elev.flatten(),
+        ))
+        # run PMM
+        v = pmm_obj.velocity_at(locs, 'geodetic')
+        ve = v.en[:, 0].reshape(length, width)
+        vn = v.en[:, 1].reshape(length, width)
+        vu = np.zeros(ve.shape, dtype=np.float32)
 
     else:
-        print('Weird lat lon grid input')
+        raise ValueError('Weird lat lon grid input')
 
-    enu *= 1e-3     # convert to meter/year
-    return enu
+    # convert from mm/year to meter/year
+    #     and from astropy.units.quantity.Quantity to np.ndarray
+    ve = np.array(ve, dtype=np.float32) * 1e-3
+    vn = np.array(vn, dtype=np.float32) * 1e-3
+    vu = np.array(vu, dtype=np.float32) * 1e-3
 
-
-def get_geobox_width_length(geo_box):
-    """Get width and length of the geo box in km
-    geo_box     tuple of 4 floats (lon_min, lat_max, lon_max, lat_min) in decimal degrees
-    """
-    geod = pyproj.Geod(ellps='WGS84')
-    width_km  = geod.inv(geo_box[0], geo_box[3], geo_box[2], geo_box[3])[2] * 1e-3
-    length_km = geod.inv(geo_box[0], geo_box[3], geo_box[0], geo_box[1])[2] * 1e-3
-    return width_km, length_km
+    return ve, vn, vu
 
 
 ####################################### Higher-level Sub Functions ##########################################
 
-def estimate_bulk_motion(geom_file, omega_cart=None, omega_sph=None, const_vel_enu=None,
-                         bpm_enu_file=None, bpm_los_file=None, pmm_reso=5.):
+def calc_bulk_plate_motion(geom_file, omega_cart=None, omega_sph=None, const_vel_enu=None,
+                           pmm_enu_file=None, pmm_los_file=None, pmm_step=10.):
     """Estimate LOS motion due to pure bulk tranlation or due to plate rotation
     Parameters: geom_file     - str, path to the input geometry file
-                omega_cart    - list or 1D array, Cartesian representation of plate rotation [wx, wy, wz]  (mas/yr)
-                omega_sph     - list or 1D array, Spherical representation of plate rotation [lat, lon, w] (deg, deg, deg/Ma)
+                omega_cart    - list or 1D array, Cartesian representation of plate rotation
+                                in [wx, wy, wz]  (mas/yr)
+                omega_sph     - list or 1D array, Spherical representation of plate rotation
+                                in [lat, lon, w] (deg, deg, deg/Ma)
                 const_vel_enu - list or 1D array, a single-vector [ve, vn, vu] (meter/year)
                                 simulating the bulk translation of the ground (e.g., from GNSS)
-                bpm_enu_file  - str, path to the output BPM (bulk plate motion) east, north, up velocity field
-                bpm_los_file  - str, path to the output BPM (bulk plate motion) LOS velocity field
+                pmm_enu_file  - str, path to the output bulk plate motion in east, north, up direction
+                pmm_los_file  - str, path to the output bulk plate motion in LOS direction
                 pmm_reso      - float, ground resolution for computing Plate rotation to ENU velocity (km)
-    Returns:    ve/vn/vu/vlos - 2D np.ndarray, bulk plate motion in east / north / up / line-of-sight direction
+    Returns:    ve/vn/vu/vlos - 2D np.ndarray, bulk plate motion in east / north / up / LOS direction
     """
-    # Read attributes
-    atr = readfile.read_attribute(geom_file)
-    width, length = int(atr['WIDTH']), int(atr['LENGTH'])
-    if 'Y_FIRST' not in atr.keys():
-        raise ValueError('Input geometry file is NOT in geo-coordinates!')
 
     # Get LOS geometry
-    inc_rad, head_rad, atr_geo = prepare_los_geometry(geom_file)
-    lats, lons                 = get_geo_lat_lon(atr_geo)
-    width_km, length_km        = get_geobox_width_length((np.min(lons), np.max(lats), np.max(lons), np.min(lats)))
-    inc_deg, head_deg          = np.rad2deg(inc_rad), np.rad2deg(head_rad)
-
-    # Turn default null value to nan
-    inc_deg[inc_deg==0]    = np.nan
-    inc_rad[inc_deg==0]    = np.nan
-    head_deg[head_deg==90] = np.nan
-    head_rad[head_deg==90] = np.nan
+    inc_angle, head_angle, atr_geo = ut.prepare_geo_los_geometry(geom_file, unit='deg')
+    shape_geo = inc_angle.shape
 
     ## Bulk motion model in the region
-    print('\nForm a bulk motion model velocity field')
-    if any([omega for omega in [omega_cart, omega_sph]]):
-        print('estimate bulk motion by building a plate motion model (e.g., ITRF2014 MORVEL)')
+    print('-'*50)
+    if omega_cart or omega_sph:
+        print('compute the bulk plate motion using a plate motion model (PMM; translation & rotation)')
         if omega_cart is not None:
-            plate = build_plate_motion_model(omega_cart=omega_cart)
-        elif omega_sph is None:
-            plate = build_plate_motion_model(omega_sph=omega_sph)
+            pmm_obj = build_plate_motion_model(omega_cart=omega_cart)
+        else:
+            pmm_obj = build_plate_motion_model(omega_sph=omega_sph)
 
-        # Use the Euler rotation to compute the ENU for each pixel in the geometry
-        skx, sky = int(width*pmm_reso/width_km), int(length*pmm_reso/length_km)
-        Lats = np.meshgrid(lons, lats)[1][::sky, ::skx]
-        Lons = np.meshgrid(lons, lats)[0][::sky, ::skx]
-        print('Compute ENU from PMM with a ~{} km ground resolution'.format(pmm_reso))
-        print('low resolution / original grid dimension: ({}, {}) / ({}, {})'.format(Lats.shape[0], Lats.shape[1], length, width))
+        # prepare the coarse grid
+        latc = float(atr_geo['Y_FIRST']) + float(atr_geo['Y_STEP']) * shape_geo[0] / 2
+        ystep = abs(int(pmm_step * 1000 / (float(atr_geo['Y_STEP']) * 108e3)))
+        xstep = abs(int(pmm_step * 1000 / (float(atr_geo['X_STEP']) * 108e3 * np.cos(np.deg2rad(latc)))))
+        ystep, xstep = max(ystep, 5), max(xstep, 5)
+        lats, lons = ut.get_lat_lon(atr_geo, dimension=2, ystep=ystep, xstep=xstep)
 
         # transform PMM to ENU velocity on a coarse grid
         # to-do: multi-pixel rotation is slow; change the `platemotion` code to Big Array operation rather than For Loops
-        v_enu_low = pmm2enu_at(plate, Lats, Lons)
+        print(f'compute PMM via platemotion.Plate: grid_size = ~{pmm_step} km, grid_shape = {lats.shape} ...')
+        ve_low, vn_low, vu_low = pmm2enu_at(pmm_obj, lats, lons)
 
         # interpolate back to the initial grid
-        print('interpolate back to the original grid')
-        v_enu = interp_2d3l(v_enu_low, Lons, Lats, width, length, 'linear')
+        print(f'interpolate corase PMM to the full resolution: {lats.shape} -> {shape_geo}'
+              ' via skimage.transform.resize ...')
+        kwargs = dict(order=1, mode='edge', anti_aliasing=True, preserve_range=True)
+        ve = resize(ve_low, shape_geo, **kwargs)
+        vn = resize(vn_low, shape_geo, **kwargs)
+        vu = resize(vu_low, shape_geo, **kwargs)
 
     elif const_vel_enu:
-        print('estimate bulk motion by assuming a single pure translation vector: {}'.format(const_vel_enu))
-        v_enu = const_vel_enu * np.ones([length, width, 3])
+        print(f'compute the bulk plate motion using a single vector (translation): {const_vel_enu}')
+        ve = const_vel_enu[0] * np.ones(shape_geo, dtype=np.float32)
+        vn = const_vel_enu[1] * np.ones(shape_geo, dtype=np.float32)
+        vu = const_vel_enu[2] * np.ones(shape_geo, dtype=np.float32)
 
-    else:
-        print('Error: Please specify either the Plate Rotation or a Single Translation Vector; See -h option')
-        print('Need to give at least ONE of [--enu, --om_cart, --om_sph]')
-        sys.exit(1)
+
+    # radar-code PMM if input geometry is in radar coordinates
+    atr = readfile.read_attribute(geom_file)
+    if 'Y_FIRST' not in atr.keys():
+        print('radar-coding the bulk plate motion in ENU ...')
+        res_obj = resample(lut_file=geom_file)
+        res_obj.open()
+        res_obj.src_meta = atr_geo
+        res_obj.prepare()
+
+        # resample data
+        box = res_obj.src_box_list[0]
+        ve = res_obj.run_resample(src_data=ve[box[1]:box[3], box[0]:box[2]])
+        vn = res_obj.run_resample(src_data=vn[box[1]:box[3], box[0]:box[2]])
+        vu = res_obj.run_resample(src_data=vu[box[1]:box[3], box[0]:box[2]])
+
 
     # Project model to LOS velocity
-    print('Project the bulk motion ENU onto radar LOS velocity')
-    ve = np.array(v_enu[:,:,0], dtype=np.float32)
-    vn = np.array(v_enu[:,:,1], dtype=np.float32)
-    vu = np.array(v_enu[:,:,2], dtype=np.float32)
-    vlos = ut.enu2los(ve, vn, vu, inc_angle=inc_deg, head_angle=head_deg)
+    print('project the bulk plate motion from ENU onto LOS direction')
+    inc_angle = readfile.read(geom_file, datasetName='incidenceAngle')[0]
+    az_angle = readfile.read(geom_file, datasetName='azimuthAngle')[0]
+    vlos = ut.enu2los(ve, vn, vu, inc_angle=inc_angle, az_angle=az_angle)
 
     # Save the bulk motion model velocity into HDF5 files
     atr['FILE_TYPE'] = 'velocity'
@@ -341,18 +319,17 @@ def estimate_bulk_motion(geom_file, omega_cart=None, omega_sph=None, const_vel_e
         'north' : vn,
         'up'    : vu,
     }
-    writefile.write(dsDict, out_file=bpm_enu_file, metadata=atr)
-    writefile.write(vlos,   out_file=bpm_los_file, metadata=atr)
+    writefile.write(dsDict, out_file=pmm_enu_file, metadata=atr)
+    writefile.write(vlos,   out_file=pmm_los_file, metadata=atr)
 
     return ve, vn, vu, vlos
 
 
-def remove_bulk_motion(vel_file, mfile, ofile):
-    """
-    Apply the bulk motion correction from files
+def correct_bulk_plate_motion(vel_file, mfile, ofile):
+    """Apply the bulk motion correction from files.
     """
     file1 = vel_file       # input uncorrected LOS velocity file
-    file2 = [mfile]        # BPM model LOS velocity file
+    file2 = [mfile]        # PMM LOS velocity file
     diff_file(file1, file2, ofile)
     return
 
@@ -360,25 +337,21 @@ def remove_bulk_motion(vel_file, mfile, ofile):
 #######################################  Main Function  ########################################
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
-    print('\n-----------------------------------')
-    print('Evaluate bulk motion')
-    print('-----------------------------------\n')
-    estimate_bulk_motion(
+
+    calc_bulk_plate_motion(
         geom_file=inps.geom_file,
         omega_cart=inps.omega_cart,
         omega_sph=inps.omega_sph,
         const_vel_enu=inps.const_vel_enu,
-        bpm_enu_file=inps.bpm_enu_file,
-        bpm_los_file=inps.bpm_los_file,
-        pmm_reso=inps.pmm_reso,
+        pmm_enu_file=inps.pmm_enu_file,
+        pmm_los_file=inps.pmm_los_file,
+        pmm_step=inps.pmm_step,
     )
 
-    if inps.vel_file and inps.bpm_los_file and inps.cor_vel_file:
-        print('\n-----------------------------------')
-        print('Remove bulk motion')
-        print('-----------------------------------\n')
-        remove_bulk_motion(inps.vel_file, inps.bpm_los_file, inps.cor_vel_file)
-        print('The BPM corrected velocity : {}'.format(inps.cor_vel_file))
+    if inps.vel_file and inps.pmm_los_file and inps.cor_vel_file:
+        print('-'*50)
+        print('Correct input velocity for the bulk plate motion')
+        correct_bulk_plate_motion(inps.vel_file, inps.pmm_los_file, inps.cor_vel_file)
 
     return
 

--- a/mintpy/bulk_plate_motion.py
+++ b/mintpy/bulk_plate_motion.py
@@ -24,7 +24,6 @@
 
 import os
 import sys
-import scipy
 import argparse
 import numpy as np
 from skimage.transform import resize

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -115,78 +115,6 @@ def cmd_line_parse(iargs=None):
 
 
 ###############################################################
-def prepare_los_geometry(geom_file):
-    """Prepare LOS geometry data/info in geo-coordinates
-    Parameters: geom_file  - str, path of geometry file
-    Returns:    inc_angle  - 2D np.ndarray, incidence angle in radians
-                head_angle - 2D np.ndarray, heading   angle in radians
-                atr        - dict, metadata in geo-coordinate
-    """
-
-    print('prepare LOS geometry in geo-coordinates from file: {}'.format(geom_file))
-    atr = readfile.read_attribute(geom_file)
-
-    print('read incidenceAngle from file: {}'.format(geom_file))
-    inc_angle = readfile.read(geom_file, datasetName='incidenceAngle')[0]
-
-    if 'azimuthAngle' in readfile.get_dataset_list(geom_file):
-        print('read azimuthAngle   from file: {}'.format(geom_file))
-        print('convert azimuth angle to heading angle')
-        az_angle  = readfile.read(geom_file, datasetName='azimuthAngle')[0]
-        head_angle = ut.azimuth2heading_angle(az_angle)
-    else:
-        print('use the HEADING attribute as the mean heading angle')
-        head_angle = np.ones(inc_angle.shape, dtype=np.float32) * float(atr['HEADING'])
-
-    # geocode inc/az angle data if in radar-coord
-    if 'Y_FIRST' not in atr.keys():
-        print('-'*50)
-        print('geocoding the incidence / heading angles ...')
-        res_obj = resample(lut_file=geom_file, src_file=geom_file)
-        res_obj.open()
-        res_obj.prepare()
-
-        # resample data
-        box = res_obj.src_box_list[0]
-        inc_angle  = res_obj.run_resample(src_data=inc_angle[box[1]:box[3], box[0]:box[2]])
-        head_angle = res_obj.run_resample(src_data=head_angle[box[1]:box[3], box[0]:box[2]])
-
-        # update attribute
-        atr = attr.update_attribute4radar2geo(atr, res_obj=res_obj)
-
-    # for 'Y_FIRST' not in 'degree'
-    # e.g. meters for UTM projection from ASF HyP3
-    if not atr['Y_UNIT'].lower().startswith('deg'):
-        # get SNWE in meter
-        length, width = int(atr['LENGTH']), int(atr['WIDTH'])
-        N = float(atr['Y_FIRST'])
-        W = float(atr['X_FIRST'])
-        y_step = float(atr['Y_STEP'])
-        x_step = float(atr['X_STEP'])
-        S = N + y_step * length
-        E = W + x_step * width
-
-        # SNWE in meter --> degree
-        lat0, lon0 = ut.to_latlon(atr['OG_FILE_PATH'], W, N)
-        lat1, lon1 = ut.to_latlon(atr['OG_FILE_PATH'], E, S)
-        lat_step = (lat1 - lat0) / length
-        lon_step = (lon1 - lon0) / width
-
-        # update Y/X_FIRST/STEP/UNIT
-        atr['Y_FIRST'] = lat0
-        atr['X_FIRST'] = lon0
-        atr['Y_STEP'] = lat_step
-        atr['X_STEP'] = lon_step
-        atr['Y_UNIT'] = 'degrees'
-        atr['X_UNIT'] = 'degrees'
-
-    # unit: degree to radian
-    inc_angle *= np.pi / 180.
-    head_angle *= np.pi / 180.
-
-    return inc_angle, head_angle, atr
-
-
 def get_datetime_list(ts_file, date_wise_acq_time=False):
     """Prepare exact datetime for each acquisition in the time-series file.
 
@@ -286,7 +214,7 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
         return set_file
 
     # prepare LOS geometry: geocoding if in radar-coordinates
-    inc_angle, head_angle, atr_geo = prepare_los_geometry(geom_file)
+    inc_angle, head_angle, atr_geo = ut.prepare_geo_los_geometry(geom_file, unit='rad')
 
     # get LOS unit vector
     with warnings.catch_warnings():

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -32,7 +32,6 @@ from mintpy.utils import (
     readfile,
     writefile,
     utils as ut,
-    attribute as attr,
 )
 
 

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -19,10 +19,11 @@ from mintpy.objects import (
     timeseries,
 )
 
-from mintpy.utils import ptime, readfile
+from mintpy.utils import ptime, readfile, attribute as attr
 from mintpy.utils.utils0 import *
 from mintpy.utils.utils1 import *
 from mintpy.objects.coord import coordinate
+from mintpy.objects.resample import resample
 
 
 #################################################################################
@@ -182,7 +183,6 @@ def read_timeseries_lalo(lat, lon, ts_file, lookup_file=None, ref_lat=None, ref_
     return dates, dis, dis_std
 
 
-#################################################################################
 def read_timeseries_yx(y, x, ts_file, ref_y=None, ref_x=None, zero_first=True,
                        win_size=1, unit='m', method='mean', print_msg=True):
     """ Read time-series of one pixel with input y/x
@@ -400,3 +400,80 @@ def transect_lines(z, atr, lines):
 
 #################################################################################
 
+def prepare_geo_los_geometry(geom_file, unit='rad'):
+    """Prepare LOS geometry data/info in geo-coordinates.
+
+    Parameters: geom_file  - str, path of geometry file
+                unit       - str, rad or deg, output angle unit
+    Returns:    inc_angle  - 2D np.ndarray, incidence angle in radians / degrees
+                head_angle - 2D np.ndarray, heading   angle in radians / degrees
+                atr        - dict, metadata in geo-coordinate
+    """
+
+    print('prepare LOS geometry in geo-coordinates from file: {}'.format(geom_file))
+    atr = readfile.read_attribute(geom_file)
+
+    print('read incidenceAngle from file: {}'.format(geom_file))
+    inc_angle = readfile.read(geom_file, datasetName='incidenceAngle')[0]
+
+    if 'azimuthAngle' in readfile.get_dataset_list(geom_file):
+        print('read azimuthAngle   from file: {}'.format(geom_file))
+        print('convert azimuth angle to heading angle')
+        az_angle  = readfile.read(geom_file, datasetName='azimuthAngle')[0]
+        head_angle = azimuth2heading_angle(az_angle)
+    else:
+        print('use the HEADING attribute as the mean heading angle')
+        head_angle = np.ones(inc_angle.shape, dtype=np.float32) * float(atr['HEADING'])
+
+    # geocode inc/az angle data if in radar-coord
+    if 'Y_FIRST' not in atr.keys():
+        print('-'*50)
+        print('geocoding the incidence / heading angles ...')
+        res_obj = resample(lut_file=geom_file, src_file=geom_file)
+        res_obj.open()
+        res_obj.prepare()
+
+        # resample data
+        box = res_obj.src_box_list[0]
+        inc_angle  = res_obj.run_resample(src_data=inc_angle[box[1]:box[3], box[0]:box[2]])
+        head_angle = res_obj.run_resample(src_data=head_angle[box[1]:box[3], box[0]:box[2]])
+
+        # update attribute
+        atr = attr.update_attribute4radar2geo(atr, res_obj=res_obj)
+
+    # for 'Y_FIRST' not in 'degree'
+    # e.g. meters for UTM projection from ASF HyP3
+    if not atr['Y_UNIT'].lower().startswith('deg'):
+        # get SNWE in meter
+        length, width = int(atr['LENGTH']), int(atr['WIDTH'])
+        N = float(atr['Y_FIRST'])
+        W = float(atr['X_FIRST'])
+        y_step = float(atr['Y_STEP'])
+        x_step = float(atr['X_STEP'])
+        S = N + y_step * length
+        E = W + x_step * width
+
+        # SNWE in meter --> degree
+        lat0, lon0 = to_latlon(atr['OG_FILE_PATH'], W, N)
+        lat1, lon1 = to_latlon(atr['OG_FILE_PATH'], E, S)
+        lat_step = (lat1 - lat0) / length
+        lon_step = (lon1 - lon0) / width
+
+        # update Y/X_FIRST/STEP/UNIT
+        atr['Y_FIRST'] = lat0
+        atr['X_FIRST'] = lon0
+        atr['Y_STEP'] = lat_step
+        atr['X_STEP'] = lon_step
+        atr['Y_UNIT'] = 'degrees'
+        atr['X_UNIT'] = 'degrees'
+
+    # set invalid values to nan
+    inc_angle[inc_angle == 0] = np.nan
+    head_angle[head_angle == 90] = np.nan
+
+    # unit: degree to radian
+    if unit.startswith('rad'):
+        inc_angle *= np.pi / 180.
+        head_angle *= np.pi / 180.
+
+    return inc_angle, head_angle, atr

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -366,17 +366,19 @@ def xyz_to_local_radius(xyz):
     return height, radius
 
 
-def get_lat_lon(meta, geom_file=None, box=None, dimension=2):
+def get_lat_lon(meta, geom_file=None, box=None, dimension=2, ystep=1, xstep=1):
     """Extract precise pixel-wise lat/lon.
 
     For meta dict in geo-coordinates OR geom_file with latitude/longitude dataset
 
     Returned lat/lon are corresponds to the pixel center
 
-    Parameters: meta : dict, including LENGTH, WIDTH and Y/X_FIRST/STEP
-                box  : 4-tuple of int for (x0, y0, x1, y1)
-    Returns:    lats : 2D np.array for latitude  in size of (length, width)
-                lons : 2D np.array for longitude in size of (length, width)
+    Parameters: meta      - dict, including LENGTH, WIDTH and Y/X_FIRST/STEP
+                box       - 4-tuple of int for (x0, y0, x1, y1)
+                dimension - int, output lat/lon matrix dimension, 1 or 2
+                y/xstep   - int, number of pixels to skip for each output pixel
+    Returns:    lats      - 1/2D np.array for latitude  in size of (length, _width_)
+                lons      - 1/2D np.array for longitude in size of (_length_, width)
     """
     length, width = int(meta['LENGTH']), int(meta['WIDTH'])
     if box is None:
@@ -425,6 +427,16 @@ def get_lat_lon(meta, geom_file=None, box=None, dimension=2):
 
     lats = np.array(lats, dtype=np.float32)
     lons = np.array(lons, dtype=np.float32)
+
+    # y/xstep
+    if ystep * xstep > 1:
+        if lats.ndim == 1:
+            lats = lats[::ystep]
+            lons = lons[::xstep]
+        elif lats.ndim == 2:
+            lats = lats[::ystep, ::xstep]
+            lons = lons[::ystep, ::xstep]
+
     return lats, lons
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.utils0.get_lat_lon()`: add `ystep` and `xstep` for more flexible output

+ `utils.utils.py`: add `prepare_geo_los_geometry()` from `solid_earth_tides.py` for easy re-use.

+ `bulk_plate_motion.py`:
   - support radar-coord geometry input via `resample` object to radar-code the PMM output
   - refactor `pmm2enu_at()`
   - replace scipy.interpolate with skimage.transform.resize
   - use `ut.get_lat_lon()` for coarse grid preparation
   - use `ut.prepare_geo_los_geometry()` and simplify the post-handling for unit and no-data value
   - remove the obsolete interp_2d3l(), get_geobox_width_length()
   - remove MORVEL56 example cmd, to avoid potential confusion
   - replace BulkPlateMotion.h5 with ITRF14.h5 for the default output file name. This may change in the future to other PMM names once they are auto determined with values auto grabbed.
   - use pmm internally in the code

**Reminders**

- [ ] Pass Codacy code review (green)
- [ ] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1302/workflows/be6d8b3e-1295-4386-b679-745d94cf1744/jobs/1305) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.