### PR TITLE
bugfix for `smallbaselineApp.py --plot` option

### DIFF
--- a/mintpy/cli/smallbaselineApp.py
+++ b/mintpy/cli/smallbaselineApp.py
@@ -33,17 +33,17 @@ REFERENCE = """reference:
 """
 
 EXAMPLE = """example:
-  smallbaselineApp.py                         #run with default template 'smallbaselineApp.cfg'
-  smallbaselineApp.py <custom_template>       #run with default and custom templates
-  smallbaselineApp.py -h / --help             #help
-  smallbaselineApp.py -H                      #print    default template options
-  smallbaselineApp.py -g                      #generate default template if it does not exist
-  smallbaselineApp.py -g <custom_template>    #generate/update default template based on custom template
-  smallbaselineApp.py --plot                  #plot results w/o run [to populate the 'pic' folder after failed runs]
+  smallbaselineApp.py                         # run with default template 'smallbaselineApp.cfg'
+  smallbaselineApp.py <custom_template>       # run with default and custom templates
+  smallbaselineApp.py -h / --help             # help
+  smallbaselineApp.py -H                      # print    default template options
+  smallbaselineApp.py -g                      # generate default template if it does not exist
+  smallbaselineApp.py -g <custom_template>    # generate/update default template based on custom template
+  smallbaselineApp.py --plot                  # plot results w/o run [to populate the 'pic' folder after failed runs]
 
-  # Run with --start/stop/dostep options
-  smallbaselineApp.py GalapagosSenDT128.template --dostep velocity  #run at step 'velocity' only
-  smallbaselineApp.py GalapagosSenDT128.template --end load_data    #end after step 'load_data'
+  # step processing with --start/stop/dostep options
+  smallbaselineApp.py GalapagosSenDT128.template --dostep velocity  # run at step 'velocity' only
+  smallbaselineApp.py GalapagosSenDT128.template --end load_data    # end after step 'load_data'
 """
 
 

--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -196,8 +196,8 @@ def get_date12_to_drop(inps):
         date12_to_drop += tempList
         print('--------------------------------------------------')
         print(f'Drop ifgrams with the following index number: {len(tempList)}')
-        for i, date12 in enumerate(tempList):
-            print(f'{i} : {date12}')
+        for ifg_idx, date12 in zip(inps.excludeIfgIndex, tempList):
+            print(f'{ifg_idx} : {date12}')
 
     # excludeDate
     if inps.excludeDate:

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -128,9 +128,10 @@ class TimeSeriesAnalysis:
             os.makedirs(backup_dir, exist_ok=True)
 
             # back up to the directory
-            for tfile in [self.customTemplateFile, self.templateFile]:
+            tfiles = [x for x in [self.customTemplateFile, self.templateFile] if x]
+            for tfile in tfiles:
                 out_file = os.path.join(backup_dir, os.path.basename(tfile))
-                if tfile and ut.run_or_skip(out_file, in_file=tfile, readable=False, print_msg=False) == 'run':
+                if ut.run_or_skip(out_file, in_file=tfile, readable=False, print_msg=False) == 'run':
                     shutil.copy2(tfile, backup_dir)
                     print('copy {f:<{l}} to {d:<8} directory for backup.'.format(
                         f=os.path.basename(tfile), l=flen, d=os.path.basename(backup_dir)))

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "pykml>=0.2",
         "pyproj",
         "pyresample",  # pip installed version does not work
-        #"pysolid",    # will be available soon after the pypi project transfer is completed
+        "pysolid",     # pip installed version does not work because Fortran compiler is needed but not available via pip
         "rich",
         "setuptools",
         "scikit-image",

--- a/tests/smallbaselineApp.py
+++ b/tests/smallbaselineApp.py
@@ -82,6 +82,7 @@ def cmd_line_parse(iargs=None):
     # expand test_dir
     inps.test_dir = os.path.expanduser(inps.test_dir)
     inps.test_dir = os.path.expandvars(inps.test_dir)
+    inps.test_dir = os.path.abspath(inps.test_dir)
 
     return inps
 


### PR DESCRIPTION
**Description of proposed changes**

+ smallbaselineApp: fix the bug of empty template file in _read_template(), which results in TypeError while running `smallbaselineApp.py --plot` (Fix #878)

+ tests/smallbaselineApp: use abspath() to fix the bug while using --dir for a different direction for testing

+ modify_network: print given ifg index number, instead of ordering number, to be more informative

+ setup: uncomment pysolid as it's now available on pypi

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1593/workflows/fbc868c0-002b-4ae4-81ea-f7c71808b844/jobs/1596) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.