### PR TITLE
timeseries_rms: bugfix for `run_or_skip` and `*RMS.deramp = no`

### DIFF
--- a/src/mintpy/timeseries_rms.py
+++ b/src/mintpy/timeseries_rms.py
@@ -24,6 +24,7 @@ def read_template2inps(templateFile, inps):
     keyList = [i for i in list(inpsDict.keys()) if prefix+i in template.keys()]
     for key in keyList:
         value = template[prefix+key]
+        # false/none values are valid inputs, thus, should be passed here without an if check
         if key in ['maskFile', 'deramp']:
             inpsDict[key] = value
         elif key in ['cutoff']:

--- a/src/mintpy/timeseries_rms.py
+++ b/src/mintpy/timeseries_rms.py
@@ -24,11 +24,10 @@ def read_template2inps(templateFile, inps):
     keyList = [i for i in list(inpsDict.keys()) if prefix+i in template.keys()]
     for key in keyList:
         value = template[prefix+key]
-        if value:
-            if key in ['maskFile', 'deramp']:
-                inpsDict[key] = value
-            elif key in ['cutoff']:
-                inpsDict[key] = float(value)
+        if key in ['maskFile', 'deramp']:
+            inpsDict[key] = value
+        elif key in ['cutoff']:
+            inpsDict[key] = float(value)
     return inps
 
 

--- a/src/mintpy/utils/utils1.py
+++ b/src/mintpy/utils/utils1.py
@@ -61,7 +61,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                                                           'maskTempCoh.h5')[:2]
     """
     # Intermediate files name
-    if ramp_type == 'no':
+    if not ramp_type or ramp_type == 'no':
         print('No ramp removal')
         deramped_file = timeseries_resid_file
     else:
@@ -69,7 +69,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
     std_file = os.path.splitext(deramped_file)[0]+'_std.txt'
 
     # Get residual std text file
-    if run_or_skip(out_file=std_file, in_file=[deramped_file, mask_file], readable=False) == 'run':
+    if run_or_skip(out_file=std_file, in_file=[timeseries_resid_file, mask_file], readable=False) == 'run':
         if run_or_skip(out_file=deramped_file, in_file=timeseries_resid_file) == 'run':
             if not os.path.isfile(timeseries_resid_file):
                 msg = 'Can not find input timeseries residual file: '+timeseries_resid_file
@@ -112,7 +112,7 @@ def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
         rms_list, date_list = ut.get_residual_rms('timeseriesResidual.h5', 'maskTempCoh.h5')
     """
     # Intermediate files name
-    if ramp_type == 'no':
+    if not ramp_type or ramp_type == 'no':
         print('No ramp removal')
         deramped_file = timeseries_resid_file
     else:
@@ -122,7 +122,7 @@ def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
     rms_file = os.path.join(fdir, f'rms_{fbase}.txt')
 
     # Get residual RMS text file
-    if run_or_skip(out_file=rms_file, in_file=[deramped_file, mask_file], readable=False) == 'run':
+    if run_or_skip(out_file=rms_file, in_file=[timeseries_resid_file, mask_file], readable=False) == 'run':
         if run_or_skip(out_file=deramped_file, in_file=timeseries_resid_file) == 'run':
             if not os.path.isfile(timeseries_resid_file):
                 msg = 'Can not find input timeseries residual file: '+timeseries_resid_file

--- a/src/mintpy/utils/utils1.py
+++ b/src/mintpy/utils/utils1.py
@@ -61,6 +61,7 @@ def get_residual_std(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
                                                           'maskTempCoh.h5')[:2]
     """
     # Intermediate files name
+    # ramp_type can sometimes be False, thus, should be treated the same as "no"
     if not ramp_type or ramp_type == 'no':
         print('No ramp removal')
         deramped_file = timeseries_resid_file
@@ -112,6 +113,7 @@ def get_residual_rms(timeseries_resid_file, mask_file='maskTempCoh.h5', ramp_typ
         rms_list, date_list = ut.get_residual_rms('timeseriesResidual.h5', 'maskTempCoh.h5')
     """
     # Intermediate files name
+    # ramp_type can sometimes be False, thus, should be treated the same as "no"
     if not ramp_type or ramp_type == 'no':
         print('No ramp removal')
         deramped_file = timeseries_resid_file


### PR DESCRIPTION
**Description of proposed changes**

+ utils.utils1.get_residual_std/rms():
   - always check the time info using the residual file for run_or_skip, instead of using the deramped residual file, as the former makes more sense. Fix #969.
   - treat the empty/false-value `ramp_type` same as `no` value, while determining the output file name from `mintpy.residualRMS.deramp` template option.

+ timeseries_rms.read_template2inps(): pass `no/False` values from `mintpy.residualRMS.maskFile/deramp/cutoff` template options to variables, as they are valid inputs.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/1983/workflows/e89b1b24-810b-4bb6-8e37-76a82b69efb1/jobs/1986) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.