### PR TITLE
docs/installation: switch link syntax from markdown to html

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"                           # location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+    # ignore patch updates for all dependencies
+    - dependency-name: "*"
+      update-typs: ["version-update:semver-patch"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,9 +1,9 @@
 ## 1. Install the released version ##
 
 <details open>
-<summary>via conda</summary>
+<p><summary>via conda</summary></p>
 
-MintPy is available on the <a href="https://anaconda.org/conda-forge/mintpy">conda-forge</a> channel. The latest released version can be installed via `conda` as:
+MintPy is available on the <a href="https://anaconda.org/conda-forge/mintpy">conda-forge</a> channel. The latest released version can be installed via <code>conda</code> as:
 
 ```bash
 conda install -c conda-forge mintpy
@@ -11,7 +11,7 @@ conda install -c conda-forge mintpy
 </details>
 
 <details>
-<summary>via docker</summary>
+<p><summary>via docker</summary></p>
 
 Docker allows one to run MintPy in a dedicated container, which is essentially an efficient virtual machine, and to be independent of platform OS. First, install <a href="https://docs.docker.com/install">docker</a> if you have not already done so. Then run the following to pull the latest stable released constainer image version from <a href="https://github.com/insarlab/MintPy/pkgs/container/mintpy">MintPy GitHub Container Registry</a> to your local machine:
 
@@ -23,7 +23,7 @@ Check <a href="./docker.md">docker.md</a> for more details on Docker container i
 </details>
 
 <details>
-<summary>via apt (Linux Debian)</summary>
+<p><summary>via apt (Linux Debian)</summary></p>
 
 MintPy is available in the main archive of the <a href="https://tracker.debian.org/pkg/mintpy">Debian</a> GNU/Linux OS. It can be installed by using your favourite package manager or running the following command:
 
@@ -40,10 +40,12 @@ Note: The installation note below is tested on Linux and macOS, and is still exp
 
 MintPy is written in Python 3 and relies on several Python modules, check the <a href="https://github.com/insarlab/MintPy/blob/main/requirements.txt">requirements.txt</a> file for details. We recommend using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> or <a href="https://www.macports.org/install.php">macports</a> to install the python environment and the prerequisite packages, because of the convenient management and default performance setting with <a href="http://markus-beuckelmann.de/blog/boosting-numpy-blas.html">numpy/scipy</a> and <a href="https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree">pyresample</a>.
 
-<details>
-<summary><h3>2.1 Install on Linux</h3></summary>
+### 2.1 Install on Linux ###
 
-#### a. Download source code ####
+<details>
+<p><summary>Click to expand for more details</summary></p>
+
+<h4>a. Download source code</h4>
 
 Run the following in your terminal to download the development version of MintPy:
 
@@ -52,7 +54,7 @@ cd ~/tools
 git clone https://github.com/insarlab/MintPy.git
 ```
 
-#### b. Install dependencies via conda ####
+<h4>b. Install dependencies via conda</h4>
 
 Install <a href="https://docs.conda.io/en/latest/miniconda.html">miniconda</a> if you have not already done so. You may need to close and restart the shell for changes to take effect.
 
@@ -76,7 +78,7 @@ conda install -c conda-forge --file ~/tools/MintPy/requirements.txt
 ```
 
 <details>
-<summary>Or install the dependencies to a new environment named "mintpy" by running:</summary>
+<p><summary>Or install the dependencies to a new environment named "mintpy" by running:</summary></p>
 
 ```bash
 conda env create -f ~/tools/MintPy/docs/environment.yml
@@ -86,12 +88,12 @@ conda activate mintpy
 ```
 </details>
 
-#### c. Install MintPy ####
+<h4>c. Install MintPy</h4>
 
 <details open>
-<summary>via pip [recommended]</summary>
+<p><summary>via pip [recommended]</summary></p>
 
-We recommend installing mintpy in the "editable" mode. This mode installs the package without copying files to your interpreter directory (e.g. the `site-packages` directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
+We recommend installing mintpy in the "editable" mode. This mode installs the package without copying files to your interpreter directory (e.g. the <code>site-packages</code> directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
 
 ```bash
 python -m pip install -e ~/tools/MintPy
@@ -99,9 +101,9 @@ python -m pip install -e ~/tools/MintPy
 </details>
 
 <details>
-<summary>via environment variables setup</summary>
+<p><summary>via path setup</summary></p>
 
-Add below in your source file, e.g. `~/.bash_profile` for _bash_ users or `~/.cshrc` for _csh/tcsh_ users:
+Add below in your source file, e.g. <code>~/.bash_profile</code> for <em>bash</em> users or <code>~/.cshrc</code> for <em>csh/tcsh</em> users:
 
 ```bash
 if [ -z ${PYTHONPATH+x} ]; then export PYTHONPATH=""; fi
@@ -110,37 +112,36 @@ export PATH=${PATH}:${MINTPY_HOME}/src/mintpy/cli
 export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}/src
 ```
 </details>
-
 </details>
 
+### 2.2 Install on macOS ###
+
 <details>
-<summary><h3>2.2 Install on macOS</h3></summary>
+<p><summary>Click to expand for more details</summary></p>
 
 Install Xcode with command line tools, if you have not already done so.
 
-+ Install `Xcode` from App store
+<ul>
+<li>Install <code>Xcode</code> from App store</li>
 
-+ Install `command line tools` within XCode and agree to the terms of license.
+<li>Install <code>command line tools</code> within XCode and agree to the terms of license.</li>
 
   ```bash
   xcode-select --install -s /Applications/Xcode.app/Contents/Developer/
   sudo xcodebuild -license
   ```
 
-+ Install <a href="https://www.xquartz.org">XQuartz</a>, then restart the terminal.
+<li>Install <a href="https://www.xquartz.org">XQuartz</a>, then restart the terminal.</li>
+</ul>
 
-<details open>
-<summary>Install MintPy via conda</summary>
-
-Same as the <a href="#21-install-on-linux">instruction for Linux</a>.
-</details>
+Install MintPy via conda, which is the same as the <a href="#21-install-on-linux">instruction for Linux</a>.
 
 <details>
-<summary>Or install MintPy via MacPorts</summary>
+<p><summary>Or install MintPy via MacPorts</summary></p>
 
-Same as the instruction for Linux, except for the dependencies' installation, which is as below.
+Same as the instruction for Linux, except for the "b. Install dependencies" section, which is as below:
 
-Install <a href="https://www.macports.org/install.php">macports</a> if you have not done so. Add the following at the bottom of your `~/.bash_profile` file:
+Install <a href="https://www.macports.org/install.php">macports</a> if you have not done so. Add the following at the bottom of your <code>~/.bash_profile</code> file:
 
 ```bash
 # MacPorts Installer addition on 2017-09-02_at_01:27:12: adding an appropriate PATH variable for use with MacPorts.
@@ -173,10 +174,12 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 </details>
 </details>
 
-<details>
-<summary><h3>2.3 Install on Windows</h3></summary>
+### 2.3 Install on Windows ###
 
-Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for the "c. Install MintPy" section, only the `pip install` approaches are recommended, as the "setup environment variable" approach is not tested.
+<details>
+<p><summary>Click to expand for more details</summary></p>
+
+Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for the "c. Install MintPy" section, only the <code>pip install</code> approaches are recommended, as the <code>path setup</code> approach is not tested.
 </details>
 
 ## 3. Post-Installation Setup
@@ -185,11 +188,11 @@ Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for
 
 Set up an account for ERA5 to download weather re-analysis datasets for tropospheric delay correction as described in <a href="https://github.com/insarlab/pyaps#2-account-setup-for-era5">insarlab/PyAPS</a>.
 
-`WEATHER_DIR`: Optionally, if you defined an environment variable named `WEATHER_DIR` to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
+<code>WEATHER_DIR</code>: Optionally, if you defined an environment variable named <code>WEATHER_DIR</code> to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
 
 #### b. Dask for parallel processing ####
 
-We recommend setting the `temporary-directory` in your <a href="https://docs.dask.org/en/stable/configuration.html">Dask configuration file</a>, e.g. `~/.config/dask/dask.yaml`, by adding the following line, to avoid the potential <a href="https://github.com/insarlab/MintPy/issues/725">workspace lock issue</a>. Check the <a href="./dask.md">dask.md</a> file for more details on parallel processing.
+We recommend setting the <code>temporary-directory</code> in your <a href="https://docs.dask.org/en/stable/configuration.html">Dask configuration file</a>, e.g. <code>~/.config/dask/dask.yaml</code>, by adding the following line, to avoid the potential <a href="https://github.com/insarlab/MintPy/issues/725">workspace lock issue</a>. Check the <a href="./dask.md">dask.md</a> file for more details on parallel processing.
 
 ```yaml
 temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /local
@@ -200,7 +203,7 @@ temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /l
 
 #### c. Extra environment variables setup ####
 
-We recommend setting the following environment variables, e.g. in your `~/.bash_profile` file, to avoid occasional errors with GDAL VRT and HDF5 files I/O.
+We recommend setting the following environment variables, e.g. in your <code>~/.bash_profile</code> file, to avoid occasional errors with GDAL VRT and HDF5 files I/O.
 
 ```bash
 export VRT_SHARED_SOURCE=0             # do not share dataset while using GDAL VRT in a multi-threading environment

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,7 @@ Install the dependencies into a custom existing environment [recommended] by run
 conda install -c conda-forge --file ~/tools/MintPy/requirements.txt
 ```
 
+<p>
 <details>
 <p><summary>Or install the dependencies to a new environment named "mintpy" by running:</summary></p>
 
@@ -90,6 +91,7 @@ conda activate mintpy
 # run "mamba install isce2" if you use ISCE-2
 ```
 </details>
+</p>
 
 <h4>c. Install MintPy</h4>
 
@@ -124,23 +126,22 @@ export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}/src
 <details>
 <p><summary>Click to expand for more details</summary></p>
 
-Install Xcode with command line tools, if you have not already done so.
+<p>Install Xcode with command line tools, if you have not already done so.</p>
 
 <ul>
 <li>Install <code>Xcode</code> from App store</li>
 
-<li>Install <code>command line tools</code> within XCode and agree to the terms of license.</li>
+<li><p>Install <code>command line tools</code> within XCode and agree to the terms of license.</p></li>
 
-  ```bash
-  xcode-select --install -s /Applications/Xcode.app/Contents/Developer/
-  sudo xcodebuild -license
-  ```
+<pre><code>xcode-select --install -s /Applications/Xcode.app/Contents/Developer/
+sudo xcodebuild -license</code></pre>
 
 <li>Install <a href="https://www.xquartz.org">XQuartz</a>, then restart the terminal.</li>
 </ul>
 
-Install MintPy via conda, which is the same as the <a href="#21-install-on-linux">instruction for Linux</a>.
+<p>Install MintPy via conda, which is the same as the <a href="#21-install-on-linux">instruction for Linux</a>.</p>
 
+<p>
 <details>
 <p><summary>Or install MintPy via MacPorts</summary></p>
 
@@ -178,6 +179,7 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 ```
 </details>
 </details>
+</p>
 </p>
 
 ### 2.3 Install on Windows ###

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 <details open>
 <summary>via conda</summary>
 
-MintPy is available on the [conda-forge](https://anaconda.org/conda-forge/mintpy) channel. The latest released version can be installed via `conda` as:
+MintPy is available on the <a href="https://anaconda.org/conda-forge/mintpy">conda-forge</a> channel. The latest released version can be installed via `conda` as:
 
 ```bash
 conda install -c conda-forge mintpy
@@ -13,34 +13,32 @@ conda install -c conda-forge mintpy
 <details>
 <summary>via docker</summary>
 
-Docker allows one to run MintPy in a dedicated container, which is essentially an efficient virtual machine, and to be independent of platform OS. First, install [docker](https://docs.docker.com/install/) if you have not already done so. Then run the following to pull the latest stable released constainer image version from [MintPy GitHub Container Registry](https://github.com/insarlab/MintPy/pkgs/container/mintpy) to your local machine:
+Docker allows one to run MintPy in a dedicated container, which is essentially an efficient virtual machine, and to be independent of platform OS. First, install <a href="https://docs.docker.com/install">docker</a> if you have not already done so. Then run the following to pull the latest stable released constainer image version from <a href="https://github.com/insarlab/MintPy/pkgs/container/mintpy">MintPy GitHub Container Registry</a> to your local machine:
 
 ```bash
 docker pull ghcr.io/insarlab/mintpy:latest
 ```
 
-Check [here](docker.md) for more details on Docker container image usage, e.g. pulling development version and running in shell or Jupyter server.
+Check <a href="./docker.md">docker.md</a> for more details on Docker container image usage, e.g. pulling development version and running in shell or Jupyter server.
 </details>
 
 <details>
 <summary>via apt (Linux Debian)</summary>
 
-MintPy is available in the main archive of the [Debian](https://tracker.debian.org/pkg/mintpy) GNU/Linux OS. It can be installed by using your favourite package manager or running the following command:
+MintPy is available in the main archive of the <a href="https://tracker.debian.org/pkg/mintpy">Debian</a> GNU/Linux OS. It can be installed by using your favourite package manager or running the following command:
 
 ```bash
 apt install mintpy
 ```
 
-The same procedure, in priciple, can be used in [Ubuntu](https://ubuntu.com) and all the other [Debian derivatives](https://wiki.debian.org/Derivatives/Census). Check [here](https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian) for more detailed usage.
+The same procedure, in priciple, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.
 </details>
-
-#### [Post-Installation Setup](#3-post-installation-setup) ####
 
 ## 2. Install the development version ##
 
 Note: The installation note below is tested on Linux and macOS, and is still experimental on Windows (may have bugs).
 
-MintPy is written in Python 3 and relies on several Python modules, check the [requirements.txt](https://github.com/insarlab/MintPy/blob/main/requirements.txt) file for details. We recommend using [conda](https://docs.conda.io/en/latest/miniconda.html) or [macports](https://www.macports.org/install.php) to install the python environment and the prerequisite packages, because of the convenient management and default [performance setting with numpy/scipy](http://markus-beuckelmann.de/blog/boosting-numpy-blas.html) and [pyresample](https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree).
+MintPy is written in Python 3 and relies on several Python modules, check the <a href="https://github.com/insarlab/MintPy/blob/main/requirements.txt">requirements.txt</a> file for details. We recommend using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> or <a href="https://www.macports.org/install.php">macports</a> to install the python environment and the prerequisite packages, because of the convenient management and default performance setting with <a href="http://markus-beuckelmann.de/blog/boosting-numpy-blas.html">numpy/scipy</a> and <a href="https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree">pyresample</a>.
 
 <details>
 <summary><h3>2.1 Install on Linux</h3></summary>
@@ -56,7 +54,7 @@ git clone https://github.com/insarlab/MintPy.git
 
 #### b. Install dependencies via conda ####
 
-Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) if you have not already done so. You may need to close and restart the shell for changes to take effect.
+Install <a href="https://docs.conda.io/en/latest/miniconda.html">miniconda</a> if you have not already done so. You may need to close and restart the shell for changes to take effect.
 
 ```bash
 # use wget or curl to download in command line or click from the web browser
@@ -113,7 +111,6 @@ export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}/src
 ```
 </details>
 
-#### d. [Post-Installation Setup](#3-post-installation-setup) ####
 </details>
 
 <details>
@@ -130,12 +127,12 @@ Install Xcode with command line tools, if you have not already done so.
   sudo xcodebuild -license
   ```
 
-+ Install [XQuartz](https://www.xquartz.org), then restart the terminal.
++ Install <a href="https://www.xquartz.org">XQuartz</a>, then restart the terminal.
 
 <details open>
 <summary>Install MintPy via conda</summary>
 
-Same as the [instruction for Linux](#21-install-on-linux).
+Same as the <a href="#21-install-on-linux">instruction for Linux</a>.
 </details>
 
 <details>
@@ -143,7 +140,7 @@ Same as the [instruction for Linux](#21-install-on-linux).
 
 Same as the instruction for Linux, except for the dependencies' installation, which is as below.
 
-Install [macports](https://www.macports.org/install.php) if you have not done so. Add the following at the bottom of your `~/.bash_profile` file:
+Install <a href="https://www.macports.org/install.php">macports</a> if you have not done so. Add the following at the bottom of your `~/.bash_profile` file:
 
 ```bash
 # MacPorts Installer addition on 2017-09-02_at_01:27:12: adding an appropriate PATH variable for use with MacPorts.
@@ -152,7 +149,7 @@ export MANPATH=/opt/local/share/man:${MANPATH}
 # Finished adapting your PATH environment variable for use with MacPorts.
 ```
 
-Update the port tree with the following command. If your network prevent the use of rsync or svn via http of port tree, try [Portfile Sync via a Snapshot Tarball](https://trac.macports.org/wiki/howto/PortTreeTarball).
+Update the port tree with the following command. If your network prevent the use of rsync or svn via http of port tree, try <a href="https://trac.macports.org/wiki/howto/PortTreeTarball">Portfile Sync via a Snapshot Tarball</a>.
 
 ```
 sudo port selfupdate
@@ -179,20 +176,20 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 <details>
 <summary><h3>2.3 Install on Windows</h3></summary>
 
-Same as the [instruction for Linux](#21-install-on-linux), except for the "c. Install MintPy" section, only the `pip install` approaches are recommended, as the "setup environment variable" approach is not tested.
+Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for the "c. Install MintPy" section, only the `pip install` approaches are recommended, as the "setup environment variable" approach is not tested.
 </details>
 
 ## 3. Post-Installation Setup
 
 #### a. ERA5 for tropospheric correction ####
 
-Set up an account for ERA5 to download weather re-analysis datasets for tropospheric delay correction as described in [insarlab/PyAPS](https://github.com/insarlab/pyaps#2-account-setup-for-era5).
+Set up an account for ERA5 to download weather re-analysis datasets for tropospheric delay correction as described in <a href="https://github.com/insarlab/pyaps#2-account-setup-for-era5">insarlab/PyAPS</a>.
 
 `WEATHER_DIR`: Optionally, if you defined an environment variable named `WEATHER_DIR` to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
 
 #### b. Dask for parallel processing ####
 
-We recommend setting the `temporary-directory` in your [Dask configuration file](https://docs.dask.org/en/stable/configuration.html), e.g. `~/.config/dask/dask.yaml`, by adding the following line, to avoid potential [workspace lock issue](https://github.com/insarlab/MintPy/issues/725). Check more details on parallel processing with Dask [here](./dask.md).
+We recommend setting the `temporary-directory` in your <a href="https://docs.dask.org/en/stable/configuration.html">Dask configuration file</a>, e.g. `~/.config/dask/dask.yaml`, by adding the following line, to avoid the potential <a href="https://github.com/insarlab/MintPy/issues/725">workspace lock issue</a>. Check the <a href="./dask.md">dask.md</a> file for more details on parallel processing.
 
 ```yaml
 temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /local
@@ -203,7 +200,7 @@ temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /l
 
 #### c. Extra environment variables setup ####
 
-We recommend setting the following environment variables, e.g. in your `~/.bash_profile` file, to avoid occasional errors.
+We recommend setting the following environment variables, e.g. in your `~/.bash_profile` file, to avoid occasional errors with GDAL VRT and HDF5 files I/O.
 
 ```bash
 export VRT_SHARED_SOURCE=0             # do not share dataset while using GDAL VRT in a multi-threading environment

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-## 1. Install the released version ##
+<h2>1. Install the released version</h2>
 
 <details open>
 <p><summary>via conda</summary></p>
@@ -19,7 +19,7 @@ Docker allows one to run MintPy in a dedicated container, which is essentially a
 docker pull ghcr.io/insarlab/mintpy:latest
 ```
 
-Check <a href="./docker.md">docker.md</a> for more details on Docker container image usage, e.g. pulling development version and running in shell or Jupyter server.
+<p>Check <a href="./docker.md">docker.md</a> for more details on Docker container image usage, e.g. pulling development version and running in shell or Jupyter server.</p>
 </details>
 
 <details>
@@ -31,16 +31,16 @@ MintPy is available in the main archive of the <a href="https://tracker.debian.o
 apt install mintpy
 ```
 
-The same procedure, in priciple, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.
+<p>The same procedure, in priciple, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.</p>
 </details>
 
-## 2. Install the development version ##
+<h2>2. Install the development version</h2>
 
 Note: The installation note below is tested on Linux and macOS, and is still experimental on Windows (may have bugs).
 
 MintPy is written in Python 3 and relies on several Python modules, check the <a href="https://github.com/insarlab/MintPy/blob/main/requirements.txt">requirements.txt</a> file for details. We recommend using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> or <a href="https://www.macports.org/install.php">macports</a> to install the python environment and the prerequisite packages, because of the convenient management and default performance setting with <a href="http://markus-beuckelmann.de/blog/boosting-numpy-blas.html">numpy/scipy</a> and <a href="https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree">pyresample</a>.
 
-### 2.1 Install on Linux ###
+<h3>2.1 Install on Linux</h3>
 
 <details>
 <p><summary>Click to expand for more details</summary></p>
@@ -114,7 +114,7 @@ export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}/src
 </details>
 </details>
 
-### 2.2 Install on macOS ###
+<h3>2.2 Install on macOS</h3>
 
 <details>
 <p><summary>Click to expand for more details</summary></p>
@@ -174,7 +174,7 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 </details>
 </details>
 
-### 2.3 Install on Windows ###
+<h3>2.3 Install on Windows</h3>
 
 <details>
 <p><summary>Click to expand for more details</summary></p>
@@ -182,15 +182,15 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for the "c. Install MintPy" section, only the <code>pip install</code> approaches are recommended, as the <code>path setup</code> approach is not tested.
 </details>
 
-## 3. Post-Installation Setup
+<h2>3. Post-Installation Setup</h2>
 
-#### a. ERA5 for tropospheric correction ####
+<h4>a. ERA5 for tropospheric correction</h4>
 
 Set up an account for ERA5 to download weather re-analysis datasets for tropospheric delay correction as described in <a href="https://github.com/insarlab/pyaps#2-account-setup-for-era5">insarlab/PyAPS</a>.
 
 <code>WEATHER_DIR</code>: Optionally, if you defined an environment variable named <code>WEATHER_DIR</code> to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
 
-#### b. Dask for parallel processing ####
+<h4>b. Dask for parallel processing</h4>
 
 We recommend setting the <code>temporary-directory</code> in your <a href="https://docs.dask.org/en/stable/configuration.html">Dask configuration file</a>, e.g. <code>~/.config/dask/dask.yaml</code>, by adding the following line, to avoid the potential <a href="https://github.com/insarlab/MintPy/issues/725">workspace lock issue</a>. Check the <a href="./dask.md">dask.md</a> file for more details on parallel processing.
 
@@ -201,7 +201,7 @@ temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /l
 # temporary-directory: /tmp/{replace_this_with_your_user_name}
 ```
 
-#### c. Extra environment variables setup ####
+<h4>c. Extra environment variables setup</h4>
 
 We recommend setting the following environment variables, e.g. in your <code>~/.bash_profile</code> file, to avoid occasional errors with GDAL VRT and HDF5 files I/O.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,6 @@
-<h2>1. Install the released version</h2>
+## 1. Install the released version ##
 
+<p>
 <details open>
 <p><summary>via conda</summary></p>
 
@@ -31,17 +32,19 @@ MintPy is available in the main archive of the <a href="https://tracker.debian.o
 apt install mintpy
 ```
 
-<p>The same procedure, in priciple, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.</p>
+The same procedure, in priciple, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.
 </details>
+</p>
 
-<h2>2. Install the development version</h2>
+## 2. Install the development version ##
 
 Note: The installation note below is tested on Linux and macOS, and is still experimental on Windows (may have bugs).
 
 MintPy is written in Python 3 and relies on several Python modules, check the <a href="https://github.com/insarlab/MintPy/blob/main/requirements.txt">requirements.txt</a> file for details. We recommend using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> or <a href="https://www.macports.org/install.php">macports</a> to install the python environment and the prerequisite packages, because of the convenient management and default performance setting with <a href="http://markus-beuckelmann.de/blog/boosting-numpy-blas.html">numpy/scipy</a> and <a href="https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree">pyresample</a>.
 
-<h3>2.1 Install on Linux</h3>
+### 2.1 Install on Linux ###
 
+<p>
 <details>
 <p><summary>Click to expand for more details</summary></p>
 
@@ -113,9 +116,11 @@ export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}/src
 ```
 </details>
 </details>
+</p>
 
-<h3>2.2 Install on macOS</h3>
+### 2.2 Install on macOS ###
 
+<p>
 <details>
 <p><summary>Click to expand for more details</summary></p>
 
@@ -173,24 +178,27 @@ sudo -H /opt/local/bin/pip install git+https://github.com/ecmwf/cdsapi.git
 ```
 </details>
 </details>
+</p>
 
-<h3>2.3 Install on Windows</h3>
+### 2.3 Install on Windows ###
 
+<p>
 <details>
 <p><summary>Click to expand for more details</summary></p>
 
 Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for the "c. Install MintPy" section, only the <code>pip install</code> approaches are recommended, as the <code>path setup</code> approach is not tested.
 </details>
+</p>
 
-<h2>3. Post-Installation Setup</h2>
+## 3. Post-Installation Setup ##
 
-<h4>a. ERA5 for tropospheric correction</h4>
+#### a. ERA5 for tropospheric correction ####
 
 Set up an account for ERA5 to download weather re-analysis datasets for tropospheric delay correction as described in <a href="https://github.com/insarlab/pyaps#2-account-setup-for-era5">insarlab/PyAPS</a>.
 
 <code>WEATHER_DIR</code>: Optionally, if you defined an environment variable named <code>WEATHER_DIR</code> to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
 
-<h4>b. Dask for parallel processing</h4>
+#### b. Dask for parallel processing ####
 
 We recommend setting the <code>temporary-directory</code> in your <a href="https://docs.dask.org/en/stable/configuration.html">Dask configuration file</a>, e.g. <code>~/.config/dask/dask.yaml</code>, by adding the following line, to avoid the potential <a href="https://github.com/insarlab/MintPy/issues/725">workspace lock issue</a>. Check the <a href="./dask.md">dask.md</a> file for more details on parallel processing.
 
@@ -201,7 +209,7 @@ temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /l
 # temporary-directory: /tmp/{replace_this_with_your_user_name}
 ```
 
-<h4>c. Extra environment variables setup</h4>
+#### c. Extra environment variables setup ####
 
 We recommend setting the following environment variables, e.g. in your <code>~/.bash_profile</code> file, to avoid occasional errors with GDAL VRT and HDF5 files I/O.
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -880,7 +880,7 @@ def get_hdf5_dataset_attrs(fname, key='UNIT'):
 
     fext = os.path.splitext(fname)[1]
     if fext not in ['.h5', '.he5']:
-        raise ValueError(f'input file ({fname}) does not end with .h5/he5!')
+        return None
 
     # default output: empty
     attrs = {}


### PR DESCRIPTION
**Description of proposed changes**

+ `docs/installation`:
   - switch link syntax from markdown to html, because the markdown link syntax within html tag, e.g. the <detail>, does not work on `readthedocs`.
   - remove the unnecessary link to section 3, as suggested by @falkamelung.

+ `.github/dependabot.yml`: ignore patch updates for all dependencies to reduce the PR frequency

+ `utils.readfile.get_hdf5_dataset_attrs()`: return None, instead of raising an error, if the input file is not hdf5, for more compatibility

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.