### PR TITLE
readfile: fix gdal_read to accept Paths

### DIFF
--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1458,6 +1458,8 @@ def read_gdal_vrt(fname):
         raise ImportError('Cannot import gdal and osr!')
 
     # read dataset using gdal
+    # Using os.fspath to convert Path objects to str, recommended by
+    # https://github.com/OSGeo/gdal/issues/1613#issuecomment-824703596
     ds = gdal.Open(os.fspath(fname), gdal.GA_ReadOnly)
 
     atr = {}
@@ -1808,6 +1810,8 @@ def read_gdal(fname, box=None, band=1, cpx_band='phase', xstep=1, ystep=1):
         raise ImportError('Cannot import gdal!')
 
     # open data file
+    # Using os.fspath to convert Path objects to str, recommended by
+    # https://github.com/OSGeo/gdal/issues/1613#issuecomment-824703596
     ds = gdal.Open(os.fspath(fname), gdal.GA_ReadOnly)
     bnd = ds.GetRasterBand(band)
 

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1458,7 +1458,7 @@ def read_gdal_vrt(fname):
         raise ImportError('Cannot import gdal and osr!')
 
     # read dataset using gdal
-    ds = gdal.Open(fname, gdal.GA_ReadOnly)
+    ds = gdal.Open(os.fspath(fname), gdal.GA_ReadOnly)
 
     atr = {}
     atr['WIDTH']  = ds.RasterXSize
@@ -1808,7 +1808,7 @@ def read_gdal(fname, box=None, band=1, cpx_band='phase', xstep=1, ystep=1):
         raise ImportError('Cannot import gdal!')
 
     # open data file
-    ds = gdal.Open(fname, gdal.GA_ReadOnly)
+    ds = gdal.Open(os.fspath(fname), gdal.GA_ReadOnly)
     bnd = ds.GetRasterBand(band)
 
     # box


### PR DESCRIPTION
GDALs python bindings fail for Path objects

https://github.com/OSGeo/gdal/issues/1613

The `os.fspath` was recommended in the issue over just using `str()` to convert.

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Without altering a `Path` input, right now GDAL throws `RuntimeError: not a string`. This uses `os.fspath` to convert the Path to something GDAL will accept.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.