### PR TITLE
`tropo_pyaps3`: ensure 2 chars for `--hour` input

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             solid_earth_tides.py -h
 
       - run:
-          name: Testing MintPy Python Modules
+          name: Unit Testing
           command: |
             export PATH=${CONDA_PREFIX}/bin:${PATH}
             ${MINTPY_HOME}/tests/asc_desc2horz_vert.py
@@ -54,28 +54,28 @@ jobs:
             ${MINTPY_HOME}/tests/objects/euler_pole.py
 
       - run:
-          name: Testing MintPy on Example Dataset 1/4 - FernandinaSenDT128 (ISCE/topsStack)
+          name: Workflow Testing 1/4 - FernandinaSenDT128 (ISCE/topsStack)
           command: |
             export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
 
       - run:
-          name: Testing MintPy on Example Dataset 2/4 - SanFranSenDT42 (ARIA)
+          name: Workflow Testing 2/4 - SanFranSenDT42 (ARIA)
           command: |
             export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
 
       - run:
-          name: Testing MintPy on Example Dataset 3/4 - WellsEnvD2T399 (Gamma)
+          name: Workflow Testing 3/4 - WellsEnvD2T399 (Gamma)
           command: |
             export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
 
       - run:
-          name: Testing MintPy on Example Dataset 4/4 - WCapeSenAT29 (SNAP)
+          name: Workflow Testing 4/4 - WCapeSenAT29 (SNAP)
           command: |
             export PATH=${CONDA_PREFIX}/bin:${PATH}
             mkdir -p ${HOME}/data

--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -10,6 +10,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         cluster
         colors
         constants
+        euler_pole
         giant
         ramp
         sensor

--- a/mintpy/cli/tropo_pyaps3.py
+++ b/mintpy/cli/tropo_pyaps3.py
@@ -136,6 +136,11 @@ def cmd_line_parse(iargs=None):
     if (not inps.dis_file and not inps.date_list):
         raise SystemExit('ERROR: --file OR --date-list is required.\n\n'+EXAMPLE)
 
+    # check: --hour option (ensure 2 chars)
+    if inps.hour:
+        hour = int(float(inps.hour))
+        inps.hour = f'{hour:02d}'
+
     # default: --tropo-file option
     if inps.geom_file and not inps.tropo_file:
         geom_dir = os.path.dirname(inps.geom_file)

--- a/mintpy/objects/euler_pole.py
+++ b/mintpy/objects/euler_pole.py
@@ -6,14 +6,7 @@
 ############################################################
 # Recommend import:
 #     from mintpy.objects.euler_pole import EulerPole
-
-
-import numpy as np
-import pyproj
-
-from mintpy.objects.constants import EARTH_RADIUS
-
-################################################################################################
+#
 # Reference:
 #  Pichon, X. L., Francheteau, J. & Bonnin, J. Plate Tectonics; Developments in Geotectonics 6;
 #    Hardcover – January 1, 1973. Page 28-29
@@ -22,13 +15,19 @@ from mintpy.objects.constants import EARTH_RADIUS
 #  Navipedia, Transformations between ECEF and ENU coordinates. [Online].
 #    https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
 
+
+import numpy as np
+import pyproj
+
+from mintpy.objects.constants import EARTH_RADIUS
+
 # global variables
-# mas = milli arc second
-MAS2RAD = np.pi / 3600000 / 180    # 1 mas          = x radian
+MAS2RAD = np.pi / 3600000 / 180    # 1 mas (milli arc second) = x radian
 MASY2DMY = 1e6 / 3600000           # 1 mas per year = x degree per million year
 
 
-## Define the Euler pole class
+####################################  EulerPole class begin  #############################################
+# Define the Euler pole class
 EXAMPLE = """Define an Euler pole:
   Method 1 - Use an Euler vector [wx, wy, wz]
              wx/y/z   - float, angular velocity in x/y/z-axis [mas/yr or deg/Ma]
@@ -50,7 +49,7 @@ EXAMPLE = """Define an Euler pole:
 class EulerPole:
     """EulerPole object to compute velocity for a given tectonic plate.
 
-    EXAMPLE:
+    Example:
         # compute velocity of the Eurasia plate in ITRF2014-PMM from Altamimi et al. (2017)
         pole_obj = EulerPole(pole_lat=55.070, pole_lon=-99.095, rot_rate=0.939, unit='mas/yr')
         pole_obj.print_info()
@@ -240,12 +239,12 @@ class EulerPole:
 
         return ve, vn, vu
 
+####################################  EulerPole class end  ###############################################
 
 
-################################################################################################
-# Sub-functions for the math of Euler Pole and linear velocity
+####################################  Utility functions  #################################################
+# Utility functions for the math/geometry operations of Euler Pole and linear velocity
 # reference: https://yuankailiu.github.io/assets/docs/Euler_pole_doc.pdf
-
 def cart2sph(rx, ry, rz):
     """Convert cartesian coordinates to spherical.
 


### PR DESCRIPTION
**Description of proposed changes**

A few minor bugfix and comments update

+ tropo_pyaps3: ensure 2 chars for --hour input

+ docs/module_hierarchy: add euler_pole

+ .circleci: use Unit/Workflow tests as names

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1605/workflows/308daf64-5687-458a-96c1-6f5319028393/jobs/1608) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.