### PR TITLE
unmask ref pixel in ts2vel and tsview

### DIFF
--- a/mintpy/timeseries2velocity.py
+++ b/mintpy/timeseries2velocity.py
@@ -616,7 +616,9 @@ def run_timeseries2time_func(inps):
         # write - residual file
         if inps.save_res:
             block = [0, num_date, box[1], box[3], box[0], box[2]]
-            ts_res = np.ones((num_date, box_len*box_wid), dtype=np.float32) * np.nan
+            ts_res = np.full((num_date, box_len, box_wid), np.nan, dtype=np.float32)
+            ts_res[:, inps.ref_yx] = 0
+            ts_res = ts_res.reshape(num_date, -1)
             ts_res[:, mask] = ts_data - np.dot(G, m)[:, mask]
             writefile.write_hdf5_block(inps.res_file,
                                        data=ts_res.reshape(num_date, box_len, box_wid),

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -466,7 +466,8 @@ def read_timeseries_data(inps):
     del ts_stack
 
     # do not mask the reference point
-    if inps.ref_yx and inps.ref_yx != (int(atr.get('REF_Y', -1)), int(atr.get('REF_X', -1))):
+    x0, y0, x1, y1 = inps.pix_box
+    if inps.ref_yx and (x0 <= inps.ref_yx[1] < x1) and (y0 <= inps.ref_yx[0] < y1):
         (ry, rx) = subset_and_multilook_yx(inps.ref_yx, inps.pix_box, inps.multilook_num)
         mask[ry, rx] = True
 

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -180,11 +180,10 @@ def auto_figure_title(fname, datasetNames=[], inps_dict=None):
             fig_title = '{}_{}'.format(ref_date, datasetNames[0])
 
         # grab info of applied phase corrections from filename
-        try:
-            processMark = os.path.basename(fname).split('timeseries')[1].split(fext)[0]
-            fig_title += processMark
-        except:
-            pass
+        if 'timeseries' in fname:
+            proc_suffix = os.path.basename(fname).split('timeseries')[1].split(fext)[0]
+            if proc_suffix:
+                fig_title += proc_suffix if proc_suffix.startswith('_') else f'_{proc_suffix}'
 
     elif k == 'geometry':
         if len(datasetNames) == 1:


### PR DESCRIPTION
when the `timeseriesResidual.h5` is created with `timeseries2velocity.py --save-res`, the reference pixel time series is overwritten with `np.nan`. 

Then, when plotting (e.g., `tsview.py`) the whole dataset is masked out because it gets referenced back to the nan time series. This fix just preserves the 0 vector timeseries at the reference point.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.