### PR TITLE
support azimuth output for `solid_earth_tides` and `bulk_plate_motion`

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - pyproj
   - pyresample
   - pysolid
+  - rich
   - scikit-image
   - scipy
   # for ISCE, ARIA, FRInGE, HyP3, GMTSAR

--- a/docs/ports.txt
+++ b/docs/ports.txt
@@ -1,3 +1,4 @@
+# compilers
 gcc5
 gcc7
 cmake
@@ -66,29 +67,30 @@ samba3
 swig
 swig-python
 gdal +expat +geos +hdf5 +netcdf +openjpeg +postgresql95 +sqlite3
+py37-bokeh
+py37-cartopy
+py37-cvxopt +accelerate +dsdp +fftw +glpk +gsl
 py37-cython
+py37-dask
 py37-defusedxml
+py37-distributed
 py37-gdbm
+py37-h5py
+py37-joblib
+py37-jupyter
 py37-mpi4py +gcc7 +openmpi
 py37-numpy +gcc7 +openblas
 py37-scipy +gcc7 +openblas
 py37-matplotlib +cairo +tkinter +webagg
 py37-netcdf4 +gcc7
 py37-pandas
-py37-yaml
-py37-h5py
-py37-cartopy
-py37-shapely
+py37-pip
+py37-rich
 py37-scikit-image
 py37-scikit-learn
-py37-jupyter
-py37-dask
-py37-distributed
-py37-bokeh
+py37-shapely
 py37-sphinx
-py37-pip
-py37-cvxopt +accelerate +dsdp +fftw +glpk +gsl
-py37-joblib
+py37-yaml
 kealib
 pandoc
 zmq

--- a/mintpy/cli/bulk_plate_motion.py
+++ b/mintpy/cli/bulk_plate_motion.py
@@ -27,7 +27,7 @@ REFERENCE = """reference:
     Altamimi, Z., Métivier, L., Rebischung, P., Rouby, H., & Collilieux, X. (2017).
     ITRF2014 plate motion model. Geophysical Journal International, 209(3), 1906-1912.
     doi:10.1093/gji/ggx136
-  MORVEL56 - Table 1 of Argus et al. (2011) - 56 plates
+  MORVEL - Table 1 of Argus et al. (2011) - 56 plates
     Argus, D. F., Gordon, R. G., & DeMets, C. (2011). Geologically current motion of 56
     plates relative to the no-net-rotation reference frame. Geochemistry, Geophysics, Geosystems, 12(11).
     doi:10.1029/2011GC003751
@@ -38,6 +38,7 @@ EXAMPLE = """example:
   # e.g., Arabia plate in ITRF14-PMM (Table 1 in Altamimi et al., 2017)
   bulk_plate_motion.py -g inputs/geometryGeo.h5   --om-cart 1.154 -0.136  1.444 -v velocity.h5
   bulk_plate_motion.py -g inputs/geometryRadar.h5 --om-cart 1.154 -0.136  1.444
+  bulk_plate_motion.py -g inputs/geometryRadar.h5 --om-cart 1.154 -0.136  1.444 --comp en2az
 
   # Simple constant local ENU translation (based on one GNSS vector) in [ve, vn, vu] in unit of m/year
   #   E.g., https://www.unavco.org/software/visualization/GPS-Velocity-Viewer/GPS-Velocity-Viewer.html
@@ -69,6 +70,8 @@ def create_parser(subparsers=None):
                         help='Input velocity file to be corrected.')
     parser.add_argument('-o', '--output', dest='cor_vel_file', type=str,
                         help='Output velocity file after the correction, default: add "_ITRF14" suffix.')
+    parser.add_argument('--comp', dest='pmm_comp', choices={'enu2los', 'en2az'}, default='enu2los',
+                        help='Convert the ENU components into the component of interest for radar (default: %(default)s).')
 
     # plate motion configurations
     pmm = parser.add_mutually_exclusive_group(required=True)
@@ -91,8 +94,10 @@ def cmd_line_parse(iargs=None):
 
     # default: output PMM filenames
     geom_dir = os.path.dirname(inps.geom_file)
-    inps.pmm_enu_file = os.path.join(geom_dir, 'ITRF14ENU.h5')
-    inps.pmm_los_file = os.path.join(geom_dir, 'ITRF14.h5')
+    inps.pmm_enu_file = os.path.join(geom_dir, 'ITRF14enu.h5')
+    inps.pmm_file = os.path.join(geom_dir, 'ITRF14.h5')
+    if inps.pmm_comp.endswith('2az'):
+        inps.pmm_file = os.path.join(geom_dir, 'ITRF14az.h5')
 
     # default: --output option
     if inps.vel_file and not inps.cor_vel_file:

--- a/mintpy/cli/save_kmz.py
+++ b/mintpy/cli/save_kmz.py
@@ -108,7 +108,7 @@ def cmd_line_parse(iargs=None):
     inps = parser.parse_args(args=iargs)
 
     # import
-    from mintpy.objects import timeseriesKeyNames
+    from mintpy.objects import TIMESERIES_KEY_NAMES
     from mintpy.utils import readfile, utils as ut
 
     # check
@@ -131,7 +131,7 @@ def cmd_line_parse(iargs=None):
 
     # check: dset option (required for timeseries and ifgramStack files)
     ftype = atr['FILE_TYPE']
-    if not inps.dset and ftype in timeseriesKeyNames + ['ifgramStack']:
+    if not inps.dset and ftype in TIMESERIES_KEY_NAMES + ['ifgramStack']:
         raise Exception(f'No date/date12 specified for {ftype} file!')
 
     return inps

--- a/mintpy/cli/view.py
+++ b/mintpy/cli/view.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
 # Author: Antonio Valentino, Zhang Yunjun, Aug 2022        #
 ############################################################
+# Recommend import:
+#   from mintpy.cli import view
 
 
 import os

--- a/mintpy/diff.py
+++ b/mintpy/diff.py
@@ -11,11 +11,11 @@ import time
 import numpy as np
 
 from mintpy.objects import (
+    IFGRAM_DSET_NAMES,
     cluster,
     timeseries,
     giantTimeseries,
     ifgramStack,
-    ifgramDatasetNames,
 )
 from mintpy.utils import readfile, writefile
 
@@ -165,7 +165,7 @@ def diff_file(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
         ds_names = list(set(obj1.datasetNames) & set(obj2.datasetNames))
         if len(ds_names) == 0:
             raise ValueError('no common dataset between two files!')
-        ds_name = [i for i in ifgramDatasetNames if i in ds_names][0]
+        ds_name = [i for i in IFGRAM_DSET_NAMES if i in ds_names][0]
 
         # read data
         print('reading {} from file {} ...'.format(ds_name, file1))

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -13,9 +13,9 @@ import warnings
 
 from mintpy.defaults import auto_path
 from mintpy.objects import (
-    geometryDatasetNames,
+    GEOMETRY_DSET_NAMES,
+    IFGRAM_DSET_NAMES,
     geometry,
-    ifgramDatasetNames,
     ifgramStack,
     sensor,
 )
@@ -336,7 +336,7 @@ def read_inps_dict2ifgram_stack_dict_object(iDict, ds_name2template_key):
     print('input data files:')
     max_digit = max([len(i) for i in list(ds_name2template_key.keys())])
     dsPathDict = {}
-    for dsName in [i for i in ifgramDatasetNames if i in ds_name2template_key.keys()]:
+    for dsName in [i for i in IFGRAM_DSET_NAMES if i in ds_name2template_key.keys()]:
         key = ds_name2template_key[dsName]
         if key in iDict.keys():
             files = sorted(glob.glob(str(iDict[key])))
@@ -471,7 +471,7 @@ def read_inps_dict2geometry_dict_object(iDict, dset_name2template_key):
     print('input data files:')
     max_digit = max([len(i) for i in list(dset_name2template_key.keys())])
     dsPathDict = {}
-    for dsName in [i for i in geometryDatasetNames if i in dset_name2template_key.keys()]:
+    for dsName in [i for i in GEOMETRY_DSET_NAMES if i in dset_name2template_key.keys()]:
         key = dset_name2template_key[dsName]
         if key in iDict.keys():
             files = sorted(glob.glob(str(iDict[key])))
@@ -489,7 +489,7 @@ def read_inps_dict2geometry_dict_object(iDict, dset_name2template_key):
                     print(f'{dsName:<{max_digit}}: {files[0]}')
 
     # Check required dataset
-    dsName0 = geometryDatasetNames[0]
+    dsName0 = GEOMETRY_DSET_NAMES[0]
     if dsName0 not in dsPathDict.keys():
         print('WARNING: No reqired {} data files found!'.format(dsName0))
 

--- a/mintpy/mask.py
+++ b/mintpy/mask.py
@@ -105,15 +105,15 @@ def mask_isce_file(in_file, mask_file, out_file=None):
     num_band = int(atr['BANDS'])
 
     # default short name for data type from ISCE
-    dataTypeDict = {
+    data_type_dict = {
         'byte': 'bool_',
         'float': 'float32',
         'double': 'float64',
         'cfloat': 'complex64',
     }
     data_type = atr['DATA_TYPE'].lower()
-    if data_type in dataTypeDict.keys():
-        data_type = dataTypeDict[data_type]
+    if data_type in data_type_dict.keys():
+        data_type = data_type_dict[data_type]
 
     print('read {}'.format(in_file))
     print('setting the (phase) value on the masked out pixels to zero')

--- a/mintpy/objects/giant.py
+++ b/mintpy/objects/giant.py
@@ -13,14 +13,16 @@ import h5py
 import numpy as np
 
 
-giantDatasetNames = ['recons',        #Reconstructed filtered time-series in mm
-                     'rawts',         #Raw time-series in mm
-                     'ifgcnt',        #Number of interferograms used for every pixel.
-                     'figram',        #Deramped + atmosphere corrected interferograms. in mm
-                     'igram',         #Unwrapped IFGs read straight from files in mm
-                     'cmask',         #Common mask for pixels
-                     'igram_aps',     #Atmosphere corrected interferogram stack in mm
-                     'sar_aps']       #Atmospheric phase screen for each of the SAR scenes in mm
+GIANT_DSET_NAMES = [
+    'recons',        #Reconstructed filtered time-series in mm
+    'rawts',         #Raw time-series in mm
+    'ifgcnt',        #Number of interferograms used for every pixel.
+    'figram',        #Deramped + atmosphere corrected interferograms. in mm
+    'igram',         #Unwrapped IFGs read straight from files in mm
+    'cmask',         #Common mask for pixels
+    'igram_aps',     #Atmosphere corrected interferogram stack in mm
+    'sar_aps',       #Atmospheric phase screen for each of the SAR scenes in mm
+]
 
 
 ########################################################################################
@@ -56,12 +58,12 @@ class giantTimeseries:
 
         # Dataset Info
         with h5py.File(self.file, 'r') as f:
-            # get existed datasetNames in the order of ifgramDatasetNames
+            # get existed datasetNames in the order of GIANT_DSET_NAMES
             dsNames = [i for i in f.keys()
                        if (isinstance(f[i], h5py.Dataset)
                            and f[i].shape[-2:] == (self.length, self.width))]
-            self.datasetNames = [i for i in giantDatasetNames if i in dsNames]
-            self.datasetNames += [i for i in dsNames if i not in giantDatasetNames]
+            self.datasetNames = [i for i in GIANT_DSET_NAMES if i in dsNames]
+            self.datasetNames += [i for i in dsNames if i not in GIANT_DSET_NAMES]
 
             self.sliceList = []
             for dsName in self.datasetNames:
@@ -140,12 +142,12 @@ class giantIfgramStack:
         # Dataset Info
         with h5py.File(self.file, 'r') as f:
             self.pbaseIfgram = f['bperp'][:]
-            # get existed datasetNames in the order of ifgramDatasetNames
+            # get existed datasetNames in the order of GIANT_DSET_NAMES
             dsNames = [i for i in f.keys()
                        if (isinstance(f[i], h5py.Dataset)
                            and f[i].shape[-2:] == (self.length, self.width))]
-            self.datasetNames = [i for i in giantDatasetNames if i in dsNames]
-            self.datasetNames += [i for i in dsNames if i not in giantDatasetNames]
+            self.datasetNames = [i for i in GIANT_DSET_NAMES if i in dsNames]
+            self.datasetNames += [i for i in dsNames if i not in GIANT_DSET_NAMES]
 
             self.sliceList = []
             for dsName in self.datasetNames:

--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -35,15 +35,15 @@ def dload_site_list(out_file=None, print_msg=True):
 
 
 def search_gps(SNWE, start_date=None, end_date=None, site_list_file=None, min_num_solution=50, print_msg=True):
-    """Search available GPS sites within the geo bounding box from UNR website
-    Parameters: SNWE       : tuple of 4 float, indicating (South, North, West, East) in degrees
-                start_date : string in YYYYMMDD format
-                end_date   : string in YYYYMMDD format
-                site_list_file : string.
-                min_num_solution : int, minimum number of solutions available
-    Returns:    site_names : 1D np.array of string for GPS station names
-                site_lats  : 1D np.array for lat
-                site_lons  : 1D np.array for lon
+    """Search available GPS sites within the geo bounding box from UNR website.
+    Parameters: SNWE             - tuple of 4 float, indicating (South, North, West, East) in degrees
+                start_date       - str in YYYYMMDD format
+                end_date         - str in YYYYMMDD format
+                site_list_file   - str.
+                min_num_solution - int, minimum number of solutions available
+    Returns:    site_names       - 1D np.array of string for GPS station names
+                site_lats        - 1D np.array for lat
+                site_lons        - 1D np.array for lon
     """
     # download site list file if it's not found in current directory
     if site_list_file is None:
@@ -84,11 +84,11 @@ def search_gps(SNWE, start_date=None, end_date=None, site_list_file=None, min_nu
 
 def get_baseline_change(dates1, pos_x1, pos_y1, pos_z1,
                         dates2, pos_x2, pos_y2, pos_z2):
-    """Calculate the baseline change between two GPS displacement time-series
-    Parameters: dates1/2     : 1D np.array of datetime.datetime object
-                pos_x/y/z1/2 : 1D np.ndarray of displacement in meters in np.float32
-    Returns:    dates        : 1D np.array of datetime.datetime object for the common dates
-                bases        : 1D np.ndarray of displacement in meters in np.float32 for the common dates
+    """Calculate the baseline change between two GPS displacement time-series.
+    Parameters: dates1/2     - 1D np.array of datetime.datetime object
+                pos_x/y/z1/2 - 1D np.ndarray of displacement in meters in np.float32
+    Returns:    dates        - 1D np.array of datetime.datetime object for the common dates
+                bases        - 1D np.ndarray of displacement in meters in np.float32 for the common dates
     """
     dates = np.array(sorted(list(set(dates1) & set(dates2))))
     bases = np.zeros(dates.shape, dtype=np.float64)
@@ -108,18 +108,18 @@ def get_gps_los_obs(meta, obs_type, site_names, start_date, end_date, gps_comp='
                     horz_az_angle=-90., print_msg=True, redo=False):
     """Get the GPS LOS observations given the query info.
 
-    Parameters: meta       - dict, dictionary of metadata of the InSAR file
-                obs_type   - str, GPS observation data type, displacement or velocity.
-                site_names - list of str, GPS sites, output of search_gps()
-                start_date - str, date in YYYYMMDD format
-                end_date   - str, date in YYYYMMDD format
-                gps_comp   - str, flag of projecting 2/3D GPS into LOS
-                             e.g. enu2los, hz2los, up2los
+    Parameters: meta          - dict, dictionary of metadata of the InSAR file
+                obs_type      - str, GPS observation data type, displacement or velocity.
+                site_names    - list of str, GPS sites, output of search_gps()
+                start_date    - str, date in YYYYMMDD format
+                end_date      - str, date in YYYYMMDD format
+                gps_comp      - str, flag of projecting 2/3D GPS into LOS
+                                e.g. enu2los, hz2los, up2los
                 horz_az_angle - float, azimuth angle of the horizontal motion in degree
-                             measured from the north with anti-clockwise as positive
-                print_msg  - bool, print verbose info
-                redo       - bool, ignore existing CSV file and re-calculate
-    Returns:    site_obs   - 1D np.ndarray(), GPS LOS velocity or displacement in m or m/yr
+                                measured from the north with anti-clockwise as positive
+                print_msg     - bool, print verbose info
+                redo          - bool, ignore existing CSV file and re-calculate
+    Returns:    site_obs      - 1D np.ndarray(), GPS LOS velocity or displacement in m or m/yr
     Examples:   from mintpy.objects import gps
                 from mintpy.utils import readfile, utils as ut
                 meta = readfile.read_attribute('geo/geo_velocity.h5')
@@ -380,11 +380,11 @@ class GPS:
         return self.site_lat, self.site_lon
 
     def read_displacement(self, start_date=None, end_date=None, print_msg=True, display=False):
-        """ Read GPS displacement time-series (defined by start/end_date)
-        Parameters: start/end_date : str in YYYYMMDD format
-        Returns:    dates : 1D np.ndarray of datetime.datetime object
-                    dis_e/n/u : 1D np.ndarray of displacement in meters in np.float32
-                    std_e/n/u : 1D np.ndarray of displacement STD in meters in np.float32
+        """ Read GPS displacement time-series (defined by start/end_date).
+        Parameters: start/end_date - str in YYYYMMDD format
+        Returns:    dates          - 1D np.ndarray of datetime.datetime object
+                    dis_e/n/u      - 1D np.ndarray of displacement in meters in np.float32
+                    std_e/n/u      - 1D np.ndarray of displacement STD in meters in np.float32
         """
         # download file if it's not exists.
         if not os.path.isfile(self.file):
@@ -437,42 +437,24 @@ class GPS:
 
     #####################################  Utility Functions ###################################
     def displacement_enu2los(self, inc_angle:float, az_angle:float, gps_comp='enu2los', horz_az_angle=-90.):
-        """Convert displacement in ENU to LOS direction
-        Parameters: inc_angle : float, LOS incidence angle in degree
-                    az_angle  : float, LOS aziuth angle in degree
-                        from the north, defined as positive in clock-wise direction
-                    gps_comp  : string, GPS components used to convert to LOS direction
-                    horz_az_angle : float, fault azimuth angle used to convert horizontal to fault-parallel
-        Returns:    dis_los  : 1D np.array for displacement in LOS direction
-                    std_los  : 1D np.array for displacement standard deviation in LOS direction
+        """Convert displacement in ENU to LOS direction.
+
+        Parameters: inc_angle     - float, LOS incidence angle in degree
+                    az_angle      - float, LOS aziuth angle in degree
+                                    from the north, defined as positive in clock-wise direction
+                    gps_comp      - str, GPS components used to convert to LOS direction
+                    horz_az_angle - float, fault azimuth angle used to convert horizontal to fault-parallel
+                                    measured from the north with anti-clockwise as positive
+        Returns:    dis_los       - 1D np.array for displacement in LOS direction
+                    std_los       - 1D np.array for displacement standard deviation in LOS direction
         """
-        inc_angle *= np.pi/180.
-        az_angle *= np.pi/180.
-        horz_az_angle *= np.pi/180.
-
-        # get LOS unit vector
-        unit_vec = [np.sin(inc_angle) * np.sin(az_angle) * -1,
-                    np.sin(inc_angle) * np.cos(az_angle),
-                    np.cos(inc_angle)]
-
-        gps_comp = gps_comp.lower()
-        if gps_comp in ['enu2los']:
-            pass
-        elif gps_comp in ['en2los', 'hz2los']:
-            unit_vec[2] = 0.
-        elif gps_comp in ['u2los', 'up2los']:
-            unit_vec[0] = 0.
-            unit_vec[1] = 0.
-        elif gps_comp in ['horz','horizontal']:
-            unit_vec[0] = np.sin(horz_az_angle) * -1
-            unit_vec[1] = np.cos(horz_az_angle)
-            unit_vec[2] = 0.
-        elif gps_comp in ['vert','vertical']:
-            unit_vec[0] = 0.
-            unit_vec[1] = 0.
-            unit_vec[2] = 1.
-        else:
-            raise ValueError('Un-known input gps components:'+str(gps_comp))
+        # get unit vector for the component of interest
+        unit_vec = ut.get_unit_vector4component_of_interest(
+            los_inc_angle=inc_angle,
+            los_az_angle=az_angle,
+            comp=gps_comp.lower(),
+            horz_az_angle=horz_az_angle,
+        )
 
         # convert ENU to LOS direction
         self.dis_los = (  self.dis_e * unit_vec[0]
@@ -516,18 +498,18 @@ class GPS:
 
     def read_gps_los_displacement(self, geom_obj, start_date=None, end_date=None, ref_site=None,
                                   gps_comp:str='enu2los', horz_az_angle=-90., print_msg=False):
-        """Read GPS displacement in LOS direction
-        Parameters: geom_obj : dict / str, metadata of InSAR file, or geometry file path
-                    start_date : string in YYYYMMDD format
-                    end_date   : string in YYYYMMDD format
-                    ref_site   : string, reference GPS site
-                    gps_comp   : string, GPS components used to convert to LOS direction
-                    az_angle   : float, fault azimuth angle used to convert horizontal to fault-parallel
-        Returns:    dates : 1D np.array of datetime.datetime object
-                    dis   : 1D np.array of displacement in meters
-                    std   : 1D np.array of displacement uncertainty in meters
-                    site_lalo : tuple of 2 float, lat/lon of GPS site
-                    ref_site_lalo : tuple of 2 float, lat/lon of reference GPS site
+        """Read GPS displacement in LOS direction.
+
+        Parameters: geom_obj      - dict / str, metadata of InSAR file, or geometry file path
+                    start_date    - str in YYYYMMDD format
+                    end_date      - str in YYYYMMDD format
+                    ref_site      - str, reference GPS site
+                    gps_comp      - str, GPS components used to convert to LOS direction
+                    horz_az_angle - float, fault azimuth angle used to convert horizontal to fault-parallel
+        Returns:    dates         - 1D np.array of datetime.datetime object
+                    dis/std       - 1D np.array of displacement / uncertainty in meters
+                    site_lalo     - tuple of 2 float, lat/lon of GPS site
+                    ref_site_lalo - tuple of 2 float, lat/lon of reference GPS site
         """
         # read GPS object
         inc_angle, az_angle = self.get_los_geometry(geom_obj)
@@ -592,4 +574,3 @@ class GPS:
         return self.velocity, dis
 
 #################################### End of GPS-UNR class ####################################
-

--- a/mintpy/objects/gps.py
+++ b/mintpy/objects/gps.py
@@ -497,7 +497,7 @@ class GPS:
 
 
     def read_gps_los_displacement(self, geom_obj, start_date=None, end_date=None, ref_site=None,
-                                  gps_comp:str='enu2los', horz_az_angle=-90., print_msg=False):
+                                  gps_comp='enu2los', horz_az_angle=-90., print_msg=False):
         """Read GPS displacement in LOS direction.
 
         Parameters: geom_obj      - dict / str, metadata of InSAR file, or geometry file path

--- a/mintpy/objects/ionex.py
+++ b/mintpy/objects/ionex.py
@@ -284,7 +284,7 @@ def read_ionex(tec_file):
     # link: https://github.com/daniestevez/jupyter_notebooks/blob/master/IONEX.ipynb
     def parse_map(tec_map, key='TEC', exponent=-1):
         tec_map = re.split(f'.*END OF {key} MAP', tec_map)[0]
-        tec_map = [np.fromstring(l, sep=' ') for l in re.split('.*LAT/LON1/LON2/DLON/H\\n', tec_map)[1:]]
+        tec_map = [np.fromstring(x, sep=' ') for x in re.split('.*LAT/LON1/LON2/DLON/H\\n', tec_map)[1:]]
         return np.stack(tec_map) * 10**exponent
 
     # read IONEX file
@@ -376,6 +376,7 @@ def plot_ionex(tec_file, save_fig=False):
     # update image
     global ind
     ind = 0
+
     def animate(*args):
         global ind
         ind += 1

--- a/mintpy/objects/ionex.py
+++ b/mintpy/objects/ionex.py
@@ -17,12 +17,8 @@ import datetime as dt
 
 import numpy as np
 from scipy import interpolate
-from matplotlib import pyplot as plt
-from matplotlib.animation import FuncAnimation
-from cartopy import crs as ccrs
 
 from mintpy.utils import ptime
-from mintpy.utils.map import draw_lalo_label, round_to_1
 
 
 IGS_SOLUTION_NAMES = {
@@ -335,6 +331,11 @@ def plot_ionex(tec_file, save_fig=False):
                 save_fig - bool, save the animation to file
     Returns:    out_fig  - str, path to the output animation file
     """
+    from cartopy import crs as ccrs
+    from matplotlib import pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    from mintpy.utils.map import draw_lalo_label, round_to_1
 
     # read TEC file
     sol_code = os.path.basename(tec_file)[:3]
@@ -353,10 +354,20 @@ def plot_ionex(tec_file, save_fig=False):
     # init figure
     proj_obj = ccrs.PlateCarree()
     fig, ax = plt.subplots(figsize=[9, 4], subplot_kw=dict(projection=proj_obj))
-    im = ax.imshow(tec_maps[0,:,:], vmin=0, vmax=vmax, extent=(W, E, S, N),
-                   origin='upper', animated=True, interpolation='nearest')
+    im = ax.imshow(
+        tec_maps[0,:,:], vmin=0, vmax=vmax,
+        extent=(W, E, S, N), origin='upper',
+        animated=True, interpolation='nearest',
+    )
+
     ax.coastlines()
-    draw_lalo_label(ax, geo_box=(W, N, E, S), projection=proj_obj, print_msg=False)
+    draw_lalo_label(
+        ax,
+        geo_box=(W, N, E, S),
+        projection=proj_obj,
+        print_msg=False,
+    )
+
     # colorbar
     cbar = fig.colorbar(im, shrink=0.5)
     cbar.set_label('TECU')

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -19,7 +19,7 @@ from mintpy.utils import ptime
 
 ##------------------ Global Variables ---------------------##
 
-dataTypeDict = {
+DATA_TYPE_DICT = {
     'bool': np.bool_, 'byte': np.bool_, 'flag': np.bool_,
     'int': np.int16, 'int16': np.int16, 'short': np.int16, 'int32': np.int32,
     'int64': np.int64, 'long': np.int64,
@@ -30,9 +30,9 @@ dataTypeDict = {
     'complex128': np.complex128, 'complex_': np.complex128, 'cpx_float64': np.complex128,
 }
 
-timeseriesKeyNames = ['timeseries', 'HDFEOS', 'giantTimeseries']
+TIMESERIES_KEY_NAMES = ['timeseries', 'HDFEOS', 'giantTimeseries']
 
-timeseriesDatasetNames = [
+TIMESERIES_DSET_NAMES = [
     'timeseries',
     'raw',
     'troposphericDelay',
@@ -41,12 +41,14 @@ timeseriesDatasetNames = [
     'displacement',
 ]
 
-geometryDatasetNames = [
+GEOMETRY_DSET_NAMES = [
+    # coordinates
     'height',
     'latitude',
     'longitude',
     'rangeCoord',
     'azimuthCoord',
+    # others
     'incidenceAngle',
     'azimuthAngle',
     'slantRangeDistance',
@@ -56,7 +58,7 @@ geometryDatasetNames = [
     'bperp',
 ]
 
-ifgramDatasetNames = [
+IFGRAM_DSET_NAMES = [
     # interferogram
     'unwrapPhase',
     'unwrapPhase_bridging_phaseClosure',
@@ -75,7 +77,7 @@ ifgramDatasetNames = [
     'refPhase',
 ]
 
-datasetUnitDict = {
+DSET_UNIT_DICT = {
     # interferogram
     'unwrapPhase'      : 'radian',
     'coherence'        : '1',
@@ -325,7 +327,7 @@ class timeseries:
             # get ref file compression type if input compression is None
             if compression is None:
                 with h5py.File(refFile, 'r') as rf:
-                    compression = rf[timeseriesDatasetNames[0]].compression
+                    compression = rf[TIMESERIES_DSET_NAMES[0]].compression
             refobj.close(print_msg=False)
         data = np.array(data, dtype=np.float32)
         dates = np.array(dates, dtype=np.string_)
@@ -582,7 +584,7 @@ class geometry:
 
     def get_size(self):
         with h5py.File(self.file, 'r') as f:
-            dsName = [i for i in f.keys() if i in geometryDatasetNames][0]
+            dsName = [i for i in f.keys() if i in GEOMETRY_DSET_NAMES][0]
             dsShape = f[dsName].shape
             if len(dsShape) == 3:
                 self.length, self.width = dsShape[1:3]
@@ -600,7 +602,7 @@ class geometry:
                 self.metadata[key] = value
         return self.metadata
 
-    def read(self, datasetName=geometryDatasetNames[0], box=None, print_msg=True):
+    def read(self, datasetName=GEOMETRY_DSET_NAMES[0], box=None, print_msg=True):
         """Read 2D / 3D dataset with bounding box in space
         Parameters: datasetName : (list of) string, to point to specific 2D dataset, e.g.:
                         height
@@ -627,7 +629,7 @@ class geometry:
             box = (0, 0, self.width, self.length)
 
         if datasetName is None:
-            datasetName = geometryDatasetNames[0]
+            datasetName = GEOMETRY_DSET_NAMES[0]
         elif isinstance(datasetName, str):
             datasetName = [datasetName]
 
@@ -705,12 +707,12 @@ class ifgramStack:
             self.dropIfgram = f['dropIfgram'][:]
             self.pbaseIfgram = f['bperp'][:]
 
-            # get existed datasetNames in the order of ifgramDatasetNames
+            # get existed datasetNames in the order of IFGRAM_DSET_NAMES
             dsNames = [i for i in f.keys()
                        if (isinstance(f[i], h5py.Dataset)
                            and f[i].shape[-2:] == (self.length, self.width))]
-            self.datasetNames = [i for i in ifgramDatasetNames if i in dsNames]
-            self.datasetNames += [i for i in dsNames if i not in ifgramDatasetNames]
+            self.datasetNames = [i for i in IFGRAM_DSET_NAMES if i in dsNames]
+            self.datasetNames += [i for i in dsNames if i not in IFGRAM_DSET_NAMES]
 
         # Get sliceList for self.read()
         self.sliceList = []
@@ -1350,8 +1352,8 @@ class ifgramStack:
             print('update HDF5 dataset "/dropIfgram".')
             f['dropIfgram'][:] = np.array([i not in date12List2Drop for i in date12ListAll], dtype=np.bool_)
 
-            # update MODIFICATION_TIME for all datasets in ifgramDatasetNames
-            for dsName in ifgramDatasetNames:
+            # update MODIFICATION_TIME for all datasets in IFGRAM_DSET_NAMES
+            for dsName in IFGRAM_DSET_NAMES:
                 if dsName in f.keys():
                     print('update MODIFICATION_TIME in HDF5 dataset "/{}"'.format(dsName))
                     f[dsName].attrs['MODIFICATION_TIME'] = str(time.time())
@@ -1485,7 +1487,7 @@ class HDFEOS:
             box = [0, 0, self.width, self.length]
 
         if datasetName is None:
-            datasetName = [timeseriesDatasetNames[-1]]
+            datasetName = [TIMESERIES_DSET_NAMES[-1]]
         elif isinstance(datasetName, str):
             datasetName = [datasetName]
 

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -266,15 +266,29 @@ class timeseries:
             # Get Index in space/2_3 dimension
             if box is None:
                 box = [0, 0, self.width, self.length]
+            xsize = box[2] - box[0]
+            ysize = box[3] - box[1]
 
             # read
-            data = ds[:,
-                      box[1]:box[3],
-                      box[0]:box[2]][dateFlag]
+            num_slice = np.sum(dateFlag)
+            inds = np.where(dateFlag)[0].tolist()
+
+            if num_slice / dateFlag.size < 0.05:
+                # single indexing if only a small fraction is read
+                data = np.zeros((num_slice, ysize, xsize), dtype=ds.dtype)
+                for i, ind in enumerate(inds):
+                    data[i] = ds[ind,
+                                 box[1]:box[3],
+                                 box[0]:box[2]]
+            else:
+                data = ds[:,
+                          box[1]:box[3],
+                          box[0]:box[2]][dateFlag]
 
             if squeeze and any(i == 1 for i in data.shape):
                 data = np.squeeze(data)
         return data
+
 
     def write2hdf5(self, data, outFile=None, dates=None, bperp=None, metadata=None, refFile=None, compression=None):
         """

--- a/mintpy/objects/stack.py
+++ b/mintpy/objects/stack.py
@@ -139,7 +139,6 @@ DSET_UNIT_DICT = {
     'dem'       : 'm',
     'hgt'       : 'm',
     'hgt_sim'   : 'm',
-    'magnitude' : '1',
     'intensity' : '1',
 }
 

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -18,9 +18,9 @@ import numpy as np
 from skimage.transform import resize
 
 from mintpy.objects import (
-    dataTypeDict,
-    geometryDatasetNames,
-    ifgramDatasetNames,
+    DATA_TYPE_DICT,
+    GEOMETRY_DSET_NAMES,
+    IFGRAM_DSET_NAMES,
 )
 from mintpy.utils import (
     ptime,
@@ -47,7 +47,7 @@ class ifgramStackDict:
         stackObj.write2hdf5(outputFile='ifgramStack.h5', box=(200,500,300,600))
     """
 
-    def __init__(self, name='ifgramStack', pairsDict=None, dsName0=ifgramDatasetNames[0]):
+    def __init__(self, name='ifgramStack', pairsDict=None, dsName0=IFGRAM_DSET_NAMES[0]):
         self.name = name
         self.pairsDict = pairsDict
         self.dsName0 = dsName0        #reference dataset name, unwrapPhase OR azimuthOffset OR rangeOffset
@@ -123,7 +123,7 @@ class ifgramStackDict:
 
         self.pairs = sorted([pair for pair in self.pairsDict.keys()])
         self.dsNames = list(self.pairsDict[self.pairs[0]].datasetDict.keys())
-        self.dsNames = [i for i in ifgramDatasetNames if i in self.dsNames]
+        self.dsNames = [i for i in IFGRAM_DSET_NAMES if i in self.dsNames]
         maxDigit = max([len(i) for i in self.dsNames])
         numIfgram, length, width = self.get_size(
             box=box,
@@ -382,14 +382,14 @@ class ifgramDict:
 
         return data, meta
 
-    def get_size(self, family=ifgramDatasetNames[0]):
+    def get_size(self, family=IFGRAM_DSET_NAMES[0]):
         self.file = self.datasetDict[family]
         metadata = readfile.read_attribute(self.file)
         length = int(metadata['LENGTH'])
         width = int(metadata['WIDTH'])
         return length, width
 
-    def get_perp_baseline(self, family=ifgramDatasetNames[0]):
+    def get_perp_baseline(self, family=IFGRAM_DSET_NAMES[0]):
         self.file = self.datasetDict[family]
         metadata = readfile.read_attribute(self.file)
         self.bperp_top = float(metadata['P_BASELINE_TOP_HDR'])
@@ -397,7 +397,7 @@ class ifgramDict:
         self.bperp = (self.bperp_top + self.bperp_bottom) / 2.0
         return self.bperp
 
-    def get_metadata(self, family=ifgramDatasetNames[0]):
+    def get_metadata(self, family=IFGRAM_DSET_NAMES[0]):
         self.file = self.datasetDict[family]
         self.metadata = readfile.read_attribute(self.file)
         self.length = int(self.metadata['LENGTH'])
@@ -624,7 +624,7 @@ class geometryDict:
             os.makedirs(output_dir)
             print(f'create directory: {output_dir}')
 
-        maxDigit = max([len(i) for i in geometryDatasetNames])
+        maxDigit = max([len(i) for i in GEOMETRY_DSET_NAMES])
         length, width = self.get_size(box=box, xstep=xstep, ystep=ystep)
 
         self.outputFile = outputFile

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -94,7 +94,7 @@ class ifgramStackDict:
         ifgramObj = [v for v in self.pairsDict.values()][0]
         dsFile = ifgramObj.datasetDict[dsName]
         metadata = readfile.read_attribute(dsFile)
-        dataType = dataTypeDict[metadata.get('DATA_TYPE', 'float32').lower()]
+        dataType = DATA_TYPE_DICT[metadata.get('DATA_TYPE', 'float32').lower()]
         return dataType
 
     def write2hdf5(self, outputFile='ifgramStack.h5', access_mode='w', box=None, xstep=1, ystep=1, mli_method='nearest',

--- a/mintpy/simulation/configSenDesc.txt
+++ b/mintpy/simulation/configSenDesc.txt
@@ -1,6 +1,0 @@
-#Typical Parameters for Sentinel-1 descending track dataset
-sensor         = Sen
-incidenceAngle = 33.4
-orbitDirection = descending
-azimuthLooks   = 5
-rangeLooks     = 15

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -925,7 +925,7 @@ class TimeSeriesAnalysis:
         opt4ts = ['--noaxis', '-u', 'cm', '--wrap', '--wrap-range', '-5', '5']
         iargs_list0 = [
             # key files
-            ['velocity.h5',          '--dem', geom_file, '--mask', mask_file, '-u', 'cm'],
+            ['velocity.h5',          '--dem', geom_file, '--mask', mask_file],
             ['temporalCoherence.h5', '-c', 'gray', '-v', '0', '1'],
             ['maskTempCoh.h5',       '-c', 'gray', '-v', '0', '1'],
 

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -10,7 +10,6 @@
 import os
 import datetime as dt
 import time
-import warnings
 
 import h5py
 import numpy as np

--- a/mintpy/solid_earth_tides.py
+++ b/mintpy/solid_earth_tides.py
@@ -35,6 +35,7 @@ def get_datetime_list(ts_file, date_wise_acq_time=False):
     Parameters: ts_file            - str, path of the time-series HDF5 file
                 date_wise_acq_time - bool, use the exact date-wise acquisition time
     Returns:    sensingMid         - list of datetime.datetime objects
+                date_list          - list(str), dates in YYYYMMDD
     """
     print('\nprepare datetime info for each acquisition')
 
@@ -85,7 +86,7 @@ def get_datetime_list(ts_file, date_wise_acq_time=False):
         print(msg)
 
 
-    return sensingMid
+    return sensingMid, date_list
 
 
 def plot_sensingMid_variation(sensingMid, save_fig=True, disp_fig=False, figsize=[8, 3]):
@@ -112,41 +113,50 @@ def plot_sensingMid_variation(sensingMid, save_fig=True, disp_fig=False, figsize
 
 
 ###############################################################
-def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_acq_time=False,
-                                      update_mode=True, verbose=False):
+def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_comp='enu2los',
+        set_file=None, date_wise_acq_time=False, update_mode=True, verbose=False):
     """Calculate the time-series of solid Earth tides (SET) in LOS direction.
-    Parameters: ts_file   - str, path of the time-series HDF5 file
+
+    Parameters: ts_file   - str, path of the time-series HDF5 file, or the date list text file
                 geom_file - str, path of the geometry HDF5 file
                 set_file  - str, output SET time-sereis file
                 date_wise_acq_time - bool, use the exact date-wise acquisition time
-    Returns:    set_file  - str, output SET time-sereis file
+    Returns:    ts_set    - 3D np.ndarray, SET component time series in meter
     """
 
-    if update_mode and os.path.isfile(set_file):
+    if update_mode and set_file and os.path.isfile(set_file):
         print('update mode: ON')
         print('skip re-calculating and use existing file: {}'.format(set_file))
         return set_file
 
     # prepare LOS geometry: geocoding if in radar-coordinates
-    inc_angle, head_angle, atr_geo = ut.prepare_geo_los_geometry(geom_file, unit='rad')
+    los_inc_angle, los_az_angle, atr_geo = ut.prepare_geo_los_geometry(geom_file, unit='deg')
 
-    # get LOS unit vector
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=RuntimeWarning)
-        unit_vec = [
-            np.sin(inc_angle) * np.cos(head_angle) * -1,
-            np.sin(inc_angle) * np.sin(head_angle),
-            np.cos(inc_angle),
-        ]
+    # get unit vector for the component of interest
+    unit_vec = ut.get_unit_vector4component_of_interest(los_inc_angle, los_az_angle, comp=set_comp)
+    msg = f'get the unit vector for {set_comp} projection with mean value: '
+    msg += f'E = {np.nanmean(unit_vec[0]):.3f}, '
+    msg += f'N = {np.nanmean(unit_vec[1]):.3f}, '
+    msg += f'U = {np.nanmean(unit_vec[2]):.3f}.'
+    print(msg)
 
     # prepare datetime
-    dt_objs = get_datetime_list(ts_file, date_wise_acq_time=date_wise_acq_time)
+    # prefer ts_file to avoid potential missing CENTER_LINE_UTC attributes in geom_file from alosStack
+    if ts_file.endswith('.h5'):
+        atr = readfile.read_attribute(ts_file)
+        dt_objs, date_list = get_datetime_list(ts_file, date_wise_acq_time=date_wise_acq_time)
+    else:
+        atr = readfile.read_attribute(geom_file)
+        # text list file
+        date_list = ptime.read_date_txt(ts_file)
+        utc_sec = dt.timedelta(seconds=float(atr['CENTER_LINE_UTC']))
+        dt_objs = [dt.datetime.strptime(x, '%Y%m%d') + utc_sec for x in date_list]
 
     # initiate data matrix
     num_date = len(dt_objs)
     length = int(atr_geo['LENGTH'])
     width = int(atr_geo['WIDTH'])
-    ts_tide = np.zeros((num_date, length, width), dtype=np.float32)
+    ts_set = np.zeros((num_date, length, width), dtype=np.float32)
     # default step size in meter: ~30 pixels
     step_size = ut.round_to_1(abs(float(atr_geo['Y_STEP'])) * 108e3 * 30)
 
@@ -156,53 +166,59 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_file, date_wise_ac
     prog_bar = ptime.progressBar(maxValue=num_date, print_msg=not verbose)
     for i, dt_obj in enumerate(dt_objs):
         # calculate tide in ENU direction
-        (tide_e,
-         tide_n,
-         tide_u) = pysolid.calc_solid_earth_tides_grid(dt_obj, atr_geo,
-                                                       step_size=step_size,
-                                                       display=False,
-                                                       verbose=verbose)
+        set_e, set_n, set_u = pysolid.calc_solid_earth_tides_grid(
+            dt_obj,
+            atr_geo,
+            step_size=step_size,
+            display=False,
+            verbose=verbose,
+        )
 
         # convert ENU to LOS direction
         # sign convention: positive for motion towards satellite
-        ts_tide[i,:,:] = (  tide_e * unit_vec[0]
-                          + tide_n * unit_vec[1]
-                          + tide_u * unit_vec[2])
+        ts_set[i,:,:] = (  set_e * unit_vec[0]
+                         + set_n * unit_vec[1]
+                         + set_u * unit_vec[2])
 
         prog_bar.update(i+1, suffix='{} ({}/{})'.format(dt_obj.isoformat(), i+1, num_date))
     prog_bar.close()
 
     # radar-coding if input in radar-coordinates
-    # use ts_file to avoid potential missing CENTER_LINE_UTC attributes in geom_file from alosStack
-    atr = readfile.read_attribute(ts_file)
     if 'Y_FIRST' not in atr.keys():
-        print('radar-coding the LOS tides time-series ...')
-        res_obj = resample(lut_file=geom_file)
+        print('radar-coding the tides time-series ...')
+        res_obj = resample(lut_file=geom_file, max_memory=0)
         res_obj.open()
         res_obj.src_meta = atr_geo
         res_obj.prepare()
 
         # resample data
         box = res_obj.src_box_list[0]
-        ts_tide = res_obj.run_resample(src_data=ts_tide[:,
-                                                        box[1]:box[3],
-                                                        box[0]:box[2]])
+        ts_set = res_obj.run_resample(
+            src_data=ts_set[:, box[1]:box[3], box[0]:box[2]],
+        )
 
     ## output
-    # attribute
-    atr['FILE_TYPE'] = 'timeseries'
-    atr['UNIT'] = 'm'
-    for key in ['REF_Y', 'REF_X', 'REF_DATE']:
-        if key in atr.keys():
-            atr.pop(key)
+    if set_file:
+        # attribute
+        atr['FILE_TYPE'] = 'timeseries'
+        atr['DATA_TYPE'] = 'float32'
+        atr['UNIT'] = 'm'
+        for key in ['REF_Y', 'REF_X', 'REF_DATE']:
+            if key in atr.keys():
+                atr.pop(key)
 
-    # write
-    ds_dict = {}
-    ds_dict['timeseries'] = ts_tide
-    ds_dict['sensingMid'] = np.array([i.strftime('%Y%m%dT%H%M%S') for i in dt_objs], dtype=np.string_)
-    writefile.write(ds_dict, out_file=set_file, metadata=atr, ref_file=ts_file)
+        # dataset
+        ds_dict = {
+            'timeseries' : ts_set,
+            'date'       : np.array(date_list, dtype=np.string_),
+            'sensingMid' : np.array([i.strftime('%Y%m%dT%H%M%S') for i in dt_objs],
+                                    dtype=np.string_),
+        }
 
-    return set_file
+        # write
+        writefile.write(ds_dict, out_file=set_file, metadata=atr)
+
+    return ts_set
 
 
 def correct_timeseries(dis_file, set_file, cor_dis_file):
@@ -229,16 +245,20 @@ def run_solid_earth_tides(inps):
     calc_solid_earth_tides_timeseries(
         ts_file=inps.dis_file,
         geom_file=inps.geom_file,
+        set_comp=inps.set_comp,
         set_file=inps.set_file,
         date_wise_acq_time=inps.date_wise_acq_time,
         update_mode=inps.update_mode,
-        verbose=inps.verbose)
+        verbose=inps.verbose,
+    )
 
     # correct SET
-    correct_timeseries(
-        dis_file=inps.dis_file,
-        set_file=inps.set_file,
-        cor_dis_file=inps.cor_dis_file)
+    if inps.dis_file.endswith('.h5'):
+        correct_timeseries(
+            dis_file=inps.dis_file,
+            set_file=inps.set_file,
+            cor_dis_file=inps.cor_dis_file,
+        )
 
     # used time
     m, s = divmod(time.time() - start_time, 60)

--- a/mintpy/tsview.py
+++ b/mintpy/tsview.py
@@ -676,7 +676,8 @@ class timeseriesViewer():
                 ds_shape=self.ts_data[0].shape[-2:],
                 disp_cbar=True,
                 disp_slider=True,
-                print_msg=self.print_msg)
+                print_msg=False)
+        vprint(f'create figure for map in size of [{self.figsize_img[0]:.1f}, {self.figsize_img[1]:.1f}]')
         subplot_kw = dict(projection=self.map_proj_obj) if self.map_proj_obj is not None else {}
         self.fig_img, self.ax_img = plt.subplots(figsize=self.figsize_img, subplot_kw=subplot_kw)
 
@@ -690,6 +691,7 @@ class timeseriesViewer():
         self.tslider.on_changed(self.update_time_slider)
 
         # Figure 2 - Time Series Displacement - Point
+        vprint(f'create figure for point in size of [{self.figsize_pts[0]:.1f}, {self.figsize_pts[1]:.1f}]')
         self.fig_pts, self.ax_pts = plt.subplots(num=self.figname_pts, figsize=self.figsize_pts)
         if self.yx:
             d_ts, m_strs = self.plot_point_timeseries(self.yx)
@@ -814,7 +816,7 @@ class timeseriesViewer():
 
         # call view.py to plot
         self.img, self.cbar_img = view.plot_slice(self.ax_img, img_data, self.atr, self)[2:4]
-        self.fig_img.canvas.set_window_title(self.figname_img)
+        self.fig_img.canvas.manager.set_window_title(self.figname_img)
         self.fig_img.tight_layout(rect=(0,0,1,0.97))
 
         return self.img, self.cbar_img

--- a/mintpy/utils/plot.py
+++ b/mintpy/utils/plot.py
@@ -21,7 +21,7 @@ from scipy import stats
 
 from mintpy.objects.coord import coordinate
 from mintpy.objects.colors import ColormapExt
-from mintpy.objects import timeseriesKeyNames, timeseriesDatasetNames
+from mintpy.objects import TIMESERIES_KEY_NAMES, TIMESERIES_DSET_NAMES
 from mintpy.utils.map import draw_lalo_label, draw_scalebar
 from mintpy.utils import (
     ptime,
@@ -166,7 +166,7 @@ def auto_figure_title(fname, datasetNames=[], inps_dict=None):
             if fbase.lower().startswith('ion'):
                 fig_title += '_ion'
 
-    elif k in timeseriesKeyNames and len(datasetNames) == 1:
+    elif k in TIMESERIES_KEY_NAMES and len(datasetNames) == 1:
         if 'ref_date' in inps_dict.keys():
             ref_date = inps_dict['ref_date']
         elif 'REF_DATE' in atr.keys():
@@ -1693,7 +1693,7 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
             vprint('Can not open mask file:', mask_file)
 
     elif k in ['HDFEOS']:
-        if datasetName.split('-')[0] in timeseriesDatasetNames:
+        if datasetName.split('-')[0] in TIMESERIES_DSET_NAMES:
             mask_file = fname
             mask = readfile.read(fname, datasetName='mask', print_msg=print_msg)[0]
             vprint('read {} contained mask dataset.'.format(k))

--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -19,13 +19,13 @@ import h5py
 import numpy as np
 
 from mintpy.objects import (
-    datasetUnitDict,
+    DSET_UNIT_DICT,
     geometry,
     giantIfgramStack,
     giantTimeseries,
     ifgramStack,
     timeseries,
-    HDFEOS
+    HDFEOS,
 )
 from mintpy.objects import sensor
 from mintpy.utils import ptime, utils0 as ut
@@ -508,14 +508,14 @@ def read_binary_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
     # ISCE
     if processor in ['isce']:
         # convert default short name for data type from ISCE
-        dataTypeDict = {
+        data_type_dict = {
             'byte': 'int8',
             'float': 'float32',
             'double': 'float64',
             'cfloat': 'complex64',
         }
-        if data_type in dataTypeDict.keys():
-            data_type = dataTypeDict[data_type]
+        if data_type in data_type_dict.keys():
+            data_type = data_type_dict[data_type]
 
         k = atr['FILE_TYPE'].lower().replace('.', '')
         if k in ['unw', 'cor', 'ion']:
@@ -1139,15 +1139,15 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             atr['FILE_TYPE'] = fext
 
         # DATA_TYPE for ISCE products
-        dataTypeDict = {
+        data_type_dict = {
             'byte': 'int8',
             'float': 'float32',
             'double': 'float64',
             'cfloat': 'complex64',
         }
         data_type = atr.get('DATA_TYPE', 'none').lower()
-        if data_type != 'none' and data_type in dataTypeDict.keys():
-            atr['DATA_TYPE'] = dataTypeDict[data_type]
+        if data_type != 'none' and data_type in data_type_dict.keys():
+            atr['DATA_TYPE'] = data_type_dict[data_type]
 
     # UNIT
     if datasetName:
@@ -1156,20 +1156,20 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
         datasetName = datasetName.replace('Std','')
     k = atr['FILE_TYPE'].replace('.', '')
     if k == 'ifgramStack':
-        if datasetName and datasetName in datasetUnitDict.keys():
-            atr['UNIT'] = datasetUnitDict[datasetName]
+        if datasetName and datasetName in DSET_UNIT_DICT.keys():
+            atr['UNIT'] = DSET_UNIT_DICT[datasetName]
         else:
             atr['UNIT'] = 'radian'
 
-    elif datasetName and datasetName in datasetUnitDict.keys():
-        atr['UNIT'] = datasetUnitDict[datasetName]
+    elif datasetName and datasetName in DSET_UNIT_DICT.keys():
+        atr['UNIT'] = DSET_UNIT_DICT[datasetName]
         # SLC stack
         if datasetName == 'timeseries' and atr.get('DATA_TYPE', 'float32').startswith('complex'):
             atr['UNIT'] = '1'
 
     elif 'UNIT' not in atr.keys():
-        if k in datasetUnitDict.keys():
-            atr['UNIT'] = datasetUnitDict[k]
+        if k in DSET_UNIT_DICT.keys():
+            atr['UNIT'] = DSET_UNIT_DICT[k]
         else:
             atr['UNIT'] = '1'
 

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy.ndimage import map_coordinates
 
 from mintpy.objects import (
-    geometryDatasetNames,
+    GEOMETRY_DSET_NAMES,
     geometry,
     ifgramStack,
     timeseries,
@@ -79,7 +79,7 @@ def check_loaded_dataset(work_dir='./', print_msg=True, relpath=False):
 
     # 2. [required] geom_file: height
     geom_file = os.path.join(work_dir, 'inputs', f'geometry{coord_type.capitalize()}.h5')
-    dname = geometryDatasetNames[0]
+    dname = GEOMETRY_DSET_NAMES[0]
 
     if is_file_exist(geom_file, abspath=True):
         obj = geometry(geom_file)
@@ -100,9 +100,9 @@ def check_loaded_dataset(work_dir='./', print_msg=True, relpath=False):
 
             # get the proper lookup table dataset names
             if processor in ['isce', 'doris']:
-                dnames = geometryDatasetNames[1:3]
+                dnames = GEOMETRY_DSET_NAMES[1:3]
             elif processor in ['gamma', 'roipac']:
-                dnames = geometryDatasetNames[3:5]
+                dnames = GEOMETRY_DSET_NAMES[3:5]
             else:
                 msg = f'Unknown InSAR processor: {processor} to locate look up table!'
                 raise AttributeError(msg)

--- a/mintpy/utils/utils.py
+++ b/mintpy/utils/utils.py
@@ -411,11 +411,13 @@ def transect_lines(z, atr, lines):
 def prepare_geo_los_geometry(geom_file, unit='rad'):
     """Prepare LOS geometry data/info in geo-coordinates.
 
-    Parameters: geom_file  - str, path of geometry file
-                unit       - str, rad or deg, output angle unit
-    Returns:    inc_angle  - 2D np.ndarray, incidence angle in radians / degrees
-                head_angle - 2D np.ndarray, heading   angle in radians / degrees
-                atr        - dict, metadata in geo-coordinate
+    Parameters: geom_file - str, path of geometry file
+                unit      - str, rad or deg, output angle unit
+    Returns:    inc_angle - 2D np.ndarray, incidence angle in radians / degrees
+                            measured from the vertical
+                az_angle  - 2D np.ndarray, azimuth   angle in radians / degrees
+                            measured from the north with anti-clockwise direction as positive
+                atr       - dict, metadata in geo-coordinate
     """
 
     print('prepare LOS geometry in geo-coordinates from file: {}'.format(geom_file))
@@ -426,12 +428,12 @@ def prepare_geo_los_geometry(geom_file, unit='rad'):
 
     if 'azimuthAngle' in readfile.get_dataset_list(geom_file):
         print('read azimuthAngle   from file: {}'.format(geom_file))
-        print('convert azimuth angle to heading angle')
         az_angle  = readfile.read(geom_file, datasetName='azimuthAngle')[0]
-        head_angle = azimuth2heading_angle(az_angle)
     else:
         print('use the HEADING attribute as the mean heading angle')
+        print('convert heading angle to azimuth angle')
         head_angle = np.ones(inc_angle.shape, dtype=np.float32) * float(atr['HEADING'])
+        az_angle = heading2azimuth_angle(head_angle)
 
     # geocode inc/az angle data if in radar-coord
     if 'Y_FIRST' not in atr.keys():
@@ -443,8 +445,8 @@ def prepare_geo_los_geometry(geom_file, unit='rad'):
 
         # resample data
         box = res_obj.src_box_list[0]
-        inc_angle  = res_obj.run_resample(src_data=inc_angle[box[1]:box[3], box[0]:box[2]])
-        head_angle = res_obj.run_resample(src_data=head_angle[box[1]:box[3], box[0]:box[2]])
+        inc_angle = res_obj.run_resample(src_data=inc_angle[box[1]:box[3], box[0]:box[2]])
+        az_angle = res_obj.run_resample(src_data=az_angle[box[1]:box[3], box[0]:box[2]])
 
         # update attribute
         atr = attr.update_attribute4radar2geo(atr, res_obj=res_obj)
@@ -477,11 +479,10 @@ def prepare_geo_los_geometry(geom_file, unit='rad'):
 
     # set invalid values to nan
     inc_angle[inc_angle == 0] = np.nan
-    head_angle[head_angle == 90] = np.nan
 
     # unit: degree to radian
     if unit.startswith('rad'):
         inc_angle *= np.pi / 180.
-        head_angle *= np.pi / 180.
+        az_angle *= np.pi / 180.
 
-    return inc_angle, head_angle, atr
+    return inc_angle, az_angle, atr

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -7,6 +7,8 @@
 # Contents
 #   InSAR
 #   File Operation
+#   Coordinate
+#   Orbit
 #   Geometry
 #   Image Processing
 #   User Interaction
@@ -27,6 +29,31 @@ K = 40.31                  # m^3/s^2, constant
 
 
 #################################### InSAR ##########################################
+def misregistration2coherence(mu):
+    """Calculate the resulting coherence due to mis-registration (coregistration error).
+
+    Reference:
+      Equation (30) in Just and Bamler (1994); Equation (4.4.27) in Hanssen (2001).
+
+    Parameters: mu  - float / np.ndarray, mis-registration in the unit of resolution cell
+                      NOTE: the unit is resolution cell, NOT pixel size/spacing.
+                      Applicable to both SAR range and azimuth directions.
+    Returns:    coh - float / np.ndarray, coherence.
+    """
+
+    # https://numpy.org/doc/stable/reference/generated/numpy.sinc.html
+    coh = np.sinc(mu)
+
+    # for coregistration errors >1, set coherence to zero
+    if type(mu) is np.ndarray:
+        coh[mu > 1] = 0
+    else:
+        if mu > 1:
+            coh = 0
+
+    return coh
+
+
 def range_distance(atr, dimension=2, print_msg=True):
     """Calculate slant range distance from input attribute dict
     Parameters: atr : dict, including the following ROI_PAC attributes:
@@ -270,7 +297,7 @@ def touch(fname_list, times=None):
 
 
 
-#################################### Geometry ##########################################
+################################## Coordinate ##########################################
 def utm_zone2epsg_code(utm_zone):
     """Convert UTM Zone string to EPSG code.
     Parameters: utm_zone - str, atr['UTM_ZONE']
@@ -316,53 +343,6 @@ def to_latlon(infile, x, y):
     return y, x
 
 
-def xyz_to_local_radius(xyz):
-    """Calculate satellite height and ellpsoid local radius from orbital state vector.
-
-    This is a simplified version of the following functions from ISCE-2:
-    + isce.isceobj.Planet.xyz_to_llh()
-    + isce.isceobj.Ellipsoid.localRadius()
-
-    Parameters: xyz    - tuple of 3 float, orbital state vector
-    Reference:  height - float, satellite altitude in m
-                radius - float, Earth radius in m
-    """
-
-    # paramters from isce.isceobj.Planet.AstronomicalHandbook
-    a = 6378137.000       # WGS84 semimajor
-    e2 = 0.0066943799901  # WGS84 eccentricity squared
-
-    # xyz --> llh
-    a2 = a**2
-    e4 = e2**2
-    r_llh =  [0]*3
-    d_llh = [[0]*3 for i in range(len(xyz))]
-    xy2 = xyz[0]**2 + xyz[1]**2
-    p = (xy2) / a2
-    q = (1. - e2) * xyz[2]**2 / a2
-    r = (p + q - e4) / 6.
-    s = e4 * p * q / (4. * r**3)
-    t = (1. + s + math.sqrt(s * (2. + s))) **(1. / 3.)
-    u = r * (1. + t + 1./t)
-    v = math.sqrt(u**2 + e4 * q)
-    w = e2 * (u + v - q) / (2. * v)
-    k = math.sqrt(u + v + w**2) - w
-    D = k * math.sqrt(xy2) / (k + e2)
-    r_llh[0] = math.atan2(xyz[2], D)
-    r_llh[1] = math.atan2(xyz[1], xyz[0])
-    r_llh[2] = (k + e2 - 1.) * math.sqrt(D**2 + xyz[2]**2) / k
-    d_llh[0] = math.degrees(r_llh[0])
-    d_llh[1] = math.degrees(r_llh[1])
-    d_llh[2] = r_llh[2]
-    height = r_llh[2]
-
-    # calculate local radius
-    b = a * (1.0 - e2)**0.5
-    latg = math.atan( math.tan(math.radians(d_llh[0])) * a**2 / b**2 )
-    arg = (math.cos(latg)**2 / a**2) + (math.sin(latg)**2 / b**2)
-    radius = 1.0 / math.sqrt(arg)
-
-    return height, radius
 
 
 def snwe_to_wkt_polygon(snwe):
@@ -478,63 +458,6 @@ def get_lat_lon_rdc(meta):
     return lat, lon
 
 
-def azimuth2heading_angle(az_angle):
-    """Convert azimuth angle from ISCE los.rdr band2 into satellite orbit heading angle
-
-    ISCE-2 los.* file band2 is azimuth angle of LOS vector from ground target to the satellite
-        measured from the north in anti-clockwise as positive
-
-    Below are typical values in deg for satellites with near-polar orbit:
-        ascending  orbit: heading angle of -12  and azimuth angle of 102
-        descending orbit: heading angle of -168 and azimuth angle of -102
-    """
-    head_angle = 90 - az_angle
-    head_angle -= np.round(head_angle / 360.) * 360.
-    return head_angle
-
-
-def heading2azimuth_angle(head_angle):
-    """Convert satellite orbit heading angle into azimuth angle as defined in ISCE-2."""
-    az_angle = 90 - head_angle
-    az_angle -= np.round(az_angle / 360.) * 360.
-    return az_angle
-
-
-def enu2los(e, n, u, inc_angle, head_angle=None, az_angle=None):
-    """Project east/north/up motion into the line-of-sight direction defined by incidence/azimuth angle.
-    Parameters: e          - np.ndarray or float, displacement in east-west direction, east as positive
-                n          - np.ndarray or float, displacement in north-south direction, north as positive
-                u          - np.ndarray or float, displacement in vertical direction, up as positive
-                inc_angle  - np.ndarray or float, local incidence angle from vertical, in the unit of degrees
-                head_angle - np.ndarray or float, azimuth angle of the SAR platform along track direction
-                             measured from the north with clockwise direction as positive, in the unit of degrees
-                az_angle   - np.ndarray or float, azimuth angle of the LOS vector from the ground to the SAR platform
-                             measured from the north with anti-clockwise direction as positive, in the unit of degrees
-                             head_angle = 90 - az_angle
-    Returns:    v_los      - np.ndarray or float, displacement in line-of-sight direction, moving toward satellite as positive
-
-    Typical values in deg for satellites with near-polar orbit:
-        For AlosA: inc_angle = 34, head_angle = -12.9,  az_angle = 102.9
-        For AlosD: inc_angle = 34, head_angle = -167.2, az_angle = -102.8
-        For  SenD: inc_angle = 34, head_angle = -168.0, az_angle = -102.0
-    """
-    ## if input angle is azimuth angle
-    #if np.abs(np.abs(head_angle) - 90) < 30:
-    #    head_angle = azimuth2heading_angle(head_angle)
-    if az_angle is None:
-        # head_angle -> az_angle
-        if head_angle is not None:
-            az_angle = heading2azimuth_angle(head_angle)
-        else:
-            raise ValueError('az_angle can not be None!')
-
-    v_los = (  e * np.sin(np.deg2rad(inc_angle)) * np.sin(np.deg2rad(az_angle)) * -1
-             + n * np.sin(np.deg2rad(inc_angle)) * np.cos(np.deg2rad(az_angle))
-             + u * np.cos(np.deg2rad(inc_angle)))
-
-    return v_los
-
-
 def four_corners(atr):
     """Get the 4 corners coordinates from metadata dict in geo-coordinates.
     Parameters: atr - dict
@@ -553,67 +476,231 @@ def four_corners(atr):
     return south, north, west, east
 
 
-def get_circular_mask(x, y, radius, shape):
-    """Get mask of pixels within circle defined by (x, y, r)"""
-    length, width = shape
-    yy, xx = np.ogrid[-y:length-y,
-                      -x:width-x]
-    cmask = (xx**2 + yy**2 <= radius**2)
-    return cmask
 
+###################################### Orbit ###########################################
+def xyz_to_local_radius(xyz):
+    """Calculate satellite height and ellpsoid local radius from orbital state vector.
 
-def circle_index(atr, circle_par):
-    """Return Index of Elements within a Circle centered at input pixel
-    Parameters: atr : dictionary
-                    containging the following attributes:
-                    WIDT
-                    LENGTH
-                circle_par : string in the format of 'y,x,radius'
-                    i.e. '200,300,20'          for radar coord
-                         '31.0214,130.5699,20' for geo   coord
-    Returns:    idx : 2D np.array in bool type
-                    mask matrix for those pixel falling into the circle
-                    defined by circle_par
-    Examples:   idx_mat = ut.circle_index(atr, '200,300,20')
-                idx_mat = ut.circle_index(atr, '31.0214,130.5699,20')
+    This is a simplified version of the following functions from ISCE-2:
+    + isce.isceobj.Planet.xyz_to_llh()
+    + isce.isceobj.Ellipsoid.localRadius()
+
+    Parameters: xyz    - tuple of 3 float, orbital state vector
+    Reference:  height - float, satellite altitude in m
+                radius - float, Earth radius in m
     """
 
-    width = int(atr['WIDTH'])
-    length = int(atr['LENGTH'])
+    # paramters from isce.isceobj.Planet.AstronomicalHandbook
+    a = 6378137.000       # WGS84 semimajor
+    e2 = 0.0066943799901  # WGS84 eccentricity squared
 
-    if isinstance(circle_par, tuple):
-        cir_par = circle_par
-    elif isinstance(circle_par, list):
-        cir_par = circle_par
+    # xyz --> llh
+    a2 = a**2
+    e4 = e2**2
+    r_llh =  [0]*3
+    d_llh = [[0]*3 for i in range(len(xyz))]
+    xy2 = xyz[0]**2 + xyz[1]**2
+    p = (xy2) / a2
+    q = (1. - e2) * xyz[2]**2 / a2
+    r = (p + q - e4) / 6.
+    s = e4 * p * q / (4. * r**3)
+    t = (1. + s + math.sqrt(s * (2. + s))) **(1. / 3.)
+    u = r * (1. + t + 1./t)
+    v = math.sqrt(u**2 + e4 * q)
+    w = e2 * (u + v - q) / (2. * v)
+    k = math.sqrt(u + v + w**2) - w
+    D = k * math.sqrt(xy2) / (k + e2)
+    r_llh[0] = math.atan2(xyz[2], D)
+    r_llh[1] = math.atan2(xyz[1], xyz[0])
+    r_llh[2] = (k + e2 - 1.) * math.sqrt(D**2 + xyz[2]**2) / k
+    d_llh[0] = math.degrees(r_llh[0])
+    d_llh[1] = math.degrees(r_llh[1])
+    d_llh[2] = r_llh[2]
+    height = r_llh[2]
+
+    # calculate local radius
+    b = a * (1.0 - e2)**0.5
+    latg = math.atan( math.tan(math.radians(d_llh[0])) * a**2 / b**2 )
+    arg = (math.cos(latg)**2 / a**2) + (math.sin(latg)**2 / b**2)
+    radius = 1.0 / math.sqrt(arg)
+
+    return height, radius
+
+
+
+#################################### Geometry ##########################################
+# Definition of angles:
+# (los_)inc_angle - the incidence angle of the LOS vector (from the ground to the SAR platform)
+#                   measured from vertical. Used in isce2.
+# (los_)az_angle  - the azimuth   angle of the LOS vecotr (from the ground to the SAR platform)
+#                   measured from the north, with anti-clockwise as positive. Used in isce2.
+# orb_az_angle    - the azimuth   angle of the SAR platform's orbit (along-track direction)
+#                   measured from the north, with anti-clockwise as positive
+# head_angle      - the azimuth   angle of the SAR platform's orbit (along-track direction)
+#                   measured from the north, with      clockwise as positive. Used in roipac.
+#
+# Typical values in deg for satellites with near-polar orbit:
+#     AlosA: los_inc_angle = 34, los_az_angle =  102, orb_az_angle =  12, head_angle =  -12
+#     AlosD: los_inc_angle = 34, los_az_angle = -102, orb_az_angle = 168, head_angle = -168
+#     SenA : los_inc_angle = 40, los_az_angle =  102, orb_az_angle =  12, head_angle =  -12
+#     SenD : los_inc_angle = 40, los_az_angle = -102, orb_az_angle = 168, head_angle = -168
+#     NiA  : los_inc_angle = 42, los_az_angle =  -78, orb_az_angle =  12, head_angle =  -12
+#     NiD  : los_inc_angle = 42, los_az_angle =   78, orb_az_angle = 168, head_angle = -168
+
+def los2orbit_azimuth_angle(los_az_angle, look_direction='right'):
+    """Convert the azimuth angle of the LOS vector to the one of the orbit flight vector.
+    Parameters: los_az_angle - np.ndarray or float, azimuth angle of the LOS vector from the ground to the SAR platform
+                               measured from the north with anti-clockwise direction as positive, in the unit of degrees
+    Returns:    orb_az_angle - np.ndarray or float, azimuth angle of the SAR platform along track/orbit direction
+                               measured from the north with anti-clockwise direction as positive, in the unit of degrees
+    """
+    if look_direction == 'right':
+        orb_az_angle = los_az_angle - 90
     else:
-        cir_par = circle_par.replace(',', ' ').split()
-    cir_par = [str(i) for i in cir_par]
+        orb_az_angle = los_az_angle + 90
+    orb_az_angle -= np.round(orb_az_angle / 360.) * 360.
+    return orb_az_angle
 
-    try:
-        c_y = int(cir_par[0])
-        c_x = int(cir_par[1])
-        radius = int(float(cir_par[2]))
-        print('Input circle index in y/x coord: %d, %d, %d' % (c_y, c_x, radius))
-    except:
-        try:
-            c_lat = float(cir_par[0])
-            c_lon = float(cir_par[1])
-            radius = int(float(cir_par[2]))
-            c_y = np.rint((c_lat-float(atr['Y_FIRST'])) / float(atr['Y_STEP']))
-            c_x = np.rint((c_lon-float(atr['X_FIRST'])) / float(atr['X_STEP']))
-            print(('Input circle index in lat/lon coord: '
-                   '{:.4f}, {:.4f}, {}'.format(c_lat, c_lon, radius)))
-        except:
-            print('\nERROR: Unrecognized circle index format: '+circle_par)
-            print('Supported format:')
-            print('--circle 200,300,20            for radar coord input')
-            print('--circle 31.0214,130.5699,20   for geo   coord input\n')
-            return 0
 
-    y, x = np.ogrid[-c_y:length-c_y, -c_x:width-c_x]
-    idx = x**2 + y**2 <= radius**2
+def azimuth2heading_angle(az_angle, look_direction='right'):
+    """Convert azimuth angle from ISCE los.rdr band2 into satellite orbit heading angle
 
-    return idx
+    ISCE-2 los.* file band2 is azimuth angle of LOS vector from ground target to the satellite
+        measured from the north in anti-clockwise as positive
+
+    Below are typical values in deg for satellites with near-polar orbit:
+        ascending  orbit: heading angle of -12  and azimuth angle of 102
+        descending orbit: heading angle of -168 and azimuth angle of -102
+    """
+    if look_direction == 'right':
+        head_angle = (az_angle - 90) * -1
+    else:
+        head_angle = (az_angle + 90) * -1
+    head_angle -= np.round(head_angle / 360.) * 360.
+    return head_angle
+
+
+def heading2azimuth_angle(head_angle, look_direction='right'):
+    """Convert satellite orbit heading angle into azimuth angle as defined in ISCE-2."""
+    if look_direction == 'right':
+        az_angle = (head_angle - 90) * -1
+    else:
+        az_angle = (head_angle + 90) * -1
+    az_angle -= np.round(az_angle / 360.) * 360.
+    return az_angle
+
+
+def enu2los(v_e, v_n, v_u, inc_angle, head_angle=None, az_angle=None):
+    """Project east/north/up motion into the line-of-sight (LOS) direction defined by incidence/azimuth angle.
+    Parameters: v_e        - np.ndarray or float, displacement in east-west   direction, east  as positive
+                v_n        - np.ndarray or float, displacement in north-south direction, north as positive
+                v_u        - np.ndarray or float, displacement in vertical    direction, up    as positive
+                inc_angle  - np.ndarray or float, incidence angle from vertical, in the unit of degrees
+                head_angle - np.ndarray or float, azimuth angle of the SAR platform along track direction
+                             measured from the north with clockwise direction as positive, in the unit of degrees
+                az_angle   - np.ndarray or float, azimuth angle of the LOS vector from the ground to the SAR platform
+                             measured from the north with anti-clockwise direction as positive, in the unit of degrees
+                             head_angle = 90 - az_angle
+    Returns:    v_los      - np.ndarray or float, displacement in LOS direction, motion toward satellite as positive
+    """
+    # unite (los_)head/az_angle into (los_)az_angle
+    if az_angle is None:
+        if head_angle is not None:
+            az_angle = heading2azimuth_angle(head_angle)
+        else:
+            raise ValueError(f'invalid az_angle: {az_angle}!')
+
+    # project ENU onto LOS
+    v_los = (  v_e * np.sin(np.deg2rad(inc_angle)) * np.sin(np.deg2rad(az_angle)) * -1
+             + v_n * np.sin(np.deg2rad(inc_angle)) * np.cos(np.deg2rad(az_angle))
+             + v_u * np.cos(np.deg2rad(inc_angle)))
+
+    return v_los
+
+
+def en2az(v_e, v_n, orb_az_angle):
+    """Project east/north motion into the radar azimuth direction.
+    Parameters: v_e          - np.ndarray or float, displacement in east-west   direction, east  as positive
+                v_n          - np.ndarray or float, displacement in north-south direction, north as positive
+                orb_az_angle - np.ndarray or float, azimuth angle of the SAR platform along track/orbit direction
+                               measured from the north with anti-clockwise direction as positive, in the unit of degrees
+                               orb_az_angle = los_az_angle + 90 for right-looking radar.
+    Returns:    v_az         - np.ndarray or float, displacement in azimuth direction,
+                               motion along flight direction as positive
+    """
+    # project EN onto azimuth
+    v_az = (  v_e * np.sin(np.deg2rad(orb_az_angle)) * -1
+            + v_n * np.cos(np.deg2rad(orb_az_angle)))
+    return v_az
+
+
+def get_unit_vector4component_of_interest(los_inc_angle, los_az_angle, comp='enu2los', horz_az_angle=None):
+    """Get the unit vector for the component of interest.
+    Parameters: los_inc_angle - np.ndarray or float, incidence angle from vertical, in the unit of degrees
+                los_az_angle  - np.ndarray or float, azimuth angle of the LOS vector from the ground to the SAR platform
+                                measured from the north with anti-clockwise direction as positive, in the unit of degrees
+                comp          - str, component of interest, choose among the following values:
+                                enu2los, en2los, hz2los, u2los, up2los, orb(it)_az, vert, horz
+                horz_az_angle - np.ndarray or float, azimuth angle of the horizontal direction of interest
+                                measured from the north with anti-clockwise direction as positive, in the unit of degrees
+    Returns:    unit_vec      - list(np.ndarray/float), unit vector of the ENU component for the component of interest
+    """
+    # check input arguments
+    comps = [
+        'enu2los', 'en2los', 'hz2los', 'horz2los', 'u2los', 'vert2los',   # radar LOS / cross-track
+        'en2az', 'hz2az', 'orb_az', 'orbit_az',                           # radar azimuth / along-track
+        'vert', 'vertical', 'horz', 'horizontal',                         # vertical / arbitraty horizontal
+    ]
+
+    if comp not in comps:
+        raise ValueError(f'un-recognized comp input: {comp}.\nchoose from: {comps}')
+
+    if comp == 'horz' and horz_az_angle is None:
+        raise ValueError('comp=horz requires horz_az_angle input!')
+
+    # initiate output
+    unit_vect = None
+
+    if comp in ['enu2los']:
+        unit_vec = [
+            np.sin(np.deg2rad(los_inc_angle)) * np.sin(np.deg2rad(los_az_angle)) * -1,
+            np.sin(np.deg2rad(los_inc_angle)) * np.cos(np.deg2rad(los_az_angle)),
+            np.cos(np.deg2rad(los_inc_angle)),
+        ]
+
+    elif comp in ['en2los', 'hz2los', 'horz2los']:
+        unit_vec = [
+            np.sin(np.deg2rad(los_inc_angle)) * np.sin(np.deg2rad(los_az_angle)) * -1,
+            np.sin(np.deg2rad(los_inc_angle)) * np.cos(np.deg2rad(los_az_angle)),
+            np.zeros_like(los_inc_angle),
+        ]
+
+    elif comp in ['u2los', 'vert2los']:
+        unit_vec = [
+            np.zeros_like(los_inc_angle),
+            np.zeros_like(los_inc_angle),
+            np.cos(np.deg2rad(los_inc_angle)),
+        ]
+
+    elif comp in ['en2az', 'hz2az', 'orb_az', 'orbit_az']:
+        orb_az_angle = los2orbit_azimuth_angle(los_az_angle)
+        unit_vec = [
+            np.sin(np.deg2rad(orb_az_angle)) * -1,
+            np.cos(np.deg2rad(orb_az_angle)),
+            np.zeros_like(orb_az_angle),
+        ]
+
+    elif comp in ['vert', 'vertical']:
+        unit_vec = [0, 0, 1]
+
+    elif comp in ['horz', 'horizontal']:
+        unit_vec = [
+            np.sin(np.deg2rad(horz_az_angle)) * -1,
+            np.cos(np.deg2rad(horz_az_angle)),
+            np.zeros_like(horz_az_angle),
+        ]
+
+    return unit_vec
 
 
 
@@ -741,6 +828,69 @@ def polygon2mask(polygon, shape):
     mask = np.array(img, dtype=np.bool_)
 
     return mask
+
+
+def get_circular_mask(x, y, radius, shape):
+    """Get mask of pixels within circle defined by (x, y, r)"""
+    length, width = shape
+    yy, xx = np.ogrid[-y:length-y,
+                      -x:width-x]
+    cmask = (xx**2 + yy**2 <= radius**2)
+    return cmask
+
+
+def circle_index(atr, circle_par):
+    """Return Index of Elements within a Circle centered at input pixel
+    Parameters: atr : dictionary
+                    containging the following attributes:
+                    WIDT
+                    LENGTH
+                circle_par : string in the format of 'y,x,radius'
+                    i.e. '200,300,20'          for radar coord
+                         '31.0214,130.5699,20' for geo   coord
+    Returns:    idx : 2D np.array in bool type
+                    mask matrix for those pixel falling into the circle
+                    defined by circle_par
+    Examples:   idx_mat = ut.circle_index(atr, '200,300,20')
+                idx_mat = ut.circle_index(atr, '31.0214,130.5699,20')
+    """
+
+    width = int(atr['WIDTH'])
+    length = int(atr['LENGTH'])
+
+    if isinstance(circle_par, tuple):
+        cir_par = circle_par
+    elif isinstance(circle_par, list):
+        cir_par = circle_par
+    else:
+        cir_par = circle_par.replace(',', ' ').split()
+    cir_par = [str(i) for i in cir_par]
+
+    try:
+        c_y = int(cir_par[0])
+        c_x = int(cir_par[1])
+        radius = int(float(cir_par[2]))
+        print('Input circle index in y/x coord: %d, %d, %d' % (c_y, c_x, radius))
+    except:
+        try:
+            c_lat = float(cir_par[0])
+            c_lon = float(cir_par[1])
+            radius = int(float(cir_par[2]))
+            c_y = np.rint((c_lat-float(atr['Y_FIRST'])) / float(atr['Y_STEP']))
+            c_x = np.rint((c_lon-float(atr['X_FIRST'])) / float(atr['X_STEP']))
+            print(('Input circle index in lat/lon coord: '
+                   '{:.4f}, {:.4f}, {}'.format(c_lat, c_lon, radius)))
+        except:
+            print('\nERROR: Unrecognized circle index format: '+circle_par)
+            print('Supported format:')
+            print('--circle 200,300,20            for radar coord input')
+            print('--circle 31.0214,130.5699,20   for geo   coord input\n')
+            return 0
+
+    y, x = np.ogrid[-c_y:length-c_y, -c_x:width-c_x]
+    idx = x**2 + y**2 <= radius**2
+
+    return idx
 
 
 

--- a/mintpy/utils/utils0.py
+++ b/mintpy/utils/utils0.py
@@ -45,7 +45,7 @@ def misregistration2coherence(mu):
     coh = np.sinc(mu)
 
     # for coregistration errors >1, set coherence to zero
-    if type(mu) is np.ndarray:
+    if isinstance(mu, np.ndarray):
         coh[mu > 1] = 0
     else:
         if mu > 1:
@@ -215,16 +215,15 @@ def azimuth_ground_resolution(atr):
     if 'X_FIRST' in atr.keys():
         print('Input file is in geo coord, no azimuth resolution info.')
         return
-    try:
-        proc = atr['PROCESSOR']
-    except:
-        proc = 'isce'
+
+    proc = atr.get('PROCESSOR', 'isce')
     if proc in ['roipac', 'isce']:
         Re = float(atr['EARTH_RADIUS'])
         height = float(atr['HEIGHT'])
         az_step = float(atr['AZIMUTH_PIXEL_SIZE']) * Re / (Re + height)
     elif proc == 'gamma':
         az_step = float(atr['AZIMUTH_PIXEL_SIZE'])
+
     return az_step
 
 
@@ -659,7 +658,7 @@ def get_unit_vector4component_of_interest(los_inc_angle, los_az_angle, comp='enu
         raise ValueError('comp=horz requires horz_az_angle input!')
 
     # initiate output
-    unit_vect = None
+    unit_vec = None
 
     if comp in ['enu2los']:
         unit_vec = [

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -16,7 +16,7 @@ import shutil
 import h5py
 import numpy as np
 import mintpy
-from mintpy.objects import deramp, ifgramStack, timeseries, geometryDatasetNames
+from mintpy.objects import deramp, ifgramStack, timeseries, GEOMETRY_DSET_NAMES
 from mintpy.utils import ptime, readfile, writefile
 from mintpy.utils.utils0 import *
 
@@ -473,7 +473,7 @@ def get_geometry_file(dset_list, work_dir=None, coord='geo', abspath=True, print
     if isinstance(dset_list, str):
         dset_list = [dset_list]
     for dset in dset_list:
-        if dset not in geometryDatasetNames:
+        if dset not in GEOMETRY_DSET_NAMES:
             raise ValueError('unrecognized geometry dataset name: {}'.format(dset))
 
     if not work_dir:
@@ -718,16 +718,17 @@ def check_template_auto_value(templateDict, auto_file='defaults/smallbaselineApp
             templateDict[key] = templateAutoDict[key]
 
     # Change yes --> True, no --> False and none --> None
-    specialValues = {'yes'  : True,
-                     'true' : True,
-                     'no'   : False,
-                     'false': False,
-                     'none' : None,
-                     }
+    special_values = {
+        'yes'  : True,
+        'true' : True,
+        'no'   : False,
+        'false': False,
+        'none' : None,
+    }
     for key, value in templateDict.items():
         value = value.lower()
-        if value in specialValues.keys():
-            templateDict[key] = specialValues[value]
+        if value in special_values.keys():
+            templateDict[key] = special_values[value]
 
     return templateDict
 

--- a/mintpy/utils/utils1.py
+++ b/mintpy/utils/utils1.py
@@ -131,7 +131,10 @@ def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                                            out_file=deramped_file)
 
         print('\ncalculating residual RMS for each epoch from file: '+deramped_file)
-        rms_file = timeseries(deramped_file).timeseries_rms(maskFile=mask_file, outFile=rms_file)
+        rms_file = timeseries(deramped_file).timeseries_rms(
+            maskFile=mask_file,
+            outFile=rms_file,
+        )
 
     # Read residual RMS text file
     print('read timeseries residual RMS from file: '+rms_file)

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -4,7 +4,7 @@
 # Author: Zhang Yunjun, Heresh Fattahi, 2013               #
 ############################################################
 # Recommend import:
-#   from mintpy import view
+#   from mintpy.view import prep_slice, plot_slice, viewer
 
 
 import os
@@ -321,12 +321,15 @@ def update_data_with_plot_inps(data, metadata, inps):
 
 ##################################################################################################
 def prep_slice(cmd, auto_fig=False):
-    """Prepare data from command line as input, for easy call plot_slice() externally
+    """Prepare data from command line as input, for easy call plot_slice() externally.
+
     Parameters: cmd  - string, command to be run in terminal
     Returns:    data - 2D np.ndarray, data to be plotted
                 atr  - dict, metadata
                 inps - namespace, input argument for plot setup
     Example:
+        from mintpy.view import prep_slice, plot_slice
+
         subplot_kw = dict(projection=ccrs.PlateCarree())
         fig, ax = plt.subplots(figsize=[4, 3], subplot_kw=subplot_kw)
         W, N, E, S = (-91.670, -0.255, -91.370, -0.515)    # geo_box
@@ -336,8 +339,8 @@ def prep_slice(cmd, auto_fig=False):
         cmd += '--cbar-loc bottom --cbar-nbins 3 --cbar-ext both --cbar-size 5% '
         cmd += '--lalo-step 0.2 --lalo-loc 1 0 1 0 --scalebar 0.3 0.80 0.05 --notitle'
 
-        data, atr, inps = view.prep_slice(cmd)
-        ax, inps, im, cbar = view.plot_slice(ax, data, atr, inps)
+        data, atr, inps = prep_slice(cmd)
+        ax, inps, im, cbar = plot_slice(ax, data, atr, inps)
         plt.show()
     """
     # parse
@@ -426,14 +429,15 @@ def plot_slice(ax, data, metadata, inps):
                 inps : Namespace for input options
                 im   : matplotlib.image.AxesImage object
                 cbar : matplotlib.colorbar.Colorbar object
-    Example:    import matplotlib.pyplot as plt
-                import mintpy.utils.readfile as readfile
-                import mintpy.view as pv
-                data, atr = readfile.read('velocity.h5')
-                fig = plt.figure()
-                ax = fig.add_axes([0.1,0.1,0.8,0.8])
-                ax = pv.plot_slice(ax, data, atr)[0]
-                plt.show()
+    Example:
+        from matplotlib import pyplot as plt
+        from mintpy.utils import readfile
+        from mintpy.view import plot_slice
+
+        data, atr = readfile.read('velocity.h5')
+        fig, ax = plt.subplots()
+        ax = plot_slice(ax, data, atr)[0]
+        plt.show()
     """
     global vprint
     vprint = print if inps.print_msg else lambda *args, **kwargs: None

--- a/mintpy/view.py
+++ b/mintpy/view.py
@@ -19,9 +19,9 @@ import numpy as np
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from mintpy.objects import (
+    TIMESERIES_KEY_NAMES,
     giantIfgramStack,
     ifgramStack,
-    timeseriesKeyNames,
 )
 from mintpy.objects.gps import GPS
 from mintpy.utils import (
@@ -642,10 +642,11 @@ def plot_slice(ax, data, metadata, inps):
         # read lats/lons if exist
         geom_file = os.path.join(os.path.dirname(metadata['FILE_PATH']), 'inputs/geometryRadar.h5')
         if os.path.isfile(geom_file):
-            try:
+            geom_ds_list = readfile.get_dataset_list(geom_file)
+            if all(x in geom_ds_list for x in ['latitude', 'longitude']):
                 lats = readfile.read(geom_file, datasetName='latitude',  box=inps.pix_box, print_msg=False)[0]
                 lons = readfile.read(geom_file, datasetName='longitude', box=inps.pix_box, print_msg=False)[0]
-            except:
+            else:
                 msg = 'WARNING: no latitude / longitude found in file: {}, '.format(os.path.basename(geom_file))
                 msg += 'skip showing lat/lon in the status bar.'
                 vprint(msg)
@@ -868,7 +869,7 @@ def read_dataset_input(inps):
     inps.dsetNum = len(inps.dset)
 
     if inps.ref_date:
-        if inps.key not in timeseriesKeyNames:
+        if inps.key not in TIMESERIES_KEY_NAMES:
             inps.ref_date = None
 
         ref_date = search_dataset_input(
@@ -893,7 +894,7 @@ def read_dataset_input(inps):
         vprint('num of datasets in file {}: {}'.format(os.path.basename(inps.file), len(inps.sliceList)))
         vprint('datasets to exclude ({}):\n{}'.format(len(inps.exDsetList), inps.exDsetList))
         vprint('datasets to display ({}):\n{}'.format(len(inps.dset), inps.dset))
-    if inps.ref_date and inps.key in timeseriesKeyNames:
+    if inps.ref_date and inps.key in TIMESERIES_KEY_NAMES:
         vprint('input reference date: {}'.format(inps.ref_date))
 
     if inps.dsetNum == 0:
@@ -1179,7 +1180,7 @@ def plot_subplot4figure(i, inps, ax, data, metadata):
     if inps.disp_title:
         # get title
         subplot_title = None
-        if inps.key in timeseriesKeyNames or inps.dset[0].startswith('bperp'):
+        if inps.key in TIMESERIES_KEY_NAMES or inps.dset[0].startswith('bperp'):
             # support / for py2-mintpy
             date_str = inps.dset[i].replace('/','-').split('-')[1]
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pykml>=0.2
 pyproj
 pyresample
 pysolid
+rich
 scikit-image
 scipy
 # for ISCE, ARIA, FRInGE, HyP3, GMTSAR

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,13 @@ setup(
         "pyproj",
         "pyresample",  # pip installed version does not work
         #"pysolid",    # will be available soon after the pypi project transfer is completed
+        "rich",
         "setuptools",
         "scikit-image",
         "scipy",
     ],
     extras_require={
-        "cli": ["argcomplete", "rich"],
+        "cli": ["argcomplete"],
         "extra": ["gdal"],
         "fractal": ["pyfftw"],
         "gbis": ["geoid"],                          # not available on pypi


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.utils0`: add more functions to support more flexible ENU to range/azimuth projection

+ `solid_earth_tides` / `bulk_plate_motion`: 
   - add `--comp enu2los / en2az` to switch between range / azimuth direction output
   - use `utils0.get_unit_vector4comp_of_interest()` above to apply the proper projection

+ objects.timeseries.read(): use single indexing to speedup IO

+ add `rich` to the formal dependency list, as it's lightweight and prints colorful template content, and will be used more.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1502/workflows/60a58d23-eab8-40e7-bb21-e942f6f5830b/jobs/1505) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.