### PR TITLE
sort ds_list to ensure `velocity` as first and `residue/intercept` as last

### DIFF
--- a/mintpy/objects/progress.py
+++ b/mintpy/objects/progress.py
@@ -8,13 +8,43 @@
 # OR from mintpy.utils import ptime
 
 
+import io
+import os
 import sys
 import time
 
 import numpy as np
 
 
-###########################Simple progress bar######################
+########################### file progress class - begin ##########################
+class FileProgressObject(io.FileIO):
+    """Show tarfile progress.
+
+    Link: https://stackoverflow.com/questions/3667865/python-tarfile-progress-output
+
+    Example:
+        print(f'extracting content from tar file: {tar_file}')
+        tar = tarfile.open(fileobj=FileProgressObject(tar_file))
+        tar.extractall()
+        tar.close()
+        print('')
+    """
+
+    def __init__(self, path, *args, **kwargs):
+        self._total_size = os.path.getsize(path)
+        io.FileIO.__init__(self, path, *args, **kwargs)
+
+    def read(self, size):
+        perc = self.tell() / self._total_size * 100
+        msg = f"extracting: {self.tell()/(1024**2):.1f} of {self._total_size/(1024**2):.1f} MB - {perc:.0f}%"
+        sys.stdout.write("\r" + msg)
+        sys.stdout.flush()
+        return io.FileIO.read(self, size)
+
+########################### file progress class - end ############################
+
+
+########################### progress bar class - begin ###########################
 class progressBar:
     """Creates a text-based progress bar. Call the object with
     the simple print command to see the progress bar, which looks
@@ -52,10 +82,12 @@ class progressBar:
         self.width = totalWidth
         self.reset()
 
+
     def reset(self):
         self.start_time = time.time()
         self.amount = 0        # When amount == max, we are 100% done
         self.update_amount(0)  # Build progress bar string
+
 
     def update_amount(self, newAmount=0, suffix=''):
         """ Update the progress bar with the new amount (with min and max
@@ -110,6 +142,7 @@ class progressBar:
                 remain_time = int(elapse_time * (100./percentDone-1))
                 self.prog_bar += f'{int(elapse_time):5d}s / {int(remain_time):5d}s'
 
+
     def update(self, value, every=1, suffix=''):
         """ Updates the amount, and writes to stdout.
         Prints a carriage return first, so it will overwrite the current line in stdout.
@@ -120,10 +153,12 @@ class progressBar:
                 sys.stdout.write('\r' + self.prog_bar)
                 sys.stdout.flush()
 
+
     def close(self):
         """Prints a blank space at the end to ensure proper printing
         of future statements.
         """
         if self.print_msg:
             print(' ')
-################################End of progress bar class####################################
+
+########################### progress bar class - end #############################

--- a/tests/smallbaselineApp.py
+++ b/tests/smallbaselineApp.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 import mintpy.cli.view
+from mintpy.objects.progress import FileProgressObject
 
 CMAP_DICT = {
     'FernandinaSenDT128' : 'jet',
@@ -95,14 +96,16 @@ def test_smallbaselineApp(dset_name, test_dir, fresh_start=True, test_pyaps=Fals
     template_file = TEMPLATE_FILES[dset_idx]
 
     # download tar file
-    tar_file = os.path.basename(dset_url)
-    if not os.path.isfile(tar_file):
-        print('downloading tar file ...')
-        cmd = f'wget {dset_url}'
-        print(cmd)
-        os.system(cmd)
-    else:
+    tar_fbase = os.path.splitext(os.path.basename(dset_url))[0]
+    tar_files = [tar_fbase + x for x in ['.xz', '.gz'] if os.path.isfile(tar_fbase + x)]
+    if tar_files:
+        tar_file = tar_files[0]
         print('tar file exists, skip re-downloading.')
+    else:
+        tar_file = os.path.basename(dset_url)
+        cmd = f'wget {dset_url}'
+        print(f'downloading tar file ...\n{cmd}')
+        os.system(cmd)
 
     # uncompress tar file
     if not fresh_start and os.path.isdir(dset_name):
@@ -115,9 +118,10 @@ def test_smallbaselineApp(dset_name, test_dir, fresh_start=True, test_pyaps=Fals
 
         # uncompress tar file
         print(f'extracting content from tar file: {tar_file}')
-        tar = tarfile.open(tar_file)
+        tar = tarfile.open(fileobj=FileProgressObject(tar_file))
         tar.extractall()
         tar.close()
+        print('')
 
     # set working directory
     work_dir = os.path.join(test_dir, dset_name, 'mintpy')


### PR DESCRIPTION
**Description of proposed changes**

+ add `utils.readfile.sort_dataset_list4velocity()` to ensure `velocity` are the first dataset, and `intercept/residue` are the last datasets. This fixes the behavior change introduced in #835, as reported by Sven in the [user forum](https://groups.google.com/g/mintpy/c/Drxi6zU2voo/m/QowHGgZdBwAJ)

+ `tests/smallbaselineApp`: use *.tar.gz file, in addition to *.tar.xz file, if exists.

+ add `mintpy.objects.progress.FileProgressObject` class to show a progrerss bar during uncompressing

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1561/workflows/419fbdb2-2b6b-4caa-b3c7-c4be508d1a86/jobs/1564) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
