### PR TITLE
update numpy expired deprecations

### DIFF
--- a/src/mintpy/legacy/save_mat.py
+++ b/src/mintpy/legacy/save_mat.py
@@ -34,7 +34,7 @@ def usage():
 
 def yyyymmdd2years(date):
     d = dt.strptime(date, "%Y%m%d")
-    yy = np.float(d.year) + np.float(d.month-1)/12 + np.float(d.day-1)/365
+    yy = float(d.year) + float(d.month-1)/12 + float(d.day-1)/365
     return yy
 
 

--- a/src/mintpy/objects/gps.py
+++ b/src/mintpy/objects/gps.py
@@ -369,7 +369,7 @@ class GPS:
 
         data = np.loadtxt(self.file, dtype=bytes, skiprows=1).astype(str)
         ref_lon, ref_lat = float(data[0, 6]), 0.
-        e0, e_off, n0, n_off = data[0, 7:11].astype(np.float)
+        e0, e_off, n0, n_off = data[0, 7:11].astype(np.float32)
         e0 += e_off
         n0 += n_off
 

--- a/src/mintpy/objects/progress.py
+++ b/src/mintpy/objects/progress.py
@@ -104,14 +104,14 @@ class progressBar:
             suffix = ' '+suffix
 
         # Figure out the new percent done (round to an integer)
-        diffFromMin = np.float(self.amount - self.min)
-        percentDone = (diffFromMin / np.float(self.span)) * 100.0
-        percentDone = np.int(np.round(percentDone))
+        diffFromMin = float(self.amount - self.min)
+        percentDone = (diffFromMin / float(self.span)) * 100.0
+        percentDone = int(np.round(percentDone))
 
         # Figure out how many hash bars the percentage should be
         allFull = self.width - 2 - 18
         numHashes = (percentDone / 100.0) * allFull
-        numHashes = np.int(np.round(numHashes))
+        numHashes = int(np.round(numHashes))
 
         # Build a progress bar with an arrow of equal signs; special cases for empty and full
         if numHashes == 0:

--- a/src/mintpy/utils/map.py
+++ b/src/mintpy/utils/map.py
@@ -84,7 +84,7 @@ def auto_lalo_sequence(geo_box, lalo_step=None, lalo_max_num=4, step_candidate=[
         lalo_step = round_to_1(max_lalo_dist / lalo_max_num)
 
         # reduce decimal if it ends with 8/9
-        digit = np.int(np.floor(np.log10(lalo_step)))
+        digit = int(np.floor(np.log10(lalo_step)))
         if str(lalo_step)[-1] in ['8','9']:
             digit += 1
             lalo_step = round(lalo_step, digit)
@@ -94,7 +94,7 @@ def auto_lalo_sequence(geo_box, lalo_step=None, lalo_max_num=4, step_candidate=[
         distance = [(i - max_lalo_dist / lalo_max_num) ** 2 for i in lalo_step_candidate]
         lalo_step = lalo_step_candidate[distance.index(min(distance))]
 
-    digit = np.int(np.floor(np.log10(lalo_step)))
+    digit = int(np.floor(np.log10(lalo_step)))
 
     # Auto tick sequence
     lat_major = np.ceil( geo_box[3] / 10**(digit+1) ) * 10**(digit+1)


### PR DESCRIPTION
**Description of proposed changes**

+ update the expired `np.float` and `np.int` (https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations) usage throughout the repo.

**Reminders**

- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1801/workflows/143023d7-3c50-4266-aef4-51671e24fffd/jobs/1805) (green)