### PR TITLE
`writefile.write`: force `BANDS` to 2 for `.unw` file

### DIFF
--- a/mintpy/utils/writefile.py
+++ b/mintpy/utils/writefile.py
@@ -168,6 +168,7 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None,
             meta['INTERLEAVE'] = 'BIL'
             if key_list != ['magnitude', 'phase']:
                 data_list = [data_list[0], data_list[0]]
+                meta['BANDS'] = 2
 
         elif fext in ['.cor', '.hgt']:
             meta['DATA_TYPE'] = 'float32'


### PR DESCRIPTION
**Description of proposed changes**

- Added a line to writefile.py so that MintPy can recognise the no. of bands after deramping the .unw file.

**Reminders**

- [ ] Fix #861
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
