### PR TITLE
replace expired numpy dtype deprecations (cont.)

### DIFF
--- a/src/mintpy/multi_transect.py
+++ b/src/mintpy/multi_transect.py
@@ -64,8 +64,9 @@ def dms2d(Coord):
 
 def gps_to_LOS(Ve, Vn, theta, heading):
 
-    unitVec = [np.cos(heading)*np.sin(theta), -np.sin(theta)
-               * np.sin(heading), np.cos(theta)]
+    unitVec = [ np.cos(heading) * np.sin(theta),
+               -np.sin(theta) * np.sin(heading),
+                np.cos(theta)]
 
     gpsLOS = unitVec[0]*Ve+unitVec[1]*Vn
 
@@ -305,7 +306,7 @@ def get_transect(z, x0, y0, x1, y1):
 
     length = int(np.hypot(x1-x0, y1-y0))
     x, y = np.linspace(x0, x1, length), np.linspace(y0, y1, length)
-    zi = z[y.astype(np.int), x.astype(np.int)]
+    zi = z[y.astype(int), x.astype(int)]
     return zi
 
 
@@ -588,10 +589,10 @@ def main(argv=None):
         print('******************************************************')
         length = int(np.hypot(x1-x0, y1-y0))
         x, y = np.linspace(x0, x1, length), np.linspace(y0, y1, length)
-        zi = z[y.astype(np.int), x.astype(np.int)]
+        zi = z[y.astype(int), x.astype(int)]
         try:
-            lat_transect = lat_all[y.astype(np.int), x.astype(np.int)]
-            lon_transect = lon_all[y.astype(np.int), x.astype(np.int)]
+            lat_transect = lat_all[y.astype(int), x.astype(int)]
+            lon_transect = lon_all[y.astype(int), x.astype(int)]
         except:
             lat_transect = 'Nan'
             lon_transect = 'Nan'

--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -97,7 +97,7 @@ def read_init_info(inps):
 
         # read error file
         error_fc = np.loadtxt(inps.error_file, dtype=bytes).astype(str)
-        inps.error_ts = error_fc[:, 1].astype(np.float)*inps.unit_fac
+        inps.error_ts = error_fc[:, 1].astype(np.float32)*inps.unit_fac
 
         # update error file with exlcude date
         if inps.ex_date_list:

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -303,7 +303,7 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
     # for nearest neighbor sampling, use indexing directly
     # for other interpolation, use scipy.ndimage.map_coordinates
     if interpolation == 'nearest':
-        z_line = z[np.rint(ys).astype(np.int), np.rint(xs).astype(np.int)]
+        z_line = z[np.rint(ys).astype(int), np.rint(xs).astype(int)]
 
     else:
         # interpolation name to order


### PR DESCRIPTION
**Description of proposed changes**

Changes due to numpy depreciation of np.int. Changes np.int to int in utils.py. See Previous Commit #934

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.