### PR TITLE
`save_roipac`: support non-velocity dataset from the velocity file

### DIFF
--- a/mintpy/cli/save_roipac.py
+++ b/mintpy/cli/save_roipac.py
@@ -16,6 +16,9 @@ EXAMPLE = """example:
   #for velocity: output an interferogram with temporal baseline in DATE12 metadata
   save_roipac.py  velocity.h5
   save_roipac.py  velocity.h5 -m maskTempCoh.h5 maskAoiShinmoe.h5
+  #for non-veloicty dataset, e.g. step or annualAmplitude
+  save_roipac.py  velocity.h5  step20080221
+  save_roipac.py  velocity.h5  annualAmplitude
 
   #for time-series: specify (date1_)date2
   save_roipac.py  timeseries_ERA5_ramp_demErr.h5  #use the last date

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -44,7 +44,7 @@ def read_data(inps):
     # various file types
     print(f'read {inps.dset} from file {inps.file}')
     k = atr['FILE_TYPE']
-        if k == 'velocity':
+    if k == 'velocity':
         # read/prepare data
         if inps.dset == None:
             inps.dset = 'velocity'

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -46,30 +46,29 @@ def read_data(inps):
     k = atr['FILE_TYPE']
     if k == 'velocity':
         # read/prepare data
-        if inps.dset == None:
+        if not inps.dset:
             inps.dset = 'velocity'
-            print('No selected datset, assuming chosen dataset is velocity')
+            print('No selected datset, assuming "velocity" and continue.')
+        data, atr = readfile.read(inps.file, datasetName=inps.dset)
+
+        # convert velocity to cumulative displacement
         if inps.dset == 'velocity':
-            data = readfile.read(inps.file)[0]
-            # velocity to displacement
             print('convert velocity to displacement for {}'.format(atr['DATE12']))
-            date1, date2 = atr['DATE12'].split('_')
-            dt1, dt2 = ptime.date_list2vector([date1, date2])[0]
+            dt1, dt2 = ptime.date_list2vector(atr['DATE12'].split('_'))[0]
             data *= (dt2 - dt1).days / 365.25
-            
-        else:
-            data = readfile.read(inps.file, datasetName = inps.dset)[0]
 
-        # displacement to phase
-        print('convert velocity or displacement to phase in radian')
-        data *= range2phase
+        # convert data from the unit of meter to radian
+        if atr.get('UNIT', 'm/year').startswith('m'):
+            print('convert the unit from meter to radian')
+            data *= range2phase
+            atr['UNIT'] = 'radian'
 
+        # apply the custom spatial referencing
         if inps.ref_yx:
             data -= data[inps.ref_yx[0], inps.ref_yx[1]]
 
         # metadata
         atr['FILE_TYPE'] = '.unw'
-        atr['UNIT'] = 'radian'
 
         # output filename
         if not inps.outfile:

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -61,7 +61,7 @@ def read_data(inps):
             data = readfile.read(inps.file, datasetName = inps.dset)[0]
 
         # displacement to phase
-        print('convert displacement to phase in radian')
+        print('convert velocity or displacement to phase in radian')
         data *= range2phase
 
         if inps.ref_yx:

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -46,7 +46,10 @@ def read_data(inps):
     k = atr['FILE_TYPE']
     if k == 'velocity':
         # read/prepare data
-        data = readfile.read(inps.file)[0]
+        if inps.dset is None:
+            data = readfile.read(inps.file)[0]
+        else:
+            data = readfile.read(inps.file, datasetName = inps.dset)[0]
 
         # velocity to displacement
         print('convert velocity to displacement for {}'.format(atr['DATE12']))

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -44,18 +44,21 @@ def read_data(inps):
     # various file types
     print(f'read {inps.dset} from file {inps.file}')
     k = atr['FILE_TYPE']
-    if k == 'velocity':
+        if k == 'velocity':
         # read/prepare data
-        if inps.dset is None:
+        if inps.dset == None:
+            inps.dset = 'velocity'
+            print('No selected datset, assuming chosen dataset is velocity')
+        if inps.dset == 'velocity':
             data = readfile.read(inps.file)[0]
+            # velocity to displacement
+            print('convert velocity to displacement for {}'.format(atr['DATE12']))
+            date1, date2 = atr['DATE12'].split('_')
+            dt1, dt2 = ptime.date_list2vector([date1, date2])[0]
+            data *= (dt2 - dt1).days / 365.25
+            
         else:
             data = readfile.read(inps.file, datasetName = inps.dset)[0]
-
-        # velocity to displacement
-        #print('convert velocity to displacement for {}'.format(atr['DATE12']))
-        #date1, date2 = atr['DATE12'].split('_')
-        #dt1, dt2 = ptime.date_list2vector([date1, date2])[0]
-        #data *= (dt2 - dt1).days / 365.25
 
         # displacement to phase
         print('convert displacement to phase in radian')

--- a/mintpy/save_roipac.py
+++ b/mintpy/save_roipac.py
@@ -52,10 +52,10 @@ def read_data(inps):
             data = readfile.read(inps.file, datasetName = inps.dset)[0]
 
         # velocity to displacement
-        print('convert velocity to displacement for {}'.format(atr['DATE12']))
-        date1, date2 = atr['DATE12'].split('_')
-        dt1, dt2 = ptime.date_list2vector([date1, date2])[0]
-        data *= (dt2 - dt1).days / 365.25
+        #print('convert velocity to displacement for {}'.format(atr['DATE12']))
+        #date1, date2 = atr['DATE12'].split('_')
+        #dt1, dt2 = ptime.date_list2vector([date1, date2])[0]
+        #data *= (dt2 - dt1).days / 365.25
 
         # displacement to phase
         print('convert displacement to phase in radian')


### PR DESCRIPTION
**Description of proposed changes**

- Ability to extract a specific dataset from a velocity file and save it in ROIPAC format.
- Removed behavior to make datasets into displacement values with the exception of the velocity dataset

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
