### PR TITLE
remove `openmp` from the dependency list

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -23,11 +23,9 @@ dependencies:
   - pyaps3>=0.3
   - pykml>=0.2
   - pyproj
+  - pyresample
   - pysolid
   - scikit-image
   - scipy
-  # for ARIA, FRInGE, HyP3, GMTSAR
+  # for ISCE, ARIA, FRInGE, HyP3, GMTSAR
   - gdal>=3
-  # for pyresample
-  - pyresample
-  - openmp

--- a/mintpy/__main__.py
+++ b/mintpy/__main__.py
@@ -513,7 +513,7 @@ def get_view_parser(subparsers=None):
 def get_parser():
     """Instantiate the command line argument parser."""
     parser = argparse.ArgumentParser(prog=PROG, description=__doc__)
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("-v","--version", action="version", version=f"{__version__}")
 
     # Sub-command management
     sp = parser.add_subparsers(title="sub-commands", dest='func', required=True, metavar='')

--- a/mintpy/asc_desc2horz_vert.py
+++ b/mintpy/asc_desc2horz_vert.py
@@ -116,7 +116,7 @@ def cmd_line_parse(iargs=None):
     if any(ref_diff > inps.max_ref_yx_diff for ref_diff in [ref_y_diff, ref_x_diff]):
         msg = 'REF_LAT/LON difference between input files > {} pixels!\n'.format(inps.max_ref_yx_diff)
         for fname, ref_lat, ref_lon in zip(inps.file, [ref_lat1, ref_lat2], [ref_lon1, ref_lon2]):
-            msg += 'file1: {}\n'.format(fname)
+            msg += 'file: {}\n'.format(fname)
             msg += '\tREF_LAT/LON: [{:.8f}, {:.8f}]\n'.format(ref_lat, ref_lon)
         raise ValueError(msg)
 

--- a/mintpy/geocode.py
+++ b/mintpy/geocode.py
@@ -219,8 +219,11 @@ def read_template2inps(template_file, inps):
 def check_num_processor(nprocs):
     """Check number of processors
     Note by Yunjun, 2019-05-02:
-    1. conda install pyresample will install pykdtree and openmp, but it seems not working
+    1. conda install pyresample will install pykdtree and openmp, but it seems not working:
         geocode.py is getting slower with more processors
+            Test on a TS HDF5 file in size of (241, 2267, 2390)
+            Memory: up to 10GB
+            Run time: 2.5 mins for nproc=1, 3 mins for nproc=4
     2. macports seems to have minor speedup when more processors
     Thus, default number of processors is set to 1; although the capability of using multiple
     processors is written here.

--- a/mintpy/reference_point.py
+++ b/mintpy/reference_point.py
@@ -464,7 +464,9 @@ def read_reference_input(inps):
         # Do not use ref_y/x in masked out area
         if inps.maskFile and os.path.isfile(inps.maskFile):
             print('mask: '+inps.maskFile)
-            mask = readfile.read(inps.maskFile, datasetName='mask')[0]
+            ds_names = readfile.get_dataset_list(inps.maskFile)
+            ds_name = [x for x in ds_names if x in ['mask', 'waterMask']][0]
+            mask = readfile.read(inps.maskFile, datasetName=ds_name)[0]
             if mask[inps.ref_y, inps.ref_x] == 0:
                 inps.ref_y, inps.ref_x = None, None
                 msg = 'input reference point is in masked OUT area defined by {}!'.format(inps.maskFile)

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -49,7 +49,7 @@ EXAMPLE = """example:
   smallbaselineApp.py -H                      #print    default template options
   smallbaselineApp.py -g                      #generate default template if it does not exist
   smallbaselineApp.py -g <custom_template>    #generate/update default template based on custom template
-  smallbaselineApp.py --plot                  #plot results without run
+  smallbaselineApp.py --plot                  #plot results w/o run [to populate the 'pic' folder after failed runs]
 
   # Run with --start/stop/dostep options
   smallbaselineApp.py GalapagosSenDT128.template --dostep velocity  #run at step 'velocity' only
@@ -617,6 +617,12 @@ class TimeSeriesAnalysis:
             msg += "Try the following:\n"
             msg += "1) Check the reference pixel and make sure it's not in areas with unwrapping errors\n"
             msg += "2) Check the network and make sure it's fully connected without subsets"
+            print(f'ERROR: {msg}')
+
+            # populate the pic folder to facilate the trouble shooting
+            self.plot_result(print_aux=False)
+
+            # terminate the program
             raise RuntimeError(msg)
         return
 

--- a/mintpy/version.py
+++ b/mintpy/version.py
@@ -34,19 +34,19 @@ release_history = (
 release_version = release_history[0].version
 release_date = release_history[0].date
 
-def get_version_info(version='v{}'.format(release_version), date=release_date):
+def get_version_info():
     """Grab version and date of the latest commit from a git repository"""
     # go to the repository directory
     dir_orig = os.getcwd()
     os.chdir(os.path.dirname(os.path.dirname(__file__)))
 
-    # grab git info into string
     try:
+        # grab from git cmd
         cmd = "git describe --tags"
         version = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
-        version = version.decode('utf-8').strip()
+        version = version.decode('utf-8').strip()[1:]
 
-        #if there are new commits after the latest release
+        # if there are new commits after the latest release
         if '-' in version:
             version, num_commit = version.split('-')[:2]
             version += '-{}'.format(num_commit)
@@ -54,8 +54,11 @@ def get_version_info(version='v{}'.format(release_version), date=release_date):
         cmd = "git log -1 --date=short --format=%cd"
         date = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
         date = date.decode('utf-8').strip()
+
     except:
-        pass
+        # use the latest release version/date
+        version = release_version
+        date = release_date
 
     # go back to the original directory
     os.chdir(dir_orig)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,11 +18,9 @@ numpy
 pyaps3>=0.3
 pykml>=0.2
 pyproj
+pyresample
 pysolid
 scikit-image
 scipy
-# for ARIA, FRInGE, HyP3, GMTSAR
+# for ISCE, ARIA, FRInGE, HyP3, GMTSAR
 # gdal>=3
-# for pyresample
-pyresample
-openmp

--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,10 @@ setup(
         "pyaps3>=0.3",
         "pykml>=0.2",
         "pyproj",
+        "pyresample",  # pip installed version does not work
         "setuptools",
         "scikit-image",
         "scipy",
-        "pyresample",
-        # "openmp",
     ],
     extras_require={
         "cli": ["argcomplete"],


### PR DESCRIPTION
**Description of proposed changes**

+ remove `openmp` from all the dependency files, as `conda install pyresample` will install `openmp` correctly (`llvm-openmp` for linux, `libgomp` for linux; https://conda-forge.org/docs/maintainer/knowledge_base.html#openmp)

+ `version`: remove the prefix "v" from the version number, to be consistent with styles from gdal/numpy

+ `smallbaselineApp.generate_temporal_coherence_mask()`: run `plot_result()` to populate pic folder before raising errors, to facilitate the troubleshooting, as described in https://github.com/insarlab/MintPy/discussions/790#discussioncomment-3341194.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1371/workflows/a3bbf5e8-781d-4e29-a41c-57f04535758a/jobs/1374) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.