### PR TITLE
copy dataset units in `geocode.py`

### DIFF
--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -871,6 +871,33 @@ def sort_dataset_list4velocity(ds_list_in):
     return ds_list
 
 
+def get_hdf5_dataset_attrs(fname, key='UNIT'):
+    """Get the top-level dataset attribute for the given HDF5 file.
+
+    Parameters: fname - str, path to the HDF5 file
+    Returns:    attrs - dict, key/value of all top-level datasets
+    """
+
+    fext = os.path.splitext(fname)[1]
+    if fext not in ['.h5', '.he5']:
+        raise ValueError(f'input file ({fname}) does not end with .h5/he5!')
+
+    # default output: empty
+    attrs = {}
+
+    # grab attrs from input file for the given key
+    with h5py.File(fname) as f:
+        # get top-level dataset names
+        ds_names = [x for x in f.keys() if isinstance(f[x], h5py.Dataset)]
+
+        # extract given attribute to the output dict
+        for ds_name in ds_names:
+            if key in f[ds_name].attrs.keys():
+                attrs[ds_name] = f[ds_name].attrs[key]
+
+    return attrs
+
+
 def get_hdf5_compression(fname):
     """Get the compression type of input HDF5 file"""
     ext = os.path.splitext(fname)[1].lower()

--- a/src/mintpy/utils/writefile.py
+++ b/src/mintpy/utils/writefile.py
@@ -27,7 +27,7 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None,
                 metadata     - dict of attributes
                 ref_file     - str, reference file to get auxliary info
                 compression  - str, compression while writing to HDF5 file, None, "lzf", "gzip"
-                ds_unit_dict - dict, dataset unit definition
+                ds_unit_dict - dict, top-level dataset unit definition
                     {dname : dunit,
                      dname : dunit,
                      ...
@@ -141,7 +141,7 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None,
             # write attributes in dataset level
             if ds_unit_dict is not None:
                 for key, value in ds_unit_dict.items():
-                    if value is not None:
+                    if key in f.keys() and value is not None:
                         f[key].attrs['UNIT'] = value
                         vprint(f'add /{key:<{maxDigit}} attribute: UNIT = {value}')
 
@@ -236,7 +236,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ds_unit_dict=None, ref_
                                 ...
                                }
                 metadata     - dict, metadata
-                ds_unit_dict - dict, dataset unit definition
+                ds_unit_dict - dict, top-level dataset unit definition
                                {dname : dunit,
                                 dname : dunit,
                                 ...
@@ -376,7 +376,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ds_unit_dict=None, ref_
         # write attributes in dataset level
         if ds_unit_dict is not None:
             for key, value in ds_unit_dict.items():
-                if value is not None:
+                if key in f.keys() and value is not None:
                     f[key].attrs['UNIT'] = value
                     vprint(f'add /{key:<{max_digit}} attribute: UNIT = {value}')
 


### PR DESCRIPTION
**Description of proposed changes**

+ utils.readfile: add `get_hdf5_dataset_attrs()` to extract a given attribute from all top-level datasets of the input HDF5 file.

+ geocode.py: copy over the dataset unit from input file to output file, e.g. for the velocity.h5 file, as requested by @EJFielding in #683.
   - call readfile.get_hdf5_dataset_attrs()
   - pass to writefile.layout_hdf5(ds_unit_dict)

**Reminders**

- [x] Fix #683
- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1734/workflows/d0265d4c-6174-4484-b5f8-b1903f91b9d3/jobs/1738) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.