### PR TITLE
`utils0.median_abs_deviation()`: divide by `scale` instead of multiply

### DIFF
--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -1081,7 +1081,7 @@ def median_abs_deviation(data, center=None, scale=0.67449):
     + scipy.stats.median_abs_deviation() since v1.5.0
       https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.median_abs_deviation.html
 
-    The implementation here is preferrred because we would like to:
+    The implementation here is preferred because we would like to:
     1. omit the NaN value in the data for the median and MAD calculation
     2. scale the returned value to be comparable with standard deviation (STD)
        for easy interpretation with 1/2/3-sigma rule.

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -1107,7 +1107,7 @@ def median_abs_deviation(data, center=None, scale=0.67449):
     # calculation
     if data.ndim == 2:
         center = np.tile(center.reshape(-1,1), (1, data.shape[1]))
-    mad = np.nanmedian(np.abs(data - center), axis=-1) * scale
+    mad = np.nanmedian(np.abs(data - center), axis=-1) / scale
     return mad
 
 


### PR DESCRIPTION
**Description of proposed changes**

"scale" parameter in median_abs_deviation function should be a divisor for MAD calculation, namely np.nanmedian(...) / scale, in order to derive a cutoff value comparable to the 1-2-3-sigma rule.

See the discussion on user forum: https://groups.google.com/d/msgid/mintpy/4db4caa8-fb82-403a-a5b4-abef9310cdddn%40googlegroups.com?utm_medium=email&utm_source=footer.

The description of the function, however, hasn't been modified accordingly.

**Reminders**

- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.