### PR TITLE
circleci: use mambaforge with 2X speedup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: ubuntu:bionic
         environment:
-          CONDA_PREFIX: /root/tools/miniconda3
+          CONDA_PREFIX: /root/tools/mambaforge
           MINTPY_HOME: /root/tools/MintPy
         user: root
     working_directory: /root/tools/MintPy
@@ -13,22 +13,17 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Setting Up Environment with Miniconda
+          name: Setting Up Environment with Mambaforge
           command: |
             apt update
             apt-get update --yes && apt-get upgrade --yes
             apt-get install --yes git wget
-            # download and install miniconda3
+            # install mambaforge
             mkdir -p ${HOME}/tools
             cd ${HOME}/tools
-            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            bash Miniconda3-latest-Linux-x86_64.sh -b -p ${HOME}/tools/miniconda3
-            ${HOME}/tools/miniconda3/bin/conda init bash
-            # add conda-forge channel and install mamba
-            ${HOME}/tools/miniconda3/bin/conda config --add channels conda-forge
-            #${HOME}/tools/miniconda3/bin/conda config --set channel_priority strict
-            ${HOME}/tools/miniconda3/bin/conda install --yes mamba
-            cat ${HOME}/.condarc
+            wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
+            bash Mambaforge-Linux-x86_64.sh -b -p ${HOME}/tools/mambaforge
+            ${HOME}/tools/mambaforge/bin/mamba init bash
             # modify/export env var PATH to BASH_ENV to be shared across run steps
             echo 'export PATH=${CONDA_PREFIX}/bin:${PATH}' >> ${BASH_ENV}
 
@@ -38,11 +33,10 @@ jobs:
           command: |
             export PYTHONUNBUFFERED=1
             # install dependencies and source code
-            source activate root
             mamba install --verbose --yes gdal">=3" --file ${MINTPY_HOME}/requirements.txt
             python -m pip install ${MINTPY_HOME}
             # test installation
-            smallbaselineApp.py -v
+            smallbaselineApp.py -h
             tropo_pyaps3.py -h
             solid_earth_tides.py -h
 
@@ -55,25 +49,25 @@ jobs:
             ${MINTPY_HOME}/tests/dem_error.py
 
       - run:
-          name: Workflow Test 1/4 - FernandinaSenDT128 (ISCE/topsStack)
+          name: Integration Test 1/4 - FernandinaSenDT128 (ISCE/topsStack)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
 
       - run:
-          name: Workflow Test 2/4 - SanFranSenDT42 (ARIA)
+          name: Integration Test 2/4 - SanFranSenDT42 (ARIA)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
 
       - run:
-          name: Workflow Test 3/4 - WellsEnvD2T399 (Gamma)
+          name: Integration Test 3/4 - WellsEnvD2T399 (Gamma)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
 
       - run:
-          name: Workflow Test 4/4 - WCapeSenAT29 (SNAP)
+          name: Integration Test 4/4 - WCapeSenAT29 (SNAP)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29


### PR DESCRIPTION
**Description of proposed changes**

+ `.circleci/config.yml`: use mambaforge to replace miniconda3 for conda env installation with 2X speedup (48s to 22s)

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2060/workflows/184ca1f4-d2dc-4d5d-9b0a-f2d61a7d16b3/jobs/2064) (green)