### PR TITLE
mv `constants` from `mintpy.objects` to `mintpy` level

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@
 **Reminders**
 
 - [ ] Fix #xxxx
-- [ ] Pass Codacy code review (green)
 - [ ] Pass Pre-commit check (green)
+- [ ] Pass Codacy code review (green)
 - [ ] Pass Circle CI test (green)
 - [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
 - [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -3,13 +3,13 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
 ```
 /mintpy
 ------------------ level 0 --------------------
+    constants
     /defaults
         auto_path
         template
     /objects
         cluster
         colors
-        constants
         euler_pole
         giant
         ramp
@@ -62,7 +62,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
     /utils
         plot          (objects/{stack, coord, colors}, utils/{ptime, utils0, readfile, network, map})
         utils         (objects/{stack, coord, resample}, utils/{ptime, attribute, utils1, readfile})
-        isce_utils    (objects/{constants}, utils/{ptime, readfile, writefile, attribute, utils1})
+        isce_utils    (constants, utils/{ptime, readfile, writefile, attribute, utils1})
 ------------------ level 6 --------------------
     /objects
         insar_vs_gps  (objects/{stack, giant}, utils/{readfile, gps, plot, utils})

--- a/src/mintpy/constants.py
+++ b/src/mintpy/constants.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
 ############################################################
 # Program is part of MintPy                                #
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
 # Author: Zhang Yunjun, Feb 2022                           #
 ############################################################
 # Recommend usage:
-#   from mintpy.objects.constants import SPEED_OF_LIGHT
+#   from mintpy.constants import SPEED_OF_LIGHT
 
 
 SPEED_OF_LIGHT = 299792458  # meters per second

--- a/src/mintpy/iono_tec.py
+++ b/src/mintpy/iono_tec.py
@@ -13,8 +13,8 @@ import h5py
 import numpy as np
 
 import mintpy
+from mintpy.constants import SPEED_OF_LIGHT
 from mintpy.objects import ionex, timeseries
-from mintpy.objects.constants import SPEED_OF_LIGHT
 from mintpy.simulation import iono
 from mintpy.utils import ptime, readfile, utils as ut, writefile
 

--- a/src/mintpy/objects/euler_pole.py
+++ b/src/mintpy/objects/euler_pole.py
@@ -21,7 +21,7 @@
 import numpy as np
 import pyproj
 
-from mintpy.objects.constants import EARTH_RADIUS
+from mintpy.constants import EARTH_RADIUS
 
 # global variables
 MAS2RAD = np.pi / 3600000 / 180    # 1 mas (milli arc second) = x radian

--- a/src/mintpy/prep_hyp3.py
+++ b/src/mintpy/prep_hyp3.py
@@ -8,8 +8,8 @@
 import datetime as dt
 import os
 
+from mintpy.constants import SPEED_OF_LIGHT
 from mintpy.objects import sensor
-from mintpy.objects.constants import SPEED_OF_LIGHT
 from mintpy.utils import readfile, utils1 as ut, writefile
 
 

--- a/src/mintpy/utils/isce_utils.py
+++ b/src/mintpy/utils/isce_utils.py
@@ -26,8 +26,8 @@ import time
 import numpy as np
 from scipy import ndimage
 
+from mintpy.constants import EARTH_RADIUS, SPEED_OF_LIGHT
 from mintpy.objects import sensor
-from mintpy.objects.constants import EARTH_RADIUS, SPEED_OF_LIGHT
 from mintpy.utils import (
     attribute as attr,
     ptime,


### PR DESCRIPTION
**Description of proposed changes**

+ move the `constants` from the `objects` directory to the root directory, to simplify its usage.

+ update all existing usage of `mintpy.constants` sub-module

**Reminders**

- [x] Pass Codacy code review (green)
- [x] Pass Pre-commit check (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1743/workflows/816bf793-112c-495b-868f-5d991a0bf10c/jobs/1747) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.