### PR TITLE
readfile: allow ENVI files created with SUFFIX=ADD

### DIFF
--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1050,6 +1050,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             fname + '.xml',
             fname + '.par',
             os.path.splitext(fname)[0] + '.hdr',
+            fname + '.hdr',
             fname + '.vrt',
             fname + '.aux.xml',
         ]

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1049,8 +1049,8 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             fname + '.rsc',
             fname + '.xml',
             fname + '.par',
-            os.path.splitext(fname)[0] + '.hdr',
-            fname + '.hdr',
+            fname + '.hdr',                        # created with SUFFIX=ADD     in gdal envi driver
+            os.path.splitext(fname)[0] + '.hdr',   # created with SUFFIX=REPLACE in gdal envi driver
             fname + '.vrt',
             fname + '.aux.xml',
         ]


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->
The GDAL creation option "SUFFIX=ADD" will append .hdr to the name, rather than replace the suffix. https://gdal.org/drivers/raster/envi.html

This addition will search for that extra naming convention for ENVI files and not miss the metadata.


**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.