### PR TITLE
dem_error: set `cond=1e-8` to fix abnormal fit residual + add unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,10 @@ jobs:
           name: Unit Testing
           command: |
             export PATH=${CONDA_PREFIX}/bin:${PATH}
-            ${MINTPY_HOME}/tests/asc_desc2horz_vert.py
-            ${MINTPY_HOME}/tests/objects/ionex.py
             ${MINTPY_HOME}/tests/objects/euler_pole.py
+            ${MINTPY_HOME}/tests/objects/ionex.py
+            ${MINTPY_HOME}/tests/asc_desc2horz_vert.py
+            ${MINTPY_HOME}/tests/dem_error.py
 
       - run:
           name: Workflow Testing 1/4 - FernandinaSenDT128 (ISCE/topsStack)

--- a/mintpy/cli/ifgram_inversion.py
+++ b/mintpy/cli/ifgram_inversion.py
@@ -175,7 +175,7 @@ def cmd_line_parse(iargs=None):
     if not inps.outfile:
         if inps.obsDatasetName.startswith('unwrapPhase'):
             if os.path.basename(inps.ifgramStackFile).startswith('ion'):
-                inps.outfile = ['timeseriesIon.h5', 'temporalCoherenceIon.h5', 'numInvIfgramIon.h5']
+                inps.outfile = ['ion.h5', 'temporalCoherenceIon.h5', 'numInvIon.h5']
             else:
                 inps.outfile = ['timeseries.h5', 'temporalCoherence.h5', 'numInvIfgram.h5']
 

--- a/mintpy/dem_error.py
+++ b/mintpy/dem_error.py
@@ -247,8 +247,8 @@ def estimate_dem_error(ts0, G0, tbase, date_flag=None, phase_velocity=False,
     if phase_velocity:
         # adjust from phase to phase velocity
         tbase_diff = np.diff(tbase[date_flag], axis=0).reshape(-1,1)
-        ts_diff = np.diff(ts, axis=0) / np.repeat(tbase_diff, ts.shape[1], axis=1)
-        G_diff = np.diff(G, axis=0) / np.repeat(tbase_diff, G.shape[1], axis=1)
+        ts = np.diff(ts, axis=0) / np.repeat(tbase_diff, ts.shape[1], axis=1)
+        G = np.diff(G, axis=0) / np.repeat(tbase_diff, G.shape[1], axis=1)
 
     # Inverse using L-2 norm to get unknown parameters X
     # X = [delta_z, constC, vel, acc, deltaAcc, ..., step1, step2, ...]
@@ -264,7 +264,7 @@ def estimate_dem_error(ts0, G0, tbase, date_flag=None, phase_velocity=False,
     # for debug
     if debug_mode or display:
         from matplotlib import pyplot as plt
-        fig, axs = plt.subplots(nrows=4, ncols=1, figsize=(8, 8), sharex=True, sharey=sharey)
+        _, axs = plt.subplots(nrows=4, ncols=1, figsize=(8, 8), sharex=True, sharey=sharey)
         titles = ['Original TS', 'Corrected TS', 'Fitting residual', 'Fitted defo model']
         for ax, data, title in zip(axs, [ts0, ts_cor, ts_res, ts_cor - ts_res], titles):
             ax.plot(data, '.')

--- a/tests/dem_error.py
+++ b/tests/dem_error.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# Author: Zhang Yunjun, Nov 2022
+"""Test topographic residuel correction due to DEM errors."""
+
+
+import argparse
+import datetime
+import math
+import sys
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from mintpy.dem_error import estimate_dem_error
+from mintpy.utils import ptime, time_func
+
+################################################################################
+# truth
+delta_z_sim = 50   # meters
+
+# setting: SAR geometry
+range_dist = 800e3  # meters
+inc_angle = 34      # degree
+max_pbase = 500     # meters
+
+# setting: time / acquisition
+revisit_time = datetime.timedelta(days=24)
+start_date = datetime.datetime(2018, 1, 1)
+num_date = 50
+ref_ind = 10
+
+
+################################################################################
+EXAMPLE = """example:
+  $MINTPY_HOME/tests/dem_error.py
+  $MINTPY_HOME/tests/dem_error.py --plot
+"""
+
+def cmd_line_parse(iargs=None):
+    # create parser
+    parser = argparse.ArgumentParser(description='Test dem_error.py',
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     epilog=EXAMPLE)
+    parser.add_argument('--plot', dest='plot', action='store_true', help='Plot testing results.')
+
+    # parsing
+    inps = parser.parse_args(args=iargs)
+
+    return inps
+
+
+################################################################################
+def sim_pbase_and_topo_residual(num_date, delta_z, ref_ind=0,
+                                max_pbase=500, inc_angle=34, range_dist=800e3):
+
+    # sim perp baseline TS
+    np.random.seed(12138)
+    pbase = np.random.rand(num_date) * max_pbase
+    pbase -= pbase[ref_ind]
+
+    # sim topo residual phase
+    G_geom = pbase / (range_dist * np.sin(np.deg2rad(inc_angle)))
+    ts_topo_res = np.dot(G_geom, delta_z_sim)
+
+    return pbase, ts_topo_res
+
+
+def plot_result(date_list, ts_sim, ts_obs=None, ts_cor=None, model=None):
+
+    dt_list = ptime.date_list2vector(date_list)[0]
+
+    fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(12, 4))
+    ax.plot(dt_list, ts_sim*100, '--', color='C0', lw=3, label='simulation')
+    if ts_obs is not None:
+        ax.plot(dt_list, ts_obs*100, '.', color='C1', lw=3, label='observation')
+    if ts_cor is not None:
+        ax.plot(dt_list, ts_cor*100, 'o',  color='C2', ms=12, fillstyle='none', label='corrected')
+
+    # plot step function
+    if model is not None and 'stepDate' in model.keys():
+        for step_date in model['stepDate']:
+            step_dt = datetime.datetime.strptime(step_date, '%Y%m%d')
+            ax.axvline(step_dt, ls='--', color='k')
+
+    # axis format
+    ax.set_xlabel('Time')
+    ax.set_ylabel('Displacement [cm]')
+    ax.legend()
+    plt.show()
+
+
+################################################################################
+def test_dem_error_with_linear_defo(date_list, tbase, rel_tol=0.01, plot=False):
+    print('Test 1: simple time-series with linear displacement.')
+
+    # setting
+    vel_sim = 0.05  # m/yr
+    model = {'polynomial' : 1}
+
+    # simulate displacement time-series
+    ts_sim = vel_sim * tbase
+    ts_sim -= ts_sim[ref_ind]
+
+    # add topo residual
+    pbase, ts_topo_res = sim_pbase_and_topo_residual(
+        num_date,
+        delta_z_sim,
+        ref_ind,
+        max_pbase=max_pbase,
+        inc_angle=inc_angle,
+        range_dist=range_dist,
+    )
+
+    # observed time-series: displacement + topo res
+    ts_obs = ts_sim + ts_topo_res
+
+    # estimate DEM error
+    G_defo = time_func.get_design_matrix4time_func(date_list, model)
+    G_geom = np.reshape(pbase / (range_dist * np.sin(np.deg2rad(inc_angle))), (-1,1))
+    G = np.hstack((G_geom, G_defo))
+
+    delta_z_est, ts_cor, ts_res = estimate_dem_error(ts_obs, G, tbase, phase_velocity=True)
+
+    # plot
+    if plot:
+        plot_result(date_list, ts_sim, ts_obs, ts_cor, model)
+
+    # validate
+    print(f'Specified DEM error: {delta_z_sim:.2f} m')
+    print(f'Estimated DEM error: {delta_z_est[0]:.2f} m')
+    assert math.isclose(delta_z_sim, delta_z_est, rel_tol=rel_tol)
+    print('Pass.')
+
+
+def test_dem_error_with_complex_defo(date_list, tbase, rel_tol=0.05, plot=False):
+    print('Test 2: complex time-series with highly non-linear displacement.')
+
+    # setting
+    model = {'polynomial' : 2, 'stepDate' : ['20190818', '20200812']}
+
+    # simulate displacement time-series
+    # run the following to re-generate:
+    #   from mintpy.simulation import simulation as sim
+    #   ts_sim = sim.sim_variable_timeseries(50)
+    ts_sim = np.array([
+         0.        , -0.00049281, -0.00098563, -0.00147844, -0.00197125,
+        -0.00246407, -0.00295688, -0.00344969, -0.0039425 , -0.00443532,
+         0.06961907,  0.08992067,  0.10159181,  0.10972946,  0.11593095,
+         0.12090778,  0.12503949,  0.12855262,  0.1315933 ,  0.13426131,
+         0.13662781,  0.13874532,  0.14065379,  0.14238422,  0.14396119,
+         0.0826078 ,  0.08704312,  0.09147844,  0.09591376,  0.10034907,
+         0.1047844 ,  0.10921971,  0.11365503,  0.11809035,  0.12252566,
+         0.126961  ,  0.1313963 ,  0.13583162,  0.14026694,  0.14470226,
+        -0.01971253, -0.02020534, -0.02069815, -0.02119097, -0.02168378,
+        -0.02217659, -0.0226694 , -0.02316222, -0.02365503, -0.02414784,
+    ], dtype=np.float32)
+
+    # add topo residual
+    pbase, ts_topo_res = sim_pbase_and_topo_residual(
+        num_date,
+        delta_z_sim,
+        ref_ind,
+        max_pbase=max_pbase,
+        inc_angle=inc_angle,
+        range_dist=range_dist,
+    )
+
+    # observed time-series: displacement + topo res
+    ts_obs = ts_sim + ts_topo_res
+
+    # estimate DEM error
+    G_defo = time_func.get_design_matrix4time_func(date_list, model)
+    G_geom = np.reshape(pbase / (range_dist * np.sin(np.deg2rad(inc_angle))), (-1,1))
+    G = np.hstack((G_geom, G_defo))
+
+    delta_z_est, ts_cor, ts_res = estimate_dem_error(ts_obs, G, tbase, phase_velocity=False)
+
+    # plot
+    if plot:
+        plot_result(date_list, ts_sim, ts_obs, ts_cor, model)
+
+    # validate
+    print(f'Specified DEM error: {delta_z_sim:.2f} m')
+    print(f'Estimated DEM error: {delta_z_est[0]:.2f} m')
+    assert math.isclose(delta_z_sim, delta_z_est, rel_tol=rel_tol)
+    print('Pass.')
+
+
+################################################################################
+def main(iargs=None):
+
+    print('-'*50)
+    print(f'Testing {__file__}')
+    inps = cmd_line_parse(iargs)
+
+    # prepare common data: date_list, tbase
+    dt_list = [start_date + revisit_time * x for x in range(num_date)]
+    date_list = [x.strftime('%Y%m%d') for x in dt_list]
+
+    tbase = np.array(ptime.date_list2tbase(date_list)[0]) / 365.25   # years
+    tbase -= tbase[ref_ind]
+
+    # scenario 1 - simple linear deformation
+    test_dem_error_with_linear_defo(
+        date_list,
+        tbase,
+        rel_tol=0.01,
+        plot=inps.plot,
+    )
+
+    # scenario 2 - complex nonlinear deformation (with more relaxed tolerance: 5%)
+    test_dem_error_with_complex_defo(
+        date_list,
+        tbase,
+        rel_tol=0.05,
+        plot=inps.plot,
+    )
+
+
+################################################################################
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/tests/dem_error.py
+++ b/tests/dem_error.py
@@ -29,6 +29,10 @@ start_date = datetime.datetime(2018, 1, 1)
 num_date = 50
 ref_ind = 10
 
+# setting: dem_error.py
+phase_velocity = False
+cond = 1e-8
+
 
 ################################################################################
 EXAMPLE = """example:
@@ -69,7 +73,7 @@ def plot_result(date_list, ts_sim, ts_obs=None, ts_cor=None, model=None):
 
     dt_list = ptime.date_list2vector(date_list)[0]
 
-    fig, ax = plt.subplots(nrows=1, ncols=1, figsize=(12, 4))
+    _, ax = plt.subplots(nrows=1, ncols=1, figsize=(12, 4))
     ax.plot(dt_list, ts_sim*100, '--', color='C0', lw=3, label='simulation')
     if ts_obs is not None:
         ax.plot(dt_list, ts_obs*100, '.', color='C1', lw=3, label='observation')
@@ -90,7 +94,7 @@ def plot_result(date_list, ts_sim, ts_obs=None, ts_cor=None, model=None):
 
 
 ################################################################################
-def test_dem_error_with_linear_defo(date_list, tbase, rel_tol=0.01, plot=False):
+def test_dem_error_with_linear_defo(date_list, tbase, rel_tol=0.05, plot=False):
     print('Test 1: simple time-series with linear displacement.')
 
     # setting
@@ -119,7 +123,11 @@ def test_dem_error_with_linear_defo(date_list, tbase, rel_tol=0.01, plot=False):
     G_geom = np.reshape(pbase / (range_dist * np.sin(np.deg2rad(inc_angle))), (-1,1))
     G = np.hstack((G_geom, G_defo))
 
-    delta_z_est, ts_cor, ts_res = estimate_dem_error(ts_obs, G, tbase, phase_velocity=True)
+    delta_z_est, ts_cor = estimate_dem_error(
+        ts_obs, G, tbase,
+        phase_velocity=phase_velocity,
+        cond=cond,
+    )[:2]
 
     # plot
     if plot:
@@ -136,7 +144,8 @@ def test_dem_error_with_complex_defo(date_list, tbase, rel_tol=0.05, plot=False)
     print('Test 2: complex time-series with highly non-linear displacement.')
 
     # setting
-    model = {'polynomial' : 2, 'stepDate' : ['20190818', '20200812']}
+    #model = {'polynomial' : 2, 'stepDate' : ['20190818', '20200812']}
+    model = {'polynomial' : 2}
 
     # simulate displacement time-series
     # run the following to re-generate:
@@ -173,7 +182,11 @@ def test_dem_error_with_complex_defo(date_list, tbase, rel_tol=0.05, plot=False)
     G_geom = np.reshape(pbase / (range_dist * np.sin(np.deg2rad(inc_angle))), (-1,1))
     G = np.hstack((G_geom, G_defo))
 
-    delta_z_est, ts_cor, ts_res = estimate_dem_error(ts_obs, G, tbase, phase_velocity=False)
+    delta_z_est, ts_cor = estimate_dem_error(
+        ts_obs, G, tbase,
+        phase_velocity=phase_velocity,
+        cond=cond,
+    )[:2]
 
     # plot
     if plot:
@@ -204,15 +217,15 @@ def main(iargs=None):
     test_dem_error_with_linear_defo(
         date_list,
         tbase,
-        rel_tol=0.01,
+        rel_tol=0.05,
         plot=inps.plot,
     )
 
-    # scenario 2 - complex nonlinear deformation (with more relaxed tolerance: 5%)
+    # scenario 2 - complex nonlinear deformation (with more relaxed tolerance: 10%)
     test_dem_error_with_complex_defo(
         date_list,
         tbase,
-        rel_tol=0.05,
+        rel_tol=0.10,
         plot=inps.plot,
     )
 


### PR DESCRIPTION
**Description of proposed changes**

+ dem_error: fix abnormal residual TS with default phase velocity mode
   - estimate_dem_error(): switch cutoff value of the least squares solution from 1e-15 to 1e-8, to avoid abnormal high TS residual value, when the phase velocity mode is turned ON by default (#875). Tests (based on the new unit test) shows this change of cutoff value has no impact on the estimation result accuracy at all, which is in contrast to the brief conclusion in https://github.com/insarlab/MintPy/commit/e28c240280c18cc7f799e45dc555217515698de7.
   - set `debug_mode` as global variable to be test a specific pixel given Y/X easily.

+ add tests/dem_error.py, to test the DEM error estimation / correction in both scenarios (simple linear and complex non-linear) for one pixel.
   - add to circle CI testing

+ tropo_pyaps3: improved auto-skip/run checks
   - skip dload if ERA5.h5 already exists
   - skip re-applying correction if corrected displacement exists and is newer
   - print out msg adjustment

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.