### PR TITLE
`view`: fix referencing error while read unwrapPhase* in 2D w/ multilook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             ${HOME}/tools/miniconda3/bin/conda init bash
             # add conda-forge channel and install mamba
             ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
-            ${HOME}/tools/miniconda3/bin/conda config --set channel_priority strict
+            #${HOME}/tools/miniconda3/bin/conda config --set channel_priority strict
             ${HOME}/tools/miniconda3/bin/conda install --yes mamba
             cat ${HOME}/.condarc
             # modify/export env var PATH to BASH_ENV to be shared across run steps

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ pyresample
 pysolid
 rich
 scikit-image
-scipy
+scipy<1.10    # avoid scipy.interpolate error [temporary]

--- a/src/mintpy/objects/ionex.py
+++ b/src/mintpy/objects/ionex.py
@@ -6,7 +6,7 @@
 ############################################################
 # Links:
 #   IGS (NASA): https://cddis.nasa.gov/Data_and_Derived_Products/GNSS/atmospheric_products.html
-#   IMPC (DLR): https://impc.dlr.de/products/total-electron-content/near-real-time-tec/nrt-tec-global/
+#   IMPC (DLR): https://impc.dlr.de/products/total-electron-content/near-real-time-tec/near-real-time-tec-maps-global
 # Recommend import:
 #   from mintpy.objects import ionex
 


### PR DESCRIPTION
**Description of proposed changes**

+ view: fix the bug while referencing unwrapPhase* 2D matrix with multilook number>1

+ requirements: pin scipy<1.10 to avoid interpolate error [temporary fix for #949]

**Reminders**

- [ ] Fix #950
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1905/workflows/b3df1973-424a-4c9f-8813-cfa523120946/jobs/1908) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.