### PR TITLE
fix typo in `smallbaselineApp.cfg` for `stepDate`

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -299,7 +299,7 @@ mintpy.timeFunc.excludeDate = auto   #[exclude_date.txt / 20080520,20090817 / no
 ##   20110311,60;20170908,120 - separated by ";"
 mintpy.timeFunc.polynomial = auto   #[int >= 0], auto for 1, degree of the polynomial function
 mintpy.timeFunc.periodic   = auto   #[1,0.5 / list_of_float / no], auto for no, periods in decimal years
-mintpy.timeFunc.step       = auto   #[20110311,20170908 / 20120928T1733 / no], auto for no, step function(s)
+mintpy.timeFunc.stepDate   = auto   #[20110311,20170908 / 20120928T1733 / no], auto for no, step function(s)
 mintpy.timeFunc.exp        = auto   #[20110311,60 / 20110311,60,120 / 20110311,60;20170908,120 / no], auto for no
 mintpy.timeFunc.log        = auto   #[20110311,60 / 20110311,60,120 / 20110311,60;20170908,120 / no], auto for no
 


### PR DESCRIPTION
**Description of proposed changes**

Minor change to smallbaselineApp.cfg to reflect a modification in the key regarding step function in the code timeseries2velocity.py due to https://github.com/insarlab/MintPy/pull/823.
.
**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.