### PR TITLE
resample: refactor default output step size calculation

### DIFF
--- a/docs/api/module_hierarchy.md
+++ b/docs/api/module_hierarchy.md
@@ -42,7 +42,7 @@ Hierarchy of sub-modules within MintPy. Level _N_ modules depends on level _N-1_
         s1_utils      (objects/{stack}, utils/{ptime, time_func})
 ------------------ level 3 --------------------
     /objects
-        resample      (utils/{utils0, ptime, readfile})
+        resample      (utils/{utils0, ptime, readfile}, constants)
         coord         (constants, utils/{utils0, utils1, readfile})
     /simulation
         iono          (utils/{utils0, readfile})

--- a/src/mintpy/cli/geocode.py
+++ b/src/mintpy/cli/geocode.py
@@ -81,7 +81,7 @@ def create_parser(subparsers=None):
     interp.add_argument('-i', '--interp', dest='interpMethod', default='nearest', choices={'nearest', 'linear'},
                         help='interpolation/resampling method (default: %(default)s).')
     interp.add_argument('--fill', dest='fillValue', type=float, default=math.nan,
-                        help='Fill value for extrapolation (default: %(default)s).')
+                        help='Fill value for extrapolation (default: %(default)s or 0 for *.int/unw files).')
     interp.add_argument('-n','--nprocs', dest='nprocs', type=int, default=1,
                         help='number of processors to be used for calculation (default: %(default)s).\n'
                              'Note: Do not use more processes than available processor cores.')
@@ -108,6 +108,11 @@ def cmd_line_parse(iargs=None):
 
     # import
     from mintpy.utils import readfile, utils as ut
+
+    # save argv (to check the manually specified arguments)
+    # use iargs        for python call
+    # use sys.argv[1:] for command line call
+    inps.argv = iargs if iargs else sys.argv[1:]
 
     # check
     if inps.templateFile:
@@ -168,6 +173,11 @@ def cmd_line_parse(iargs=None):
         if inps.software == 'scipy':
             print('ERROR: "--geo2radar" is NOT supported for "--software scipy"!')
             sys.exit(0)
+
+    # default: --fill (set default to zero for .int/unw file)
+    fext = os.path.splitext(inps.file[0])[1]
+    if '--fill' not in inps.argv and fext in ['.int', '.unw']:
+        inps.fillValue = 0
 
     return inps
 

--- a/src/mintpy/objects/progress.py
+++ b/src/mintpy/objects/progress.py
@@ -36,7 +36,7 @@ class FileProgressObject(io.FileIO):
 
     def read(self, size):
         perc = self.tell() / self._total_size * 100
-        msg = f"extracting: {self.tell()/(1024**2):.1f} of {self._total_size/(1024**2):.1f} MB - {perc:.0f}%"
+        msg = f"extracting: {self.tell()/(1024**2):.0f} of {self._total_size/(1024**2):.0f} MB - {perc:.0f}%"
         sys.stdout.write("\r" + msg)
         sys.stdout.flush()
         return io.FileIO.read(self, size)

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -24,9 +24,9 @@ import h5py
 import numpy as np
 
 # global variables
-SPEED_OF_LIGHT = 299792458 # m/s
-EARTH_RADIUS = 6371e3      # Earth radius in meters
-K = 40.31                  # m^3/s^2, constant
+SPEED_OF_LIGHT = 299792458  # m/s
+EARTH_RADIUS = 6371.0088e3  # Earth radius in meters
+K = 40.31                   # m^3/s^2, constant
 
 
 #################################### InSAR ##########################################
@@ -125,7 +125,7 @@ def incidence_angle(atr, dem=None, dimension=2, print_msg=True):
     # Read Attributes
     range_n = float(atr['STARTING_RANGE'])
     dR = float(atr['RANGE_PIXEL_SIZE'])
-    r = float(atr['EARTH_RADIUS'])
+    r = float(atr.get('EARTH_RADIUS', EARTH_RADIUS))
     H = float(atr['HEIGHT'])
     width = int(atr['WIDTH'])
 
@@ -226,47 +226,6 @@ def azimuth_ground_resolution(atr):
         az_step = float(atr['AZIMUTH_PIXEL_SIZE'])
 
     return az_step
-
-
-def auto_lat_lon_step_size(atr, lat_c=None):
-    """Get the default lat/lon step size for geocoding.
-
-    Treat the pixel in radar coordinates as an rotated rectangle. Use the bounding box
-    of the rotated rectangle for the ratio between lat and lon steps. Then scale the
-    lat and lon step size to ensure the same area between the pixels in radar and geo
-    coordinates.
-
-    Link: https://math.stackexchange.com/questions/4001034
-
-    Parameters: atr      - dict, standard mintpy metadata
-                lat_c    - float, central latitude in degree
-    Returns:    lat_step - float, latitude  step size in degree
-                lon_step - float, longitude step size in degree
-    """
-    # azimuth angle (rotation angle) in radian
-    az_angle = np.deg2rad(abs(heading2azimuth_angle(float(atr['HEADING']))))
-
-    # radar pixel size in meter
-    az_step = azimuth_ground_resolution(atr)
-    rg_step = range_ground_resolution(atr)
-
-    # geo pixel size in meter
-    x_step = rg_step * abs(np.cos(az_angle)) + az_step * abs(np.sin(az_angle))
-    y_step = rg_step * abs(np.sin(az_angle)) + az_step * abs(np.cos(az_angle))
-    scale_factor = np.sqrt((rg_step * az_step) / (x_step * y_step))
-    x_step *= scale_factor
-    y_step *= scale_factor
-
-    # geo pixel size in degree
-    if lat_c is None:
-        if 'LAT_REF1' in atr.keys():
-            lat_c = (float(atr['LAT_REF1']) + float(atr['LAT_REF3'])) / 2.
-        else:
-            lat_c = 0
-    lon_step = np.rad2deg(x_step / (EARTH_RADIUS * np.cos(np.deg2rad(lat_c))))
-    lat_step = np.rad2deg(y_step / EARTH_RADIUS) * -1.
-
-    return lat_step, lon_step
 
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ rename utils.utils0.auto_lat_lon_step_size() to objects.resample.resample.get_lat_lon_step()
   - move the location because this function is only used in the resample code so far
   - add the user-specified lalo_step code body into this function, for a more simple `prepare_geometry_definition_radar()`
   - replace try/except with if/else and explicit required metadata checking and warning msg

+ objects.resample.resample.prepare_geometry_definition_radar.find_valid_lat_lon():
   - rename mark_lat_lon_anomaly() to find_valid_lat_lon()
   - add more comments on the input/output args

+ cli.geocode: set default fillValue to zero for .int/unw files, to be consistent with isce/roipac.

+ docs/api/module_hierarchy.md: update for objects.resample.py

+ objects.progress.FileProgressObject(): display in int MB to be simple

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2069/workflows/b130cbac-2298-4c43-8012-3c75c67de983/jobs/2073) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.