### PR TITLE
view: add `--faultline` option

### DIFF
--- a/src/mintpy/cli/view.py
+++ b/src/mintpy/cli/view.py
@@ -40,6 +40,9 @@ EXAMPLE = """example:
   view.py geo_velocity_msk.h5 velocity --show-gps --gps-comp enu2los --ref-gps GV01
   view.py geo_timeseries_ERA5_ramp_demErr.h5 20180619 --ref-date 20141213 --show-gps --gps-comp enu2los --ref-gps GV01
 
+  # Faults
+  view.py filt_dense_offsets.bil range --faultline simple_fault_confident.lonlat
+
   # Save and Output
   view.py velocity.h5 --save
   view.py velocity.h5 --nodisplay

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -260,6 +260,8 @@ def add_mask_argument(parser):
 def add_map_argument(parser):
     """Argument group parser for map options"""
     mapg = parser.add_argument_group('Map', 'for one subplot in geo-coordinates only')
+
+    # coastline
     mapg.add_argument('--coastline', dest='coastline', type=str, choices={'10m', '50m', '110m'},
                       help="Draw coastline with specified resolution (default: %(default)s).\n"
                            "This will enable --lalo-label option.\n"
@@ -268,6 +270,13 @@ def add_map_argument(parser):
     mapg.add_argument('--coastline-lw', '--coastline-linewidth', dest='coastline_linewidth',
                       metavar='NUM', type=float, default=1,
                       help='Coastline linewidth (default: %(default)s).')
+
+    # faultline
+    mapg.add_argument('--faultline', dest='faultline_file', type=str,
+                      help='Draw fault line using specified GMT lonlat file.')
+    mapg.add_argument('--faultline-lw', '--faultline-linewidth', dest='faultline_linewidth',
+                      metavar='NUM', type=float, default=0.5,
+                      help='Faultline linewidth (default: %(default)s).')
 
     # lalo label
     mapg.add_argument('--lalo-label', dest='lalo_label', action='store_true',

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1420,6 +1420,44 @@ def plot_colorbar(inps, im, cax):
     return inps, cbar
 
 
+def plot_faultline(ax, faultline_file, SNWE, linewidth=0.5, print_msg=True):
+    """Plot fault lines.
+
+    Parameters: ax             - matplotlib.axes object
+                faultline_file - str, path to the fault line file in GMT lonlat format
+                SNWE           - tuple of 4 float, for south, north, west and east
+    Returns:    ax             - matplotlib.axes object
+                faults         - list of 2D np.ndarray in size of [num_point, 2] in float32
+                                 with each row for one point in [lon, lat] in degrees
+    """
+
+    if print_msg:
+        print(f'plot fault lines from GMT lonlat file: {faultline_file}')
+
+    # read faults
+    faults = readfile.read_gmt_lonlat_file(
+        faultline_file,
+        SNWE=SNWE,
+        min_dist=0.1,
+        print_msg=print_msg,
+    )
+
+    # plot
+    print_msg = False if len(faults) < 1000 else print_msg
+    prog_bar = ptime.progressBar(maxValue=len(faults), print_msg=print_msg)
+    for i, fault in enumerate(faults):
+        ax.plot(fault[:,0], fault[:,1], 'k-', lw=linewidth)
+        prog_bar.update(i+1, every=10)
+    prog_bar.close()
+
+    # keep the same axis limit
+    S, N, W, E = SNWE
+    ax.set_xlim(W, E)
+    ax.set_ylim(S, N)
+
+    return ax, faults
+
+
 def add_arrow(line, position=None, direction='right', size=15, color=None):
     """Add an arrow to a line.
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -2002,7 +2002,7 @@ def read_gdal(fname, box=None, band=1, cpx_band='phase', xstep=1, ystep=1):
 
 ############################  Read GMT Faults  ################################
 
-def read_gmt_lonlat_file(ll_file, SNWE=None, min_dist=10):
+def read_gmt_lonlat_file(ll_file, SNWE=None, min_dist=10, print_msg=True):
     """Read GMT lonlat file into list of 2D np.ndarray.
 
     Parameters: ll_file  - str, path to the GMT lonlat file
@@ -2044,11 +2044,13 @@ def read_gmt_lonlat_file(ll_file, SNWE=None, min_dist=10):
         lines = lines[:1000]
 
     # loop to extract/organize the data into list of arrays
+    faults, fault = [], []
     num_line = len(lines)
-    faults = []
-    fault = []
-    prog_bar = ptime.progressBar(maxValue=num_line)
+    print_msg = False if num_line < 5000 else print_msg
+    prog_bar = ptime.progressBar(maxValue=num_line, print_msg=print_msg)
     for i, line in enumerate(lines):
+        prog_bar.update(i+1, every=1000, suffix=f'line {i+1} / {num_line}')
+
         line = line.strip().replace('\n','').replace('\t', ' ')
         if line.startswith('>'):
             fault = []
@@ -2075,9 +2077,8 @@ def read_gmt_lonlat_file(ll_file, SNWE=None, min_dist=10):
 
             if fault is not None:
                 faults.append(fault)
-
-        prog_bar.update(i+1, every=1000, suffix=f'line {i+1} / {num_line}')
     prog_bar.close()
+
     return faults
 
 

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -474,6 +474,10 @@ def plot_slice(ax, data, metadata, inps):
             and inps.fig_coord == 'geo'):
         vprint('plot in geo-coordinate')
 
+        # extent info for matplotlib.imshow and other functions
+        extent = (inps.geo_box[0], inps.geo_box[2], inps.geo_box[3], inps.geo_box[1])  # (W, E, S, N)
+        SNWE = (inps.geo_box[3], inps.geo_box[1], inps.geo_box[0], inps.geo_box[2])
+
         # Draw coastline using cartopy resolution parameters
         if inps.coastline:
             vprint(f'draw coast line with resolution: {inps.coastline}')
@@ -504,12 +508,19 @@ def plot_slice(ax, data, metadata, inps):
             # do not show the original InSAR reference point
             inps.disp_ref_pixel = False
 
-        extent = (inps.geo_box[0], inps.geo_box[2],
-                  inps.geo_box[3], inps.geo_box[1])  # (W, E, S, N)
-
         im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
                        extent=extent, origin='upper', interpolation='nearest',
                        alpha=inps.transparency, animated=inps.animation, zorder=1)
+
+        # Draw faultline using GMT lonlat file
+        if inps.faultline_file:
+            pp.plot_faultline(
+                ax=ax,
+                faultline_file=inps.faultline_file,
+                SNWE=SNWE,
+                linewidth=inps.faultline_linewidth,
+                print_msg=inps.print_msg,
+            )
 
         # Scale Bar
         if inps.coord_unit.startswith('deg') and (inps.geo_box[2] - inps.geo_box[0]) > 30:
@@ -519,7 +530,7 @@ def plot_slice(ax, data, metadata, inps):
         if inps.disp_scalebar:
             vprint(f'plot scale bar: {inps.scalebar}')
             pp.draw_scalebar(
-                ax,
+                ax=ax,
                 geo_box=inps.geo_box,
                 unit=inps.coord_unit,
                 loc=inps.scalebar,
@@ -530,7 +541,7 @@ def plot_slice(ax, data, metadata, inps):
         # Lat Lon labels
         if inps.lalo_label:
             pp.draw_lalo_label(
-                ax,
+                ax=ax,
                 geo_box=inps.geo_box,
                 lalo_step=inps.lalo_step,
                 lalo_loc=inps.lalo_loc,


### PR DESCRIPTION
**Description of proposed changes**

Add `view.py --faultline --faultline-linewidth` options to plot faults using GMT lonlat file.

+ utils.arg_utils.add_map_argument(): add `--faultline` and `--faultline-lw` options

+ utils.plot: add `plot_faultline()`

+ view.plot_slice: call `pp.plot_faultline()`

+ cli.view: add example usage

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1962/workflows/630ba80f-5bca-48a5-af0d-ec49f5409319/jobs/1965) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.