### PR TITLE
closure_phase_bias: use `wrapPhase` if available

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,8 +82,9 @@ conda install -c conda-forge --file ~/tools/MintPy/requirements.txt
 
 ```bash
 conda env create -f ~/tools/MintPy/docs/environment.yml
-# run "mamba install isce2" if you use ISCE-2
 conda activate mintpy
+
+# run "mamba install isce2" if you use ISCE-2
 ```
 </details>
 

--- a/src/mintpy/closure_phase_bias.py
+++ b/src/mintpy/closure_phase_bias.py
@@ -349,6 +349,8 @@ def compute_unwrap_closure_phase(stack_file, conn, num_worker=1, outdir='./', ma
     ## calc the cumulativev unwrapped closure phase time-series
     print('-'*60)
     print('step 3/3: calculate the unwrapped cumulative sequential closure phase time-series ...')
+    print('step 3/3: Note that you need a specified referece point in the ifgramStack.h5 to continue. ')
+    print('step 3/3: A good reference point should be a pixel that has good temporal coherence and no bias')
     cum_seq_unw_closure_phase_timeseries(conn, conn_dir, date_list, meta)
 
     return

--- a/src/mintpy/closure_phase_bias.py
+++ b/src/mintpy/closure_phase_bias.py
@@ -349,8 +349,8 @@ def compute_unwrap_closure_phase(stack_file, conn, num_worker=1, outdir='./', ma
     ## calc the cumulativev unwrapped closure phase time-series
     print('-'*60)
     print('step 3/3: calculate the unwrapped cumulative sequential closure phase time-series ...')
-    print('step 3/3: Note that you need a specified referece point in the ifgramStack.h5 to continue. ')
-    print('step 3/3: A good reference point should be a pixel that has good temporal coherence and no bias')
+    print('  Note that a referece point in the ifgramStack.h5 (as attributes "REF_Y/X") is needed to continue. ')
+    print('  A good reference point should be a pixel that has good temporal coherence and no bias.')
     cum_seq_unw_closure_phase_timeseries(conn, conn_dir, date_list, meta)
 
     return

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1169,7 +1169,7 @@ class ifgramStack:
             phase = self.read(datasetName='wrapPhase',box=box, print_msg=False)
 
         else:
-            phase = self.read(datasetName='unwrapPhase',box=box, print_msg=False)
+            phase = self.read(box=box, print_msg=False)
 
         ## calculate the 3D complex seq closure phase
         cp_w = np.zeros((num_cp, np.shape(phase)[1], np.shape(phase)[2]), dtype=np.complex64)
@@ -1177,9 +1177,9 @@ class ifgramStack:
 
             # calculate closure phase
             idx_plus, idx_minor = cp_idx[i, :-1], cp_idx[i, -1]
-            phasecpx = np.exp(1j*phase)
-            cp_w[i] = np.prod(phasecpx[idx_plus], axis=0) * np.conj(phasecpx[idx_minor])
-
+            cp0_w[i] = np.sum(phase[idx_plus], axis=0) - phase[idx_minor]
+            # get the wrapped closure phase
+            cp_w[i] = np.exp(1j * cp0_w)
 
         ## post-processing
         if not post_proc:

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1164,6 +1164,10 @@ class ifgramStack:
                 raise Exception(f"No triplets found at connection level: {conn}!")
 
         ## read data
+        # Removed the lines where a reference pixel is read. 
+        # Since no moisture change should have a naturally zero closure phase,
+        # choosing a reference point in the wrong place can lead to misinterpretations.
+        # Tests in both Central Valley and Bristol Dry lakes proved spatial referencing is not needed.
         if 'wrapPhase' in self.datasetNames:
             print('Using wrapped phase to compute closure phases')
             phase = self.read(datasetName='wrapPhase',box=box, print_msg=False)

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1164,25 +1164,23 @@ class ifgramStack:
                 raise Exception(f"No triplets found at connection level: {conn}!")
 
         ## read data
-        # Removed the lines where a reference pixel is read. 
-        # Since no moisture change should have a naturally zero closure phase,
-        # choosing a reference point in the wrong place can lead to misinterpretations.
-        # Tests in both Central Valley and Bristol Dry lakes proved spatial referencing is not needed.
-        if 'wrapPhase' in self.datasetNames:
-            print('Using wrapped phase to compute closure phases')
-            phase = self.read(datasetName='wrapPhase',box=box, print_msg=False)
-
-        else:
-            phase = self.read(box=box, print_msg=False)
+        # Note by Yujie Zheng on Dec 2, 2022: I removed the lines for spatial referencing,
+        # because no moisture change should have a naturally zero closure phase. On the other
+        # hand, choosing a reference point in the wrong place can lead to misinterpretations.
+        # Tests in both Central Valley and Bristol Dry lakes confirms this.
+        ds_name = 'wrapPhase' if 'wrapPhase' in self.datasetNames else 'unwrapPhase'
+        print(f'reading {ds_name} to compute closure phases')
+        phase = self.read(datasetName=ds_name, box=box, print_msg=False)
 
         ## calculate the 3D complex seq closure phase
         cp_w = np.zeros((num_cp, box_len, box_wid), dtype=np.complex64)
         for i in range(num_cp):
 
-            # calculate closure phase
+            # calculate (un)wrapped closure phase
             idx_plus, idx_minor = cp_idx[i, :-1], cp_idx[i, -1]
             cp0_w = np.sum(phase[idx_plus], axis=0) - phase[idx_minor]
-            # get the wrapped closure phase
+
+            # re-wrapping to ensure the wrapped closure phase
             cp_w[i] = np.exp(1j * cp0_w)
 
         ## post-processing

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1172,7 +1172,7 @@ class ifgramStack:
             phase = self.read(box=box, print_msg=False)
 
         ## calculate the 3D complex seq closure phase
-        cp_w = np.zeros((num_cp, np.shape(phase)[1], np.shape(phase)[2]), dtype=np.complex64)
+        cp_w = np.zeros((num_cp, box_len, box_wid), dtype=np.complex64)
         for i in range(num_cp):
 
             # calculate closure phase

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1177,7 +1177,7 @@ class ifgramStack:
 
             # calculate closure phase
             idx_plus, idx_minor = cp_idx[i, :-1], cp_idx[i, -1]
-            cp0_w[i] = np.sum(phase[idx_plus], axis=0) - phase[idx_minor]
+            cp0_w = np.sum(phase[idx_plus], axis=0) - phase[idx_minor]
             # get the wrapped closure phase
             cp_w[i] = np.exp(1j * cp0_w)
 


### PR DESCRIPTION
Due to some issues with filtering implemented in ISCE2, I added the option of using wrapped phase (read from fine.int) to compute closure phase.
Now if there are wrapped phase in the ifgramStack.h5, wrapped phase will be used instead of the unwrapped phase.

+ docs/install: bugfix in #923 for the order of `conda activate mintpy` and `mamba install isce2`