### PR TITLE
bugfix in `load_data` for empty path due to the new iono file in `auto_path`

### DIFF
--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -766,7 +766,7 @@ def prepare_metadata(iDict):
         geom_names = ['dem', 'lookupY', 'lookupX', 'incAngle', 'azAngle', 'shadowMask', 'waterMask']
         geom_keys = ['mintpy.load.{}File'.format(i) for i in geom_names]
         geom_files = [os.path.basename(iDict[key]) for key in geom_keys
-                      if (iDict.get(key, 'auto') != 'auto')]
+                      if iDict.get(key, 'auto') not in ['auto', 'None', 'no',  None, False]]
 
         # compose list of input arguments
         iargs = ['-m', meta_file, '-g', geom_dir]


### PR DESCRIPTION
**Description of proposed changes**

+ load_data.py: bugfix when empty file path found, introduced in load iono stack PR #780 due to the additional new iono file path defined in `defaults/auto_path.py`, reported in the user forum (https://groups.google.com/g/mintpy/c/U80jnQWIFkI).

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1386/workflows/703d5746-8092-4fb4-bdfe-f9add4124bff/jobs/1388) (green)