### PR TITLE
support `hyp3` `lv_phi` file as azimuth angle

### DIFF
--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -395,6 +395,7 @@ $DATA_DIR/RidgecrestSenDT71
 │   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_corr_clip.tif
 │   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_dem_clip.tif
 │   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_lv_theta_clip.tif
+│   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_lv_phi_clip.tif
 │   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_unw_phase_clip.tif
 │   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43_water_mask_clip.tif
 │   │   ├── S1AA_20190622T135157_20190704T135158_VVP012_INT80_G_ueF_4C43.txt
@@ -419,6 +420,7 @@ mintpy.load.corFile          = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*corr_clip.tif
 ##---------geometry datasets:
 mintpy.load.demFile          = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*dem_clip.tif
 mintpy.load.incAngleFile     = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*lv_theta_clip.tif
+mintpy.load.azAngleFile      = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*lv_phi_clip.tif
 mintpy.load.waterMaskFile    = $DATA_DIR/RidgecrestSenDT71/hyp3/*/*water_mask_clip.tif
 ```
 

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -719,14 +719,25 @@ class geometryDict:
                         print(f'    scale value of {dsName:<15} by 1/{ystep} due to multilooking')
                         data /= ystep
 
-                    elif dsName == 'incidenceAngle':
-                        # HyP3 (Gamma) incidence angle file 'theta' is measure from horizontal in radians
+                    elif dsName in ['incidenceAngle', 'azimuthAngle']:
+                        # HyP3 (Gamma) angle of the line-of-sight vector (from ground to SAR platform)
+                        # incidence angle 'theta' is measured from horizontal in radians
+                        # azimuth   angle 'phi'   is measured from the east with anti-clockwise as positivve in radians
                         atr = readfile.read_attribute(self.file)
-                        if (atr.get('PROCESSOR', 'isce') == 'hyp3'
-                                and atr.get('UNIT', 'degrees').startswith('rad')):
-                            print(('    convert {:<15} from Gamma (from horizontal in radian) to '
-                                  'MintPy (from vertical in degree) convention.').format(dsName))
-                            data = 90. - (data * 180. / np.pi)
+                        if (atr.get('PROCESSOR', 'isce') == 'hyp3' and atr.get('UNIT', 'degrees').startswith('rad')):
+
+                            if dsName == 'incidenceAngle':
+                                msg = f'    convert {dsName:<15} from Gamma (from horizontal in radian) '
+                                msg += ' to MintPy (from vertical in degree) convention.'
+                                print(msg)
+                                data = 90. - (data * 180. / np.pi)
+
+                            elif dsName == 'azimuthAngle':
+                                msg = f'    convert {dsName:<15} from Gamma (from east in radian) '
+                                msg += ' to MintPy (from north in degree) convention.'
+                                print(msg)
+                                data = data * 180. / np.pi - 90.
+                                data = ut.wrap(data, wrap_range=[-180, 180])
 
                     # write
                     ds = f.create_dataset(dsName,

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -736,8 +736,9 @@ class geometryDict:
                                 msg = f'    convert {dsName:<15} from Gamma (from east in radian) '
                                 msg += ' to MintPy (from north in degree) convention.'
                                 print(msg)
-                                data = data * 180. / np.pi - 90.
-                                data = ut.wrap(data, wrap_range=[-180, 180])
+                                data[data == 0] = np.nan                        # convert no-data-value from 0 to nan
+                                data = data * 180. / np.pi - 90.                # hyp3/gamma to mintpy/isce2 convention
+                                data = ut.wrap(data, wrap_range=[-180, 180])    # rewrap within -180 to 180
 
                     # write
                     ds = f.create_dataset(dsName,

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -724,7 +724,7 @@ class geometryDict:
                         # incidence angle 'theta' is measured from horizontal in radians
                         # azimuth   angle 'phi'   is measured from the east with anti-clockwise as positivve in radians
                         atr = readfile.read_attribute(self.file)
-                        if (atr.get('PROCESSOR', 'isce') == 'hyp3' and atr.get('UNIT', 'degrees').startswith('rad')):
+                        if atr.get('PROCESSOR', 'isce') == 'hyp3' and atr.get('UNIT', 'degrees').startswith('rad'):
 
                             if dsName == 'incidenceAngle':
                                 msg = f'    convert {dsName:<15} from Gamma (from horizontal in radian) '

--- a/mintpy/objects/stackDict.py
+++ b/mintpy/objects/stackDict.py
@@ -483,7 +483,8 @@ class geometryDict:
                 atr = readfile.read_attribute(self.file)
                 if atr.get('PROCESSOR', 'isce') == 'hyp3' and atr.get('UNIT', 'degrees').startswith('rad'):
                     print('    convert incidence angle from Gamma to MintPy convention.')
-                    inc_angle = 90. - (inc_angle * 180. / np.pi)
+                    inc_angle[inc_angle == 0] = np.nan              # convert the no-data-value from 0 to nan
+                    inc_angle = 90. - (inc_angle * 180. / np.pi)    # hyp3/gamma to mintpy/isce2 convention
                 # inc angle -> slant range distance
                 data = ut.incidence_angle2slant_range_distance(self.extraMetadata, inc_angle)
 
@@ -730,7 +731,8 @@ class geometryDict:
                                 msg = f'    convert {dsName:<15} from Gamma (from horizontal in radian) '
                                 msg += ' to MintPy (from vertical in degree) convention.'
                                 print(msg)
-                                data = 90. - (data * 180. / np.pi)
+                                data[data == 0] = np.nan                        # convert no-data-value from 0 to nan
+                                data = 90. - (data * 180. / np.pi)              # hyp3/gamma to mintpy/isce2 convention
 
                             elif dsName == 'azimuthAngle':
                                 msg = f'    convert {dsName:<15} from Gamma (from east in radian) '

--- a/mintpy/prep_hyp3.py
+++ b/mintpy/prep_hyp3.py
@@ -85,9 +85,9 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
         meta['RANGE_PIXEL_SIZE'] = sensor.SEN['range_pixel_size'] * int(meta['RLOOKS'])
         meta['AZIMUTH_PIXEL_SIZE'] = sensor.SEN['azimuth_pixel_size'] * int(meta['ALOOKS'])
 
-    # note: HyP3 (incidence) angle datasets are in the unit of radian
+    # note: HyP3 (incidence, azimuth) angle datasets are in the unit of radian
     # which is different from the isce-2 convention of degree
-    if 'lv_theta' in os.path.basename(fname):
+    if any(x in os.path.basename(fname) for x in ['lv_theta', 'lv_phi']):
         meta['UNIT'] = 'radian'
 
     # add metadata that is only relevant to interferogram files


### PR DESCRIPTION
**Description of proposed changes**

+ prep_hyp3.add_hyp3_metadata(): set UNIT to radian for "lv_phi" file

+ objects.stackDict.geometryDict(): convert hyp3 azimuthAngle input from gamma to mintpy/isce2 convention, as described in #857 by @cirrusasf and @forrestfwilliams.

+ docs: add lv_phi file to the example dir structure for hyp3

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1569/workflows/a055da64-8217-4e90-b688-c123b0c49c85/jobs/1572) (green)
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.