### PR TITLE
ts2vel: save `residue` & `intercept`

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -41,7 +41,7 @@ jobs:
         .
 
     - name: Publish developed version 📦 to Test PyPI
-      if: github.ref == 'refs/heads/main'
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
**Description of proposed changes**

+ timeseries2velocity.py:
   - save `residue` for the overall fitting residues, a useful parameter to evaluate the fitting quality
   - save `intercept` for the Y-axis intercept of the polynomial function, to be able to reconstruct the time-series completely.

+ .github/workflows/pypi: publish the release to test-pypi as well

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1417/workflows/c402bcb1-be12-4fdd-ab14-3db284ab91b7/jobs/1420) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.