### PR TITLE
`dem_error`: change default from phase to phase velocity

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -257,7 +257,7 @@ mintpy.deramp.maskFile = auto  #[filename / no], auto for maskTempCoh.h5, mask f
 ##                     no  - use the mean   geometry [fast]
 mintpy.topographicResidual                   = auto  #[yes / no], auto for yes
 mintpy.topographicResidual.polyOrder         = auto  #[1-inf], auto for 2, poly order of temporal deformation model
-mintpy.topographicResidual.phaseVelocity     = auto  #[yes / no], auto for no - phase, use phase velocity for minimization
+mintpy.topographicResidual.phaseVelocity     = auto  #[yes / no], auto for yes - use phase velocity for minimization
 mintpy.topographicResidual.stepFuncDate      = auto  #[20080529,20190704T1733 / no], auto for no, date of step jump
 mintpy.topographicResidual.excludeDate       = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
 mintpy.topographicResidual.pixelwiseGeometry = auto  #[yes / no], auto for yes, use pixel-wise geometry info

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -108,7 +108,7 @@ mintpy.deramp.maskFile   = maskTempCoh.h5
 ########## correct_topography
 mintpy.topographicResidual                    = yes
 mintpy.topographicResidual.polyOrder          = 2
-mintpy.topographicResidual.phaseVelocity      = no
+mintpy.topographicResidual.phaseVelocity      = yes
 mintpy.topographicResidual.stepFuncDate       = no
 mintpy.topographicResidual.excludeDate        = exclude_date.txt
 mintpy.topographicResidual.pixelwiseGeometry  = yes

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -241,7 +241,7 @@ def estimate_dem_error(ts0, G0, tbase, date_flag=None, phase_velocity=False):
     if phase_velocity:
         tbase = tbase[date_flag]
         G = np.diff(G, axis=0) / np.repeat(np.diff(tbase, axis=0).reshape(-1,1), G.shape[1], axis=1)
-        ts = np.diff(ts, axis=0) / np.repeat(np.diff(tbase, axis=0).reshape(-1,1), ts.shape[1], axis=1) #np.diff(tbase, axis=0)
+        ts = np.diff(ts, axis=0) / np.repeat(np.diff(tbase, axis=0).reshape(-1,1), ts.shape[1], axis=1)
 
     # Inverse using L-2 norm to get unknown parameters X
     # X = [delta_z, constC, vel, acc, deltaAcc, ..., step1, step2, ...]

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -239,9 +239,9 @@ def estimate_dem_error(ts0, G0, tbase, date_flag=None, phase_velocity=False):
     G = G0[date_flag, :]
     ts = ts0[date_flag, :]
     if phase_velocity:
-        tbase = tbase[date_flag, :]
-        G = np.diff(G, axis=0) / np.diff(tbase, axis=0)
-        ts = np.diff(ts, axis=0) / np.diff(tbase, axis=0)
+        tbase = tbase[date_flag]
+        G = np.diff(G, axis=0) / np.repeat(np.diff(tbase, axis=0).reshape(-1,1), G.shape[1], axis=1)
+        ts = np.diff(ts, axis=0) / np.repeat(np.diff(tbase, axis=0).reshape(-1,1), ts.shape[1], axis=1) #np.diff(tbase, axis=0)
 
     # Inverse using L-2 norm to get unknown parameters X
     # X = [delta_z, constC, vel, acc, deltaAcc, ..., step1, step2, ...]


### PR DESCRIPTION
**Description of proposed changes**

In this PR, the DEM error calculation default is changed from phase history to phase velocity history based on the conclusion of the paper proposing the algorithm and experiment of geolocation correction on urban area
