### PR TITLE
`isce_utils.get_processor()`: use `*.track.xml` file to identify `alosStack/2App`

### DIFF
--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -285,22 +285,22 @@ The corresponding template options for `load_data`:
 
 ```cfg
 mintpy.load.processor        = isce
-##NOTE: 150408 is the reference date of alosStack processing.
-##      (parameter "reference date of the stack" of alosStack input xml file)
+## NOTE: 150408 is the reference date of alosStack processing.
+##       (parameter "reference date of the stack" of alosStack input xml file)
 ##---------for ISCE only:
-mintpy.load.metaFile         = $DATA_DIR/NCalAlos2DT169/pairs/*-*/150408.track.xml
+mintpy.load.metaFile         = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/150408.track.xml
 mintpy.load.baselineDir      = $DATA_DIR/NCalAlos2DT169/baseline
 ##---------interferogram datasets:
 mintpy.load.unwFile          = $DATA_DIR/NCalAlos2DT169/pairs/*-*/insar/filt_*-*_5rlks_28alks.unw
 mintpy.load.corFile          = $DATA_DIR/NCalAlos2DT169/pairs/*-*/insar/*-*_5rlks_28alks.cor
 mintpy.load.connCompFile     = $DATA_DIR/NCalAlos2DT169/pairs/*-*/insar/filt_*-*_5rlks_28alks.unw.conncomp
 ##---------geometry datasets:
-mintpy.load.demFile          = $DATA_DIR/NCalAlos2DT169/dates_resampled/150408/insar/*_5rlks_28alks.hgt
-mintpy.load.lookupYFile      = $DATA_DIR/NCalAlos2DT169/dates_resampled/150408/insar/*_5rlks_28alks.lat
-mintpy.load.lookupXFile      = $DATA_DIR/NCalAlos2DT169/dates_resampled/150408/insar/*_5rlks_28alks.lon
-mintpy.load.incAngleFile     = $DATA_DIR/NCalAlos2DT169/dates_resampled/150408/insar/*_5rlks_28alks.los
-mintpy.load.azAngleFile      = $DATA_DIR/NCalAlos2DT169/dates_resampled/150408/insar/*_5rlks_28alks.los
-mintpy.load.waterMaskFile    = $DATA_DIR/NCalAlos2DT169/dates_resampled/150408/insar/*_5rlks_28alks.wbd
+mintpy.load.demFile          = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/insar/*_5rlks_28alks.hgt
+mintpy.load.lookupYFile      = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/insar/*_5rlks_28alks.lat
+mintpy.load.lookupXFile      = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/insar/*_5rlks_28alks.lon
+mintpy.load.incAngleFile     = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/insar/*_5rlks_28alks.los
+mintpy.load.azAngleFile      = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/insar/*_5rlks_28alks.los
+mintpy.load.waterMaskFile    = $DATA_DIR/NCalAlos2DT169/dates_res*/150408/insar/*_5rlks_28alks.wbd
 ```
 
 ### ARIA from [ARIA-tools](https://github.com/aria-tools/ARIA-tools) ###

--- a/src/mintpy/cli/multilook.py
+++ b/src/mintpy/cli/multilook.py
@@ -14,9 +14,12 @@ from mintpy.utils.arg_utils import create_argument_parser
 EXAMPLE = """example:
   multilook.py velocity.h5 -r 15 -a 15
   multilook.py srtm30m.dem -x 10 -y 10 -o srtm300m.dem
+  multilook.py filt_fine.int -r 2 -a 2 -o filt_fine_mli.int
+
+  # support GDAL VRT file from ISCE2 as input
   multilook.py lat.rdr.full.vrt lon.rdr.full.vrt -x 9 -y 3
 
-  # generate multilooked lookup table (lat/lon.rdr) for dense offsets
+  # --off-file option: use as reference to adjust for the irregular size from isce2 dense offsets
   multilook.py lat.rdr.full.vrt -x 128 -y 64 -o lat.rdr.mli --off-file dense_offsets.bil
   multilook.py ../../geom_reference/lat.rdr.full -x 300 -y 100 -o lat.rdr --off-file offset.bip
 """


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.isce_utils`:
    - `get_processor()`: use `*.track.xml` file to identify the isce2 sub-type processor of alosStack or alos2App.
    - `get_full_resolution()`: account for A/RLOOKS while calculating the full resolution size.
    - the above two changes allow the multilook number and resolution conversion for alosStack and alos2App (https://github.com/insarlab/MintPy-tutorial/tree/main/applications/calc_multilook_number.ipynb).

+ `docs/dir_structure`: shorten template input for alosStack

+ cli.multilook.py: update example usage for clarity

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2080/workflows/063c161a-8d93-4595-a0eb-dafedfdea9ca/jobs/2085) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.