### PR TITLE
simpify obj input args for tsview/plot_tran*/plot_coh*_mat*

### DIFF
--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -75,6 +75,11 @@ def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
 
+    # save argv (to check the manually specified arguments)
+    # use iargs        for python call
+    # use sys.argv[1:] for command line call
+    inps.argv = iargs if iargs else sys.argv[1:]
+
     # default: auxiliary file paths (velocity and template)
     mintpy_dir = os.path.dirname(os.path.dirname(inps.ifgram_file))
     if not inps.img_file:
@@ -106,8 +111,8 @@ def main(iargs=None):
     from mintpy.plot_coherence_matrix import coherenceMatrixViewer
 
     # run
-    obj = coherenceMatrixViewer(iargs=iargs)
-    obj.configure(inps)
+    obj = coherenceMatrixViewer(inps)
+    obj.open()
     obj.plot()
     obj.fig.canvas.mpl_disconnect(obj.cid)
 

--- a/src/mintpy/cli/plot_transection.py
+++ b/src/mintpy/cli/plot_transection.py
@@ -191,9 +191,8 @@ def main(iargs=None):
 
     # run
     view_cmd = get_view_cmd(iargs)
-
-    obj = transectionViewer(iargs=iargs)
-    obj.configure(inps, view_cmd)
+    obj = transectionViewer(inps, view_cmd)
+    obj.open()
     obj.plot()
     obj.fig.canvas.mpl_disconnect(obj.cid)
 

--- a/src/mintpy/cli/tsview.py
+++ b/src/mintpy/cli/tsview.py
@@ -75,7 +75,8 @@ def create_parser(subparsers=None):
     # temporal model fitting
     parser.add_argument('--nomodel', '--nofit', dest='plot_model', action='store_false',
                         help='Do not plot the prediction of the time function (deformation model) fitting.')
-    parser.add_argument('--plot-model-conf-int', '--plot-fit-conf-int', dest='plot_model_conf_int', action='store_true',
+    parser.add_argument('--plot-model-conf-int', '--plot-fit-conf-int',
+                        dest='plot_model_conf_int', action='store_true',
                         help='Plot the time function prediction confidence intervals.\n'
                              '[!-- Preliminary feature alert! --!]\n'
                              '[!-- This feature is NOT throughly checked. '
@@ -176,8 +177,8 @@ def main(iargs=None):
     from mintpy.tsview import timeseriesViewer
 
     # run
-    obj = timeseriesViewer(iargs=iargs)
-    obj.configure(inps)
+    obj = timeseriesViewer(inps)
+    obj.open()
     obj.plot()
     #obj.fig_img.canvas.mpl_disconnect(obj.cid)
 

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -47,41 +47,46 @@ def read_network_info(inps):
 
 
 class coherenceMatrixViewer():
-    """class for plot_coherence_matrix
+    """class for plot_coherence_matrix.
+
     Example:
+        from mintpy.cli.plot_coherence_matrix import cmd_line_parse
         from mintpy.plot_coherence_matrix import coherenceMatrixViewer
-        cmd = 'plot_coherence_matrix.py ./inputs/ifgramStack.h5 --noverbose --figsize 9 3 --yx 216 310'
-        obj = coherenceMatrixViewer(cmd)
-        obj.configure()
+
+        cmd = './inputs/ifgramStack.h5 --noverbose --figsize 9 3 --yx 216 310'
+        inps = cmd_line_parse(cmd.split())
+        obj = coherenceMatrixViewer(inps)
+        obj.open()
         obj.plot()
     """
-    def __init__(self, cmd=None, iargs=None):
-        if cmd:
-            iargs = cmd.split()[1:]
-        self.cmd = cmd
-        self.iargs = iargs
 
+    def __init__(self, inps):
         # figure variables
         self.figname = 'Coherence matrix'
         self.fig_size = None
         self.fig = None
         self.ax_img = None
         self.ax_mat = None
-        return
 
-    def configure(self, inps):
-        global vprint
-        vprint = print if inps.print_msg else lambda *args, **kwargs: None
-
-        # matplotlib backend setting
-        if not inps.disp_fig:
-            plt.switch_backend('Agg')
-
-        # read network info
-        inps = read_network_info(inps)
         # copy inps to self object
         for key, value in inps.__dict__.items():
             setattr(self, key, value)
+
+
+    def open(self):
+        global vprint
+        vprint = print if self.print_msg else lambda *args, **kwargs: None
+
+        # print command line
+        if self.argv is not None:
+            print(f'{os.path.basename(__file__)} ' + ' '.join(self.argv))
+
+        # matplotlib backend setting
+        if not self.disp_fig:
+            plt.switch_backend('Agg')
+
+        # read network info
+        self = read_network_info(self)
 
         # auto figure size
         if not self.fig_size:
@@ -103,7 +108,7 @@ class coherenceMatrixViewer():
             if template['mintpy.networkInversion.maskDataset'] == 'coherence':
                 self.min_coh_used = float(template['mintpy.networkInversion.maskThreshold'])
                 vprint('Pixel-wised masking is applied in invert_network step')
-        return
+
 
     def plot(self):
         # Figure 1
@@ -112,22 +117,25 @@ class coherenceMatrixViewer():
         # Axes 1 - Image
         self.ax_img = self.fig.add_axes([0.05, 0.1, 0.4, 0.8])
         view_cmd = self.view_cmd.format(self.img_file)
-        d_img, atr, inps_img = view.prep_slice(view_cmd)
+        d_img, atr, view_inps = view.prep_slice(view_cmd)
+        self.coord = ut.coordinate(atr)
+
         if all(i is not None for i in self.yx):
-            inps_img.pts_marker = 'r^'
-            inps_img.pts_yx = np.array(self.yx).reshape(-1, 2)
+            view_inps.pts_marker = 'r^'
+            view_inps.pts_yx = np.array(self.yx).reshape(-1, 2)
 
             # point yx --> lalo for geocoded product
             if 'Y_FIRST' in atr.keys():
-                coord = ut.coordinate(atr)
-                inps_img.pts_lalo = np.array(coord.radar2geo(self.yx[0], self.yx[1])[0:2]).reshape(-1,2)
+                view_inps.pts_lalo = np.array(
+                    self.coord.radar2geo(
+                        self.yx[0],
+                        self.yx[1],
+                    )[0:2],
+                ).reshape(-1,2)
 
-        inps_img.print_msg = self.print_msg
-        self.ax_img = view.plot_slice(self.ax_img, d_img, atr, inps_img)[0]
-
-        # coordinate info
-        self.coord = ut.coordinate(atr)
-        self.fig_coord = inps_img.fig_coord
+        view_inps.print_msg = self.print_msg
+        self.ax_img = view.plot_slice(self.ax_img, d_img, atr, view_inps)[0]
+        self.fig_coord = view_inps.fig_coord
 
         # Axes 2 - coherence matrix
         self.ax_mat = self.fig.add_axes([0.55, 0.125, 0.40, 0.75])
@@ -174,7 +182,8 @@ class coherenceMatrixViewer():
             date12List=self.date12_list,
             cohList=coh.tolist(),
             date12List_drop=ex_date12_list,
-            p_dict=plotDict)[1]
+            p_dict=plotDict,
+        )[1]
 
         self.ax_mat.annotate('ifgrams\navailable', xy=(0.05, 0.05), xycoords='axes fraction', fontsize=12)
         self.ax_mat.annotate('ifgrams\nused', ha='right', xy=(0.95, 0.85), xycoords='axes fraction', fontsize=12)

--- a/src/mintpy/plot_transection.py
+++ b/src/mintpy/plot_transection.py
@@ -5,6 +5,8 @@
 ############################################################
 
 
+import os
+
 from matplotlib import pyplot as plt, ticker
 
 from mintpy import view
@@ -13,20 +15,22 @@ from mintpy.utils import plot as pp, readfile, utils as ut
 
 #####################################################################
 class transectionViewer():
-    """class for plot_transection
+    """class for plot_transection.
+
     Example:
+        from mintpy.cli.plot_transection import cmd_line_parse, get_view_cmd
         from mintpy.plot_transection import transectionViewer
-        cmd = 'plot_transection.py velocity.h5 --noverbose --start-yx 10 10 --end-yx 200 300'
-        obj = transectionViewer(cmd)
-        obj.configure()
+
+        cmd = 'velocity.h5 --noverbose --start-yx 10 10 --end-yx 200 300'
+        inps = cmd_line_parse(cmd.split())
+        view_cmd = get_view_cmd(cmd.split())
+        obj = transectionViewer(inps, view_cmd)
+        obj.open()
         obj.plot()
+        obj.fig.canvas.mpl_disconnect(obj.cid)
     """
 
-    def __init__(self, cmd=None, iargs=None):
-        if cmd:
-            iargs = cmd.split()[1:]
-        self.cmd = cmd
-        self.iargs = iargs
+    def __init__(self, inps, view_cmd):
 
         # figure variables
         self.figname = 'Transection'
@@ -37,38 +41,41 @@ class transectionViewer():
         self.img = None
         self.line_ann = None
         self.pts_idx = 0
-        return
 
-    def configure(self, inps, view_cmd):
-        global vprint
-        vprint = print if inps.print_msg else lambda *args, **kwargs: None
-
-        # matplotlib backend setting
-        if not inps.disp_fig:
-            plt.switch_backend('Agg')
+        self.view_cmd = view_cmd
 
         # copy inps to self object
         for key, value in inps.__dict__.items():
             setattr(self, key, value)
 
+
+    def open(self):
+        global vprint
+        vprint = print if self.print_msg else lambda *args, **kwargs: None
+
+        # print command line
+        if self.argv is not None:
+            print(f'{os.path.basename(__file__)} ' + ' '.join(self.argv))
+
+        # matplotlib backend setting
+        if not self.disp_fig:
+            plt.switch_backend('Agg')
+
         # copy inps from view.py to self object
-        self.data_img, atr, inps_view = view.prep_slice(view_cmd)
-        for key, value in inps_view.__dict__.items():
-            setattr(self, key, value)
+        self.data_img, atr, view_inps = view.prep_slice(self.view_cmd)
+        for key, value in view_inps.__dict__.items():
+            # do not update the following setting from view.py
+            if key not in ['file', 'dset', 'fig_size']:
+                setattr(self, key, value)
 
         self.offset *= self.disp_scale  # due to unit change from view.prep_slice()
-
-        # do not update the following setting from view.py
-        self.file = inps.file
-        self.dset = inps.dset
-        self.fig_size = inps.fig_size
 
         # auto figure size
         if not self.fig_size:
             length, width = int(self.atr['LENGTH']), int(self.atr['WIDTH'])
             fig_size = pp.auto_figure_size((length, width), disp_cbar=True)
             self.fig_size = [fig_size[0] + fig_size[1], fig_size[1]]
-        return
+
 
     def plot(self):
         # Read data for transection

--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -634,20 +634,17 @@ class timeseriesViewer():
     """Class for tsview.py
 
     Example:
-        cmd = 'tsview.py timeseries_ERA5_ramp_demErr.h5'
-        obj = timeseriesViewer(cmd)
-        obj.configure()
+        from mintpy.cli.tsview import cmd_line_parse
+        from mintpy.tsview import timeseriesViewer
+
+        cmd = 'timeseries.h5 --yx 273 271 --figsize 8 4'
+        inps = cmd_line_parse(cmd.split())
+        obj = timeseriesViewer(inps)
+        obj.open()
         obj.plot()
     """
 
-    def __init__(self, cmd=None, iargs=None):
-        if cmd:
-            iargs = cmd.split()[1:]
-        self.cmd = cmd
-        self.iargs = iargs
-        # print command line
-        if iargs is not None:
-            print(f'{os.path.basename(__file__)} ' + ' '.join(iargs))
+    def __init__(self, inps):
 
         # figure variables
         self.figname_img = 'Cumulative Displacement Map'
@@ -665,19 +662,23 @@ class timeseriesViewer():
         self.fig_pts = None
         self.ax_pts = None
 
-    def configure(self, inps):
-        global vprint
-        vprint = print if inps.print_msg else lambda *args, **kwargs: None
-
-        # matplotlib backend setting
-        if not inps.disp_fig:
-            plt.switch_backend('Agg')
-
-        inps, self.atr = read_init_info(inps)
-
         # copy inps to self object
         for key, value in inps.__dict__.items():
             setattr(self, key, value)
+
+    def open(self):
+        global vprint
+        vprint = print if self.print_msg else lambda *args, **kwargs: None
+
+        # print command line
+        if self.argv is not None:
+            print(f'{os.path.basename(__file__)} ' + ' '.join(self.argv))
+
+        # matplotlib backend setting
+        if not self.disp_fig:
+            plt.switch_backend('Agg')
+
+        self, self.atr = read_init_info(self)
 
         # input figsize for the point time-series plot
         self.figsize_pts = self.fig_size


### PR DESCRIPTION
**Description of proposed changes**

Simplify the input arguments for object initiation for `tsview, plot_transection and plot_coherence_matrix`:

+ for each *Viewer object __init__(): replace cmd/iargs with inps, as the later covers both, and simpler.

+ for each *Viewer configure(): rename to open() for simplicity

**Reminders**

- [ ] Fix #977
- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass [Circle CI test](https://circleci.com/gh/yunjunz/MintPy/2014) (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.