### PR TITLE
docs/install: remove pip non-editable mode

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,6 +82,7 @@ conda install -c conda-forge --file ~/tools/MintPy/requirements.txt
 
 ```bash
 conda env create -f ~/tools/MintPy/docs/environment.yml
+# run "mamba install isce2" if you use ISCE-2
 conda activate mintpy
 ```
 </details>
@@ -89,27 +90,17 @@ conda activate mintpy
 #### c. Install MintPy ####
 
 <details open>
-<summary>Install MintPy with pip in development mode [recommended]:</summary>
+<summary>via pip [recommended]</summary>
 
-The development mode allows one to install the package without copying files to your interpreter directory (e.g. the `site-packages` directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
+We recommend installing mintpy in the "editable" mode. This mode installs the package without copying files to your interpreter directory (e.g. the `site-packages` directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
 
 ```bash
-cd ~/tools
-python -m pip install -e MintPy
+python -m pip install -e ~/tools/MintPy
 ```
 </details>
 
 <details>
-<summary>Or install MintPy with pip:</summary>
-
-```bash
-cd ~/tools
-python -m pip install MintPy
-```
-</details>
-
-<details>
-<summary>Or simply set up the environment variables:</summary>
+<summary>via environment variables setup</summary>
 
 Add below in your source file, e.g. `~/.bash_profile` for _bash_ users or `~/.cshrc` for _csh/tcsh_ users:
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1178,7 +1178,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
 
         # Read metadata file and FILE_TYPE
         metafile = metafiles[0]
-        meta_ext = os.path.splitext(metafile)[1]
+        meta_ext = os.path.splitext(metafile)[1].lower()
 
         # ignore certain meaningless file extensions
         while fext in ['.geo', '.rdr', '.full', '.wgs84', '.grd']:


### PR DESCRIPTION
**Description of proposed changes**

+ docs/installation.md: update based on feedbacks from @yjzhenglamarmota 
   - remove note for the regular `pip install` in non-editable mode, as this is not really useful for development version, because one needs to frequently git pull, and re-install to keep up with updates
   - add `mamba install isce2` note for `conda env create -f environment.yml` dependency installation

+ readfile.read_attribute: enforce lower case for metadata file extension for more robust detection against TIF file with upper case file extension.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1779/workflows/86a0eba9-4ed7-4cca-84a1-fc9e240d63db/jobs/1782) (green)