### PR TITLE
smallbaselineApp/dem_error: roll back to "phase" minimization as default

### DIFF
--- a/mintpy/defaults/smallbaselineApp.cfg
+++ b/mintpy/defaults/smallbaselineApp.cfg
@@ -257,7 +257,7 @@ mintpy.deramp.maskFile = auto  #[filename / no], auto for maskTempCoh.h5, mask f
 ##                     no  - use the mean   geometry [fast]
 mintpy.topographicResidual                   = auto  #[yes / no], auto for yes
 mintpy.topographicResidual.polyOrder         = auto  #[1-inf], auto for 2, poly order of temporal deformation model
-mintpy.topographicResidual.phaseVelocity     = auto  #[yes / no], auto for yes - use phase velocity for minimization
+mintpy.topographicResidual.phaseVelocity     = auto  #[yes / no], auto for no - use phase velocity for minimization
 mintpy.topographicResidual.stepFuncDate      = auto  #[20080529,20190704T1733 / no], auto for no, date of step jump
 mintpy.topographicResidual.excludeDate       = auto  #[20070321 / txtFile / no], auto for exclude_date.txt
 mintpy.topographicResidual.pixelwiseGeometry = auto  #[yes / no], auto for yes, use pixel-wise geometry info

--- a/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -108,7 +108,7 @@ mintpy.deramp.maskFile   = maskTempCoh.h5
 ########## correct_topography
 mintpy.topographicResidual                    = yes
 mintpy.topographicResidual.polyOrder          = 2
-mintpy.topographicResidual.phaseVelocity      = yes
+mintpy.topographicResidual.phaseVelocity      = no
 mintpy.topographicResidual.stepFuncDate       = no
 mintpy.topographicResidual.excludeDate        = exclude_date.txt
 mintpy.topographicResidual.pixelwiseGeometry  = yes

--- a/mintpy/utils/time_func.py
+++ b/mintpy/utils/time_func.py
@@ -271,11 +271,13 @@ def get_design_matrix4time_func(date_list, model=None, ref_date=None, seconds=0)
 def get_design_matrix4polynomial_func(yr_diff, degree):
     """design matrix/function model of linear/polynomial velocity estimation
 
+    d = c0 + c1 * t + 1/2 * c2 * t^2 + 1/6 * c3 * t^3 + ...
+
     The k! denominator makes the estimated polynomial coefficient (c_k) physically meaningful:
-        k=0 makes c_0 the offset;
-        k=1 makes c_1 the velocity;
-        k=2 makes c_2 the acceleration;
-        k=3 makes c_3 the acceleration rate;
+        k=0 makes c0 the offset;
+        k=1 makes c1 the velocity;
+        k=2 makes c2 the acceleration;
+        k=3 makes c3 the acceleration rate;
 
     Parameters: yr_diff: time difference from ref_date in decimal years
                 degree : polynomial models: 0=offset, 1=linear, 2=quadratic, 3=cubic, etc.

--- a/tests/dem_error.py
+++ b/tests/dem_error.py
@@ -144,8 +144,7 @@ def test_dem_error_with_complex_defo(date_list, tbase, rel_tol=0.05, plot=False)
     print('Test 2: complex time-series with highly non-linear displacement.')
 
     # setting
-    #model = {'polynomial' : 2, 'stepDate' : ['20190818', '20200812']}
-    model = {'polynomial' : 2}
+    model = {'polynomial' : 2, 'stepDate' : ['20190818', '20200812']}
 
     # simulate displacement time-series
     # run the following to re-generate:


### PR DESCRIPTION
**Description of proposed changes**

+ mintpy/defaults/smallbaselineApp(_auto).cfg: roll back the default to `phase velocity` for topo resid, as discussed in #892.

+ tests/dem_error: use model with step functions, which has better est. accuracy for complex deformation

+ mintpy/utils/time_func/*design_matrix4poly*: more comments on the math form of the polynomial equations

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1686/workflows/55336732-83c0-4b04-80bc-3ee96b59a1d2/jobs/1690) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.