### PR TITLE
automate PyPI publishing with GitHub Actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   dockerize:
+    name: Build Docker image and push to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +32,7 @@ jobs:
       - name: Set environment variables for docker build
         run: |
           # Lowercase repo for Github Container Registry
-          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
           # Ensure tags are checked out
           git fetch origin +refs/tags/*:refs/tags/*
           # Version number from tag

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-n-publish:
-    if: github.repository_owner == 'insarlab' || github.repository_owner == 'yunjunz'
+    if: github.repository_owner == 'insarlab'
 
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
@@ -46,11 +46,11 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
+        skip_existing: false
         verbose: true
 
     - name: Publish released version 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'insarlab'
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,56 @@
+# link: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: publish distributions 📦 to PyPI and TestPyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-n-publish:
+    if: github.repository_owner == 'insarlab' || github.repository_owner == 'yunjunz'
+
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish developed version 📦 to Test PyPI
+      if: github.ref == 'refs/heads/main'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
+        verbose: true
+
+    - name: Publish released version 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'insarlab'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true
+

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 
 jobs:
   build-n-publish:

--- a/mintpy/__init__.py
+++ b/mintpy/__init__.py
@@ -1,5 +1,5 @@
 # get version info
 from mintpy.version import (
-    version_num as __version__,
+    version as __version__,
     logo as __logo__,
 )

--- a/mintpy/version.py
+++ b/mintpy/version.py
@@ -67,9 +67,9 @@ def get_version_info():
 
 ###########################################################################
 
-version_num, version_date = get_version_info()
+version, version_date = get_version_info()
 version_description = """MintPy version {v}, date {d}""".format(
-    v=version_num,
+    v=version,
     d=version_date,
 )
 
@@ -90,7 +90,7 @@ ___________________________________________________________
    Miami InSAR Time-series software in Python    \______/ 
           MintPy {v}, {d}
 ___________________________________________________________
-""".format(v=version_num, d=version_date)
+""".format(v=version, d=version_date)
 
 website = 'https://github.com/insarlab/MintPy'
 

--- a/setup.py
+++ b/setup.py
@@ -5,25 +5,19 @@
 # Author: Zhang Yunjun, Nov 2020                           #
 ############################################################
 
-
+import os
+import sys
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 
+# Grab version and description from version.py
+# link: https://stackoverflow.com/questions/53648900
+sys.path.append(os.path.dirname(__file__))
+from mintpy.version import version, description
 
-# Grab from README file: long_description
+# Grab long_description from README.md
 with open("docs/README.md", "r") as f:
     long_description = f.read()
-
-# Grab from version.py file: version and description
-with open("mintpy/version.py", "r") as f:
-    lines = f.readlines()
-    # version
-    line = [line for line in lines if line.strip().startswith("Tag(")][0].strip()
-    version = line.replace("'",'"').split('"')[1]
-    # description
-    line = [line for line in lines if line.startswith("description")][0].strip()
-    description = line.replace("'",'"').split('"')[1]
-
 
 setup(
     name="mintpy",


### PR DESCRIPTION
**Description of proposed changes**

+ version: replace version_num with version for easy re-use, and update its usage in __inti__.py

+ setup: use sys.path.append() to replace open() to grab version from version.py

+ add .github/workflows/publish-to-test-pypi.yml:
   - triggered for push event on main branch
   - run only if repo owner is insarlab or yunjunz, due to the limited access to the PyPI token
   - use "pip install" and "python -m build" to build the binary wheel and source tarball
   - use pypa/gh-action-pypi-publish action to push to PyPI and TestPyPI
   - enable skip_existing for TestPyPI to avoid frequent existing errors
   - push to PyPI only for released version and when owner is insarlab

+ repo setting: add github secrets from pypi and test-pypi, to support the above action

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1389/workflows/246eb9cf-cb88-48ed-a9fd-5c2bd1aed041/jobs/1391) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.