### PR TITLE
`multilook`: support GDAL VRT file

### DIFF
--- a/src/mintpy/cli/multilook.py
+++ b/src/mintpy/cli/multilook.py
@@ -12,8 +12,9 @@ from mintpy.utils.arg_utils import create_argument_parser
 
 ##################################################################################################
 EXAMPLE = """example:
-  multilook.py  velocity.h5  -r 15 -a 15
-  multilook.py  srtm30m.dem  -r 10 -a 10  -o srtm30m_300m.dem
+  multilook.py velocity.h5 -r 15 -a 15
+  multilook.py srtm30m.dem -x 10 -y 10 -o srtm300m.dem
+  multilook.py lat.rdr.full.vrt lon.rdr.full.vrt -x 9 -y 3
 
   # Ignore / skip marginal pixels
   multilook.py ../../geom_reference/hgt.rdr.full -r 300 -a 100 --margin 58 58 58 58 -o hgt.rdr

--- a/src/mintpy/multilook.py
+++ b/src/mintpy/multilook.py
@@ -20,127 +20,110 @@ np_logger.setLevel(logging.WARNING)
 
 
 ######################################## Sub Functions ############################################
-def multilook_matrix(matrix, lks_y, lks_x):
-    """Obsolete multilooking functions"""
-    rows, cols = matrix.shape
-    lks_x = int(lks_x)
-    lks_y = int(lks_y)
-    if lks_x == 1 and lks_y == 1:
-        return matrix
-
-    rows_mli = int(np.floor(rows/lks_y))
-    cols_mli = int(np.floor(cols/lks_x))
-    #thr = np.floor(lks_x*lks_y/2)
-    matrix_Cmli = np.zeros((rows,    cols_mli))
-    matrix_mli = np.zeros((rows_mli, cols_mli))
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=RuntimeWarning)
-        for c in range(cols_mli):
-            matrix_Cmli[:, c] = np.nanmean(matrix[:, (c)*lks_x:(c+1)*lks_x], 1)
-        for r in range(rows_mli):
-            matrix_mli[r, :] = np.nanmean(matrix_Cmli[(r)*lks_y:(r+1)*lks_y, :], 0)
-    del matrix, matrix_Cmli
-    return matrix_mli
-
-
 def multilook_data(data, lks_y=1, lks_x=1, method='mean'):
-    """Modified from Praveen on StackOverflow:
+    """Apply multilooking (spatial averaging/resampling) to a multi-dimensional array.
 
-    link: https://stackoverflow.com/questions/34689519/how-to-coarser-the-2-d-array-data-resolution
+    Link: https://stackoverflow.com/questions/34689519/how-to-coarser-the-2-d-array-data-resolution
 
-    Parameters: data        : 2D / 3D np.array in real or complex
-                lks_y       : int, number of multilook in y/azimuth direction
-                lks_x       : int, number of multilook in x/range direction
-                method      : str, multilook method, mean, median or nearest
-    Returns:    coarse_data : 2D / 3D np.array after multilooking in last two dimension
+    Parameters: data     - 2D / 3D np.array in real or complex
+                lks_y    - int, number of multilook in y/azimuth direction
+                lks_x    - int, number of multilook in x/range direction
+                method   - str, multilook method, mean, median or nearest
+    Returns:    out_data - 2D / 3D np.array after multilooking in last two dimension
     """
+    # check - method
     method_list = ['mean', 'median', 'nearest']
     if method not in method_list:
         msg = f'un-supported multilook method: {method}. '
         msg += f'Available methods: {method_list}'
         raise ValueError(msg)
 
-    # do nothing if no multilook is applied
+    # check - number of looks: do nothing if no multilook is applied
     lks_y = int(lks_y)
     lks_x = int(lks_x)
     if lks_y * lks_x == 1:
         return data
 
-    dtype = data.dtype
     shape = np.array(data.shape, dtype=float)
-    ysize = int(shape[0] / lks_y)
-    xsize = int(shape[1] / lks_x)
-
     if len(shape) == 2:
-        if method in ['mean', 'median']:
-            # crop data to the exact multiple of the multilook number
-            new_shape = np.floor(shape / (lks_y, lks_x)).astype(int) * (lks_y, lks_x)
-            crop_data = data[:new_shape[0],
-                             :new_shape[1]]
+        # prepare - crop data to the exact multiple of the multilook number
+        new_shape = np.floor(shape / (lks_y, lks_x)).astype(int) * (lks_y, lks_x)
+        crop_data = data[:new_shape[0], :new_shape[1]]
 
-            # reshape to more dimensions and collapse the extra dimensions with mean
+        if method in ['mean', 'median']:
+            # approach 1: reshape to higher dimensions, then collapse the extra dimensions
+            #   with desired math operation
+            # a. reshape to more dimensions
             temp = crop_data.reshape((new_shape[0] // lks_y, lks_y,
                                       new_shape[1] // lks_x, lks_x))
 
+            # b. collapse the extra dimensions with mean / median
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=RuntimeWarning)
                 if method == 'mean':
-                    coarse_data = np.nanmean(temp, axis=(1, 3))
+                    out_data = np.nanmean(temp, axis=(1, 3))
                 elif method == 'median':
-                    coarse_data = np.nanmedian(temp, axis=(1, 3))
+                    out_data = np.nanmedian(temp, axis=(1, 3))
+
+            # [obsolete] approach 2: indexing + averaging: first in col/x, then in row/y
+            # out_len, out_wid = np.floor(shape / (lks_y, lks_x)).astype(int)
+            # out_data_col = np.zeros((shape[0], out_wid), dtype=data.dtype)
+            # out_data = np.zeros((out_len, out_wid), dtype=data.dtype)
+
+            # for x in range(out_wid):
+            #     x0, x1 = x * lks_x, (x + 1) * lks_x
+            #     out_data_col[:, x] = np.nanmean(crop_data[:, x0:x1], 1)
+            # for y in range(out_len):
+            #     y0, y1 = y * lks_y, (y + 1) * lks_y
+            #     out_data[y, :] = np.nanmean(out_data_col[y0:y1, :], 0)
 
         elif method == 'nearest':
-            coarse_data = data[int(lks_y/2)::lks_y,
-                               int(lks_x/2)::lks_x]
-
-            # fix size discrepency from average method
-            if coarse_data.shape != (ysize, xsize):
-                coarse_data = coarse_data[:ysize, :xsize]
+            out_data = crop_data[int(lks_y/2)::lks_y,
+                                 int(lks_x/2)::lks_x]
 
     elif len(shape) == 3:
-        if method in ['mean', 'median']:
-            # crop data to the exact multiple of the multilook number
-            new_shape = np.floor(shape / (1, lks_y, lks_x)).astype(int) * (1, lks_y, lks_x)
-            crop_data = data[:new_shape[0],
-                             :new_shape[1],
-                             :new_shape[2]]
+        # prepare - crop data to the exact multiple of the multilook number
+        new_shape = np.floor(shape / (1, lks_y, lks_x)).astype(int) * (1, lks_y, lks_x)
+        crop_data = data[:new_shape[0],
+                         :new_shape[1],
+                         :new_shape[2]]
 
-            # reshape to more dimensions and collapse the extra dimensions with mean
+        if method in ['mean', 'median']:
+            # a. reshape to more dimensions
             temp = crop_data.reshape((new_shape[0],
                                       new_shape[1] // lks_y, lks_y,
                                       new_shape[2] // lks_x, lks_x))
 
+            # b. collapse the extra dimensions with mean / median
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=RuntimeWarning)
                 if method == 'mean':
-                    coarse_data = np.nanmean(temp, axis=(2, 4))
+                    out_data = np.nanmean(temp, axis=(2, 4))
                 elif method == 'median':
-                    coarse_data = np.nanmedian(temp, axis=(2, 4))
+                    out_data = np.nanmedian(temp, axis=(2, 4))
 
         elif method == 'nearest':
-            coarse_data = data[:,
-                               int(lks_y/2)::lks_y,
-                               int(lks_x/2)::lks_x]
+            out_data = crop_data[:,
+                                 int(lks_y/2)::lks_y,
+                                 int(lks_x/2)::lks_x]
 
-            # fix size discrepency from average method
-            if coarse_data.shape[-2:] != (ysize, xsize):
-                coarse_data = coarse_data[:, :ysize, :xsize]
+    else:
+        raise ValueError(f'Un-supported data dimension: {shape} --> {len(shape)}!')
 
     # ensure output data type
-    coarse_data = np.array(coarse_data, dtype=dtype)
+    out_data = np.array(out_data, dtype=data.dtype)
 
-    return coarse_data
+    return out_data
 
 
 def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,0,0,0], max_memory=4):
     """ Multilook input file
-    Parameters: infile - str, path of input file to be multilooked.
-                lks_y  - int, number of looks in y / row direction.
-                lks_x  - int, number of looks in x / column direction.
-                margin - list of 4 int, number of pixels to be skipped during multilooking.
-                         useful for offset product, where the marginal pixels are ignored during
-                         cross correlation matching.
+    Parameters: infile  - str, path of input file to be multilooked.
+                lks_y   - int, number of looks in y / row direction.
+                lks_x   - int, number of looks in x / column direction.
+                margin  - list of 4 int, number of pixels to be skipped during multilooking.
+                          useful for offset product, where the marginal pixels are ignored during
+                          cross correlation matching.
                 outfile - str, path of output file
     Returns:    outfile - str, path of output file
     """
@@ -169,18 +152,17 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,
         box = (0, 0, width, length)
 
     # output file name
-    ext = os.path.splitext(infile)[1]
+    fbase, fext = os.path.splitext(infile)
     if not outfile:
         if os.getcwd() == os.path.dirname(os.path.abspath(infile)):
-            suffix = f'_{lks_y}alks_{lks_x}rlks'
-            outfile = os.path.splitext(infile)[0] + suffix + ext
+            outfile = f'{fbase}_{lks_y}alks_{lks_x}rlks{fext}'
         else:
             outfile = os.path.basename(infile)
 
     # update metadata
     atr = attr.update_attribute4multilook(atr, lks_y, lks_x, box=box)
 
-    if ext in ['.h5', '.he5']:
+    if fext in ['.h5', '.he5']:
         writefile.layout_hdf5(outfile, metadata=atr, ref_file=infile)
 
     # read source data and multilooking
@@ -192,11 +174,10 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,
             d=dsName, w=maxDigit, f=os.path.basename(infile)))
 
         # split in Y/row direction for IO for HDF5 only
-        if ext in ['.h5', '.he5']:
+        if fext in ['.h5', '.he5']:
             # calc step size with memory usage up to 4 GB
             with h5py.File(infile, 'r') as f:
-                ds = f[dsName]
-                ds_size = np.prod(ds.shape) * 4
+                ds_size = np.prod(f[dsName].shape) * 4
             num_step = int(np.ceil(ds_size * 4 / (max_memory * 1024**3)))
             row_step = int(np.rint(length / num_step / 10) * 10)
             row_step = max(row_step, 10)
@@ -209,29 +190,19 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,
             r0 = box[1] + row_step * lks_y * i
             r1 = box[1] + row_step * lks_y * (i + 1)
             r1 = min(r1, box[3])
+
             # IO box
             box_i = (box[0], r0, box[2], r1)
-            box_o = (int((box[0] - box[0]) / lks_x),
-                     int((r0     - box[1]) / lks_y),
-                     int((box[2] - box[0]) / lks_x),
-                     int((r1     - box[1]) / lks_y))
+            box_o = (int((box[0] - box[0]) / lks_x), int((r0 - box[1]) / lks_y),
+                     int((box[2] - box[0]) / lks_x), int((r1 - box[1]) / lks_y))
             print(f'box: {box_o}')
 
             # read / multilook
+            kwargs = dict(datasetName=dsName, box=box_i, print_msg=False)
             if method == 'nearest':
-                data = readfile.read(infile,
-                                     datasetName=dsName,
-                                     box=box_i,
-                                     xstep=lks_x,
-                                     ystep=lks_y,
-                                     print_msg=False)[0]
-
+                data = readfile.read(infile, xstep=lks_x, ystep=lks_y, **kwargs)[0]
             else:
-                data = readfile.read(infile,
-                                     datasetName=dsName,
-                                     box=box_i,
-                                     print_msg=False)[0]
-
+                data = readfile.read(infile, **kwargs)[0]
                 data = multilook_data(data, lks_y, lks_x, method=method)
 
             # output block
@@ -244,7 +215,7 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,
                          box_o[0], box_o[2]]
 
             # write
-            if ext in ['.h5', '.he5']:
+            if fext in ['.h5', '.he5']:
                 writefile.write_hdf5_block(outfile,
                                            data=data,
                                            datasetName=dsName,
@@ -257,11 +228,11 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', margin=[0,
     if (len(dsDict.keys()) == 2
             and os.path.splitext(infile)[1] not in ['.h5','.he5']
             and atr.get('INTERLEAVE', 'BIL').upper() != 'BIL'):
-        print('the input binary file has 2 bands with band interleave as: {}'.format(atr['INTERLEAVE']))
+        print(f'the input binary file has 2 bands with band interleave as: {atr["INTERLEAVE"]}')
         print('for the output binary file, change the band interleave to BIL as default.')
         atr['INTERLEAVE'] = 'BIL'
 
-    if ext not in ['.h5', '.he5']:
+    if fext not in ['.h5', '.he5']:
         atr['BANDS'] = len(dsDict.keys())
         writefile.write(dsDict, out_file=outfile, metadata=atr, ref_file=infile)
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -698,7 +698,7 @@ def get_slice_list(fname, no_complex=False):
     fbase, fext = os.path.splitext(os.path.basename(fname))
     fext = fext.lower()
     # ignore certain meaningless file extensions
-    while fext in ['.geo', '.rdr', '.full', '.wgs84', '.grd']:
+    while fext in ['.geo', '.rdr', '.full', '.mli', '.wgs84', '.grd']:
         fbase, fext = os.path.splitext(fbase)
     fext = fext if fext else fbase
 
@@ -789,12 +789,12 @@ def get_slice_list(fname, no_complex=False):
             else:
                 slice_list = ['complex']
 
-        elif fbase.startswith('off') and fext in ['.bip'] and num_band == 2:
-            # ampcor offset file
+        elif 'offset' in fbase and num_band == 2:
+            # ampcor offset file, e.g. offset.bip, dense_offsets.bil
             slice_list = ['azimuthOffset', 'rangeOffset']
 
-        elif fbase.startswith('off') and fname.endswith('cov.bip') and num_band == 3:
-            # ampcor offset covariance file
+        elif 'offset' in fbase and '_cov' in fbase and num_band == 3:
+            # ampcor offset covariance file, e.g. offset_cov.bip, dense_offsets_cov.bil
             slice_list = ['azimuthOffsetVar', 'rangeOffsetVar', 'offsetCovar']
 
         elif fext in ['.lkv']:
@@ -1181,7 +1181,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
         meta_ext = os.path.splitext(metafile)[1].lower()
 
         # ignore certain meaningless file extensions
-        while fext in ['.geo', '.rdr', '.full', '.wgs84', '.grd']:
+        while fext in ['.geo', '.rdr', '.full', '.mli', '.wgs84', '.grd']:
             fbase, fext = os.path.splitext(fbase)
         if not fext:
             fext = fbase


### PR DESCRIPTION
**Description of proposed changes**

+ `multilook.py`:
   - add `multilook_gdal()` to generate the multilooked `lat/lon.rdr` files from isce-generated GDAL VRT files (lat/lon.rdr.full.vrt) directly; add example usage in `cli.multilook.py`.
   - remove the obsolete `multilook_matrix()` and add its core part as commented code block within `multilook_data()`.
   - `multilook_data()`: apply cropping of the input data for all methods, as a generic preparation step, to simplify the code laterward.

+ utils.readfile.py:
   - read_attribute(): ignore '.mli' for FILE_TYPE, similar to '.full' and '.rdr' in the path
   - get_slice_list(): support dense offsets generated by isce2/topsApp.py, to facilitate the auto reading of read()

**Reminders**

- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1930/workflows/118d0d96-d6cf-4c46-b7f8-ac6fbd05adfc/jobs/1933) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
