### PR TITLE
deps: drop `defusedxml`

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - cvxopt
   - dask>=1.0
   - dask-jobqueue>=0.3
-  - defusedxml
   - gdal>=3      # for ISCE, ARIA, FRInGE, HyP3, GMTSAR users
   - h5py
   - joblib

--- a/docs/ports.txt
+++ b/docs/ports.txt
@@ -72,7 +72,6 @@ py37-cartopy
 py37-cvxopt +accelerate +dsdp +fftw +glpk +gsl
 py37-cython
 py37-dask
-py37-defusedxml
 py37-distributed
 py37-gdbm
 py37-h5py

--- a/docs/requirements4rtd.txt
+++ b/docs/requirements4rtd.txt
@@ -1,5 +1,4 @@
 # requirements file to build Read the Docs ONLY
-defusedxml
 h5py
 lxml
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ cartopy
 cvxopt
 dask>=1.0
 dask-jobqueue>=0.3
-defusedxml
 # gdal>=3     # for ISCE, ARIA, FRInGE, HyP3, GMTSAR users
 h5py
 joblib

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
     entry_points={
         'console_scripts': [
             'mintpy = mintpy.__main__:main',
-            'add_attribute.py = mintpy.add_attribute:main',
             'add.py = mintpy.cli.add:main',
             'asc_desc2horz_vert.py = mintpy.cli.asc_desc2horz_vert:main',
             'closure_phase_bias.py = mintpy.cli.closure_phase_bias:main',

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         "cvxopt",
         "dask>=1.0",
         "dask-jobqueue>=0.3",
-        "defusedxml",
         "h5py",
         "joblib",
         "lxml",

--- a/src/mintpy/__main__.py
+++ b/src/mintpy/__main__.py
@@ -561,7 +561,6 @@ def get_parser():
     get_unwrap_error_phase_closure_parser(sp)
 
     # misc
-    # get_add_attribute_parser(sp)
     get_dem_gsi_parser(sp)
     get_generate_mask_parser(sp)
     try:

--- a/src/mintpy/cli/closure_phase_bias.py
+++ b/src/mintpy/cli/closure_phase_bias.py
@@ -20,6 +20,8 @@ REFERENCE = """reference:
 
 EXAMPLE = """example:
   # Note: ONLY sequential network is supported in this implementation.
+  # Notebook tutorial:
+  #   https://nbviewer.org/github/insarlab/MintPy-tutorial/blob/main/applications/closure_phase_bias.ipynb
 
   # create mask for areas suseptible to biases
   closure_phase_bias.py -i inputs/ifgramStack.h5 --nl 5  -a mask

--- a/src/mintpy/objects/ionex.py
+++ b/src/mintpy/objects/ionex.py
@@ -78,7 +78,7 @@ def dload_ionex(date_str, tec_dir, sol_code='jpl', date_fmt='%Y%m%d', print_msg=
 
 #################################### Read ######################################
 
-def get_ionex_value(tec_file, utc_sec, lat, lon, interp_method='linear3d', rotate_tec_map=False,
+def get_ionex_value(tec_file, utc_sec, lat, lon, interp_method='linear3d', rotate_tec_map=True,
                     print_msg=True):
     """Get the TEC value from input IONEX file for the input lat/lon/datetime.
 

--- a/src/mintpy/prep_fringe.py
+++ b/src/mintpy/prep_fringe.py
@@ -7,8 +7,8 @@
 
 import glob
 import os
+import xml.etree.ElementTree as ET
 
-import defusedxml.ElementTree as ET
 import h5py
 import numpy as np
 

--- a/src/mintpy/simulation/iono.py
+++ b/src/mintpy/simulation/iono.py
@@ -58,7 +58,6 @@ def vtec2range_delay(vtec, inc_angle, freq, obs_type='phase'):
 
     # convert to TEC in LOS based on equation (3) in Chen and Zebker (2012)
     ref_angle = iono_incidence2refraction_angle(inc_angle, vtec, freq)
-    #print('refraction angle on the ionosphere min/max: {:.1f}/{:.1f} deg'.format(np.nanmin(ref_angle), np.nanmax(ref_angle)))
     tec = vtec / np.cos(ref_angle * np.pi / 180.0)
 
     # calculate range delay based on equation (1) in Chen and Zebker (2012)

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -13,8 +13,8 @@ import os
 import re
 import sys
 import warnings
+import xml.etree.ElementTree as ET
 
-import defusedxml.ElementTree as ET
 import h5py
 import numpy as np
 


### PR DESCRIPTION
**Description of proposed changes**

+ dependencies: revert #340 back the ElementTree usage from `defusedxml` to the native `xml.etree` module, to drop this extra dependency, because there are only two use cases in the code: parse known XML files from ISCE and SNAP.

+ delete `add_attribute` from `setup.py` and `__main__.py`, which was missed in #906

+ `objects.ionex.get_ionex_value()`: turn ON `rotate_tec_map` by default

+ `cli.closure_phase_bias`: add a link to the notebook (https://github.com/insarlab/MintPy-tutorial/pull/40) in the example usage.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1765/workflows/5809325b-d109-473c-96cd-2024c79b53d8/jobs/1768) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.