### PR TITLE
bugfix for block-by-block resample & run/skip in load_data

### DIFF
--- a/mintpy/geocode.py
+++ b/mintpy/geocode.py
@@ -99,7 +99,8 @@ def run_geocode(inps):
                 dest_box = res_obj.dest_box_list[i]
 
                 # read
-                print('-'*50+'\nreading {d:<{w}} in block {b} from {f} ...'.format(
+                print('-'*50 + f'{i+1}/{res_obj.num_box}')
+                print('reading {d:<{w}} in block {b} from {f} ...'.format(
                     d=dsName, w=maxDigit, b=src_box, f=os.path.basename(infile)))
 
                 data = readfile.read(infile,

--- a/mintpy/load_data.py
+++ b/mintpy/load_data.py
@@ -575,7 +575,7 @@ def run_or_skip(outFile, inObj, box, updateMode=True, xstep=1, ystep=1, geom_obj
             out_dset_list = outObj.datasetNames
             out_date12_list = outObj.date12List
 
-            if (out_size == in_size
+            if (out_size[1:] == in_size[1:]
                     and set(in_dset_list).issubset(set(out_dset_list))
                     and set(in_date12_list).issubset(set(out_date12_list))):
                 print('All date12   exists in file {} with same size as required,'

--- a/mintpy/objects/resample.py
+++ b/mintpy/objects/resample.py
@@ -404,8 +404,8 @@ class resample:
                                               lon0:lon1:lon_num*1j]
 
                 # src_box
-                src_area = (src_lat1 - src_lat0) * (src_lon1 - src_lon0)
-                dest_area = (lat1 - lat0) * (lon1 - lon0)
+                src_area = abs(src_lat1 - src_lat0) * abs(src_lon1 - src_lon0)
+                dest_area = abs(lat1 - lat0) * abs(lon1 - lon0)
                 if dest_area < src_area * 0.5:
                     # reduction of swath data
                     # https://pyresample.readthedocs.io/en/latest/data_reduce.html

--- a/mintpy/smallbaselineApp.py
+++ b/mintpy/smallbaselineApp.py
@@ -941,6 +941,7 @@ class TimeSeriesAnalysis:
 
         # use relative path for shorter and cleaner printout view command
         stack_file  = os.path.relpath(stack_file)  if stack_file  else stack_file
+        ion_file    = os.path.relpath(ion_file)    if ion_file    else ion_file
         geom_file   = os.path.relpath(geom_file)   if geom_file   else geom_file
         lookup_file = os.path.relpath(lookup_file) if lookup_file else lookup_file
         mask_file   = os.path.relpath(mask_file)   if mask_file   else mask_file


### PR DESCRIPTION
**Description of proposed changes**

+ objects.resample.prepare_geometry_definition_radar(): use abs() to ensure positive area calculation for both source/destination, before the adaptive source bbox calculation for block-by-block processing.

+ load_data.run_or_skip: check length/width only for ifgramStack to be able to skip re-loading if the existing ifgramStack file has more pairs than the input.

+ smallbaselineApp --plot: use relpath() for ionStack.h5 file

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1617/workflows/489c959d-bbb8-4465-a22c-6c513d8c7207/jobs/1620) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.