### PR TITLE
`readfile`: add `auto_no_data_value()` for known files

### DIFF
--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -369,7 +369,8 @@ def run_timeseries2time_func(inps):
             # =>      sigma^2 = sigma_hat^2 * N / (N - P)           (11)
             #                 = (e_hat.T * e_hat) / (N - P)         (12)
             #
-            # Eq. (10) in Fattahi & Amelung (2015, JGR) is a simplified form of eq. (12) for linear velocity.
+            # Eq. (12) is the generalized form of eq. (10) in Fattahi & Amelung (2015, JGR),
+            # which is for linear velocity.
 
             if inps.uncertaintyQuantification == 'covariance':
                 # option 2.2 - linear propagation from time-series (co)variance matrix

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -1057,8 +1057,12 @@ def read_data4figure(i_start, i_end, inps, metadata):
     # slow reading with one 2D matrix at a time
     else:
         vprint('reading data as a list of 2D matrices ...')
+        kwargs['print_msg'] = False
         prog_bar = ptime.progressBar(maxValue=i_end-i_start, print_msg=inps.print_msg)
         for i in range(i_start, i_end):
+            prog_bar.update(i - i_start + 1, suffix=inps.dset[i].split('/')[-1])
+
+            # read 2D matrix
             d = readfile.read(inps.file, datasetName=inps.dset[i], **kwargs)[0]
 
             # reference pixel info for unwrapPhase
@@ -1068,8 +1072,6 @@ def read_data4figure(i_start, i_end, inps, metadata):
 
             # save the matrix
             data[i - i_start, :, :] = d
-
-            prog_bar.update(i - i_start + 1, suffix=inps.dset[i].split('/')[-1])
         prog_bar.close()
 
     # ref_date for timeseries
@@ -1284,13 +1286,16 @@ def plot_figure(j, inps, metadata):
     prog_bar = ptime.progressBar(maxValue=i_end-i_start, print_msg=inps.print_msg)
     for i in range(i_start, i_end):
         idx = i - i_start
+        prog_bar.update(idx+1, suffix=inps.dset[i].split('/')[-1])
+
+        # plot subplot
         im = plot_subplot4figure(
             i, inps,
             ax=axs[idx],
             data=data[idx, :, :],
             metadata=metadata)
 
-        # colorbar for each subplot
+        # add colorbar for each subplot
         if inps.disp_cbar and not inps.vlim:
             cbar = fig.colorbar(im, ax=axs[idx], pad=0.03, shrink=0.5, aspect=30, orientation='vertical')
 
@@ -1298,8 +1303,6 @@ def plot_figure(j, inps, metadata):
             data_unit = readfile.read_attribute(inps.file, datasetName=inps.dset[i]).get('UNIT', None)
             if data_unit:
                 cbar.set_label(data_unit)
-
-        prog_bar.update(idx+1, suffix=inps.dset[i].split('/')[-1])
     prog_bar.close()
     del data
 


### PR DESCRIPTION
**Description of proposed changes**

+ utils.readfile: add auto_no_data_value() for know file types: dense offsets from isce2/topsApp.py

+ utils.readfile: set the following functions as private, to discourage usage out of this sub-module:
   - `_get_file_base_and_ext()`
   - `_sort_dataset_list2velocity()`
   - `_attribute_gamma2roipac()`
   - `_attribute_gmtsar2roipac()`

+ view.read_data4figure(): do not print out msg while reading a list of 2D matrix (fine tune for https://github.com/insarlab/MintPy/issues/950).

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1952/workflows/465945d3-e6fb-4404-8bde-449fa5dec204/jobs/1955) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
