### PR TITLE
`dem_error` w/ phase velocity: rm all-zero column in design matrix

### DIFF
--- a/src/mintpy/dem_error.py
+++ b/src/mintpy/dem_error.py
@@ -249,6 +249,10 @@ def estimate_dem_error(ts0, G0, tbase, date_flag=None, phase_velocity=False,
         tbase_diff = np.diff(tbase[date_flag], axis=0).reshape(-1,1)
         ts = np.diff(ts, axis=0) / np.repeat(tbase_diff, ts.shape[1], axis=1)
         G = np.diff(G, axis=0) / np.repeat(tbase_diff, G.shape[1], axis=1)
+        # remove the all-zero column in G
+        G = np.hstack((G[:,:1], G[:,2:]))
+        # remove the all-one column in G0 because it is not estimated
+        G0 = np.hstack((G0[:,:1], G0[:,2:]))
 
     # Inverse using L-2 norm to get unknown parameters X
     # X = [delta_z, constC, vel, acc, deltaAcc, ..., step1, step2, ...]

--- a/src/mintpy/dem_error.py
+++ b/src/mintpy/dem_error.py
@@ -249,9 +249,11 @@ def estimate_dem_error(ts0, G0, tbase, date_flag=None, phase_velocity=False,
         tbase_diff = np.diff(tbase[date_flag], axis=0).reshape(-1,1)
         ts = np.diff(ts, axis=0) / np.repeat(tbase_diff, ts.shape[1], axis=1)
         G = np.diff(G, axis=0) / np.repeat(tbase_diff, G.shape[1], axis=1)
-        # remove the all-zero column in G
+        # remove the all-zero column in G and all-one column in G0
+        # as the unknown constant term of the polynomial func is not estimated,
+        # resulting in a larger time-series residual ts_res, thus, not suitable
+        # for RMS based noise evaluation with timeseries_rms.py
         G = np.hstack((G[:,:1], G[:,2:]))
-        # remove the all-one column in G0 because it is not estimated
         G0 = np.hstack((G0[:,:1], G0[:,2:]))
 
     # Inverse using L-2 norm to get unknown parameters X


### PR DESCRIPTION
**Description of proposed changes**

+ `dem_error.py --phase-velocity`: remove the all-zero column in the design matrix `G` and the all-one column in the design matrix `G0`, as suggested by @mirzaees in #892. This is because the constant intercept term of the polynomial is not estimated in the phase velocity minimization scenario. Including this all-zero column in `G` could sometimes introduce abnormally large eigenvalues in the least-squares inversion, resulting in an unrealistic TS residual.

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.