### PR TITLE
docs/install: set env variables for more robust handling of HDF5 and GDAL VRT

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -187,3 +187,13 @@ temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /l
 # If you are sharing the same machine with others, use the following instead to avoid permission issues with others.
 # temporary-directory: /tmp/{replace_this_with_your_user_name}
 ```
+
+#### c. Extra environment variables setup ####
+
+We recommend setting the following environment variables, e.g. in your `~/.bash_profile` file, to avoid occasional errors.
+
+```bash
+export VRT_SHARED_SOURCE=0             # do not share dataset while using GDAL VRT in a multi-threading environment
+export HDF5_DISABLE_VERSION_CHECK=2    # supress the HDF5 version warning message (0 for abort; 1/2 for printout/suppress warning message)
+export HDF5_USE_FILE_LOCKING=FALSE     # request that HDF5 file locks should NOT be used
+```

--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -4,14 +4,14 @@
 # Author: Zhang Yunjun, Heresh Fattahi, 2013               #
 ############################################################
 
-import os
+
 import h5py
 import numpy as np
 from matplotlib import dates as mdates, pyplot as plt
 
 from mintpy.objects import ifgramStack
 from mintpy.utils import network as pnet, plot as pp, ptime, utils as ut
-os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
 
 ###########################  Sub Function  #############################
 def reset_network(stackFile):

--- a/mintpy/modify_network.py
+++ b/mintpy/modify_network.py
@@ -4,14 +4,14 @@
 # Author: Zhang Yunjun, Heresh Fattahi, 2013               #
 ############################################################
 
-
+import os
 import h5py
 import numpy as np
 from matplotlib import dates as mdates, pyplot as plt
 
 from mintpy.objects import ifgramStack
 from mintpy.utils import network as pnet, plot as pp, ptime, utils as ut
-
+os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 ###########################  Sub Function  #############################
 def reset_network(stackFile):


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**modify code in order to prevent being locked while reading hdf5 file**

I faced the following error while modifying network “OSError: Unable to open file ”. The solution which worked for me was preventing hdf5 file being locked by command which was added to script

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.