### PR TITLE
`timeseries2velocity`: add `--polyline` option

### DIFF
--- a/src/mintpy/cli/timeseries2velocity.py
+++ b/src/mintpy/cli/timeseries2velocity.py
@@ -160,7 +160,7 @@ def cmd_line_parse(iargs=None):
     if inps.polynomial < 0:
         raise ValueError(f'--polynomial ({inps.polynomial}) can NOT be smaller than zero!')
     if inps.polyline and inps.polynomial == 0:
-        raise ValueError(f'--polyline is NOT supported when --polynomial is zero!')
+        raise ValueError('--polyline is NOT supported when --polynomial is zero!')
 
     # default: sort --step / --polyline option
     inps.stepDate = sorted(inps.stepDate)

--- a/src/mintpy/cli/timeseries2velocity.py
+++ b/src/mintpy/cli/timeseries2velocity.py
@@ -33,6 +33,7 @@ EXAMPLE = """example:
   timeseries2velocity.py timeseries_ERA5_demErr.h5 --poly 1 --exp 20170910 90
   timeseries2velocity.py timeseries_ERA5_demErr.h5 --poly 1 --log 20170910 60.4
   timeseries2velocity.py timeseries_ERA5_demErr.h5 --poly 1 --log 20170910 60.4 200 --log 20171026 200.7
+  timeseries2velocity.py timeseries_ERA5_demErr.h5 --poly 1 --polyline 20190101 20200501
 
   # uncertainty quantification of the estimated time functions
   timeseries2velocity.py timeseries_ERA5_demErr.h5 --uq residue
@@ -154,6 +155,16 @@ def cmd_line_parse(iargs=None):
             inps.ref_yx = [ref_y, ref_x]
             print(f'input reference point in (lat, lon): ({inps.ref_lalo[0]}, {inps.ref_lalo[1]})')
             print(f'corresponding   point in (y, x): ({inps.ref_yx[0]}, {inps.ref_yx[1]})')
+
+    # check: --poly-order / --polyline option
+    if inps.polynomial < 0:
+        raise ValueError(f'--polynomial ({inps.polynomial}) can NOT be smaller than zero!')
+    if inps.polyline and inps.polynomial == 0:
+        raise ValueError(f'--polyline is NOT supported when --polynomial is zero!')
+
+    # default: sort --step / --polyline option
+    inps.stepDate = sorted(inps.stepDate)
+    inps.polyline = sorted(inps.polyline)
 
     # default: --output option
     if not inps.outfile:

--- a/src/mintpy/cli/tsview.py
+++ b/src/mintpy/cli/tsview.py
@@ -155,11 +155,6 @@ def cmd_line_parse(iargs=None):
             msg += 'Ignore it and continue'
             print(msg)
 
-    # check: --noverbose option
-    # print tsview.py command line if --noverbose
-    if not inps.print_msg:
-        print('tsview.py', ' '.join(inps.argv))
-
     # default: -u / -c / --fig-size options
     inps.disp_unit = inps.disp_unit if inps.disp_unit else 'cm'
     inps.colormap = inps.colormap if inps.colormap else 'jet'

--- a/src/mintpy/simulation/iono.py
+++ b/src/mintpy/simulation/iono.py
@@ -223,6 +223,9 @@ def lalo_ground2iono(lat, lon, inc_angle, az_angle=None, head_angle=None, iono_h
     if az_angle is None:
         raise ValueError('az_angle can not be None!')
 
+    # In spherical coordinate system, given the starting lat/lon, angular distance and azimuth angle
+    #   calculate the ending lat/lon.
+    #
     # option 1 - spherical_distance
     # link:
     #   https://gis.stackexchange.com/questions/5821 [there is a typo there]

--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -616,17 +616,17 @@ def save_ts_data_and_plot(yx, d_ts, m_strs, inps):
 
     # write
     np.savetxt(outName, data, fmt='%s', delimiter='\t', header=header)
-    vprint('save displacement time-series to file: '+outName)
+    print('save displacement time-series to file: '+outName)
 
     # Figure - point time-series
     outName = f'{inps.outfile_base}_ts.pdf'
     inps.fig_pts.savefig(outName, bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-    vprint('save time-series plot to file: '+outName)
+    print('save time-series plot to file: '+outName)
 
     # Figure - map
     outName = f'{inps.outfile_base}_{inps.date_list[inps.idx]}.png'
     inps.fig_img.savefig(outName, bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-    vprint('save map plot to file: '+outName)
+    print('save map plot to file: '+outName)
     return
 
 

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -155,8 +155,11 @@ def add_figure_argument(parser):
     # colorbar
     fig.add_argument('--nocbar', '--nocolorbar', dest='disp_cbar',
                      action='store_false', help='do not display colorbar')
-    fig.add_argument('--cbar-nbins', dest='cbar_nbins', metavar='NUM',
-                     type=int, help='number of bins for colorbar.')
+    tik = fig.add_mutually_exclusive_group(required=False)
+    tik.add_argument('--cbar-nbins', dest='cbar_nbins', metavar='NUM', type=int,
+                     help='number of bins for colorbar.')
+    tik.add_argument('--cbar-ticks', dest='cbar_ticks', nargs='+', metavar='NUM', type=float,
+                     help='colorbar ticks.')
     fig.add_argument('--cbar-ext', dest='cbar_ext', default=None,
                      choices={'neither', 'min', 'max', 'both', None},
                      help='Extend setting of colorbar; based on data stat by default.')
@@ -437,6 +440,11 @@ def add_timefunc_argument(parser):
                        help='step function(s) at YYYYMMDD (default: %(default)s). E.g.:\n'
                             '--step 20061014                        # coseismic step  at 2006-10-14T00:00\n'
                             '--step 20110311 20120928T1733          # coseismic steps at 2011-03-11T00:00 and 2012-09-28T17:33\n')
+
+    model.add_argument('--polyline', dest='polyline', type=str, nargs='+', default=[],
+                       help='polyline segment(s) starting at YYYYMMDD (default: %(default)s). E.g.:\n'
+                            '--polyline 20190101                    # extra velocity   since 2019-01-01T00:00\n'
+                            '--polyline 20190101 20200501T1725      # extra velocities since 2019-01-01T00:00 and 2020-05-01T17:25\n')
 
     model.add_argument('--exp', '--exponential', dest='exp', type=str, nargs='+', action='append', default=[],
                        help='exponential function(s) defined by onset time(s) and characteristic time(s) tau in days (default: %(default)s). E.g.:\n'

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1408,6 +1408,8 @@ def plot_colorbar(inps, im, cax):
         else:
             cbar.locator = ticker.MaxNLocator(nbins=inps.cbar_nbins)
             cbar.update_ticks()
+    elif inps.cbar_ticks:
+        cbar.set_ticks(inps.cbar_ticks)
 
     cbar.ax.tick_params(which='both', direction='out', labelsize=inps.font_size, colors=inps.font_color)
 

--- a/src/mintpy/utils/ptime.py
+++ b/src/mintpy/utils/ptime.py
@@ -419,41 +419,53 @@ def get_exclude_date_list(date_list, start_date=None, end_date=None, exclude_dat
 
 
 ################################################################
-def date_list2tbase(date_list):
+def date_list2tbase(date_list, ref_date=None):
     """Get temporal Baseline in days with respect to the 1st date
-    Parameters: date_list - list of string, date in YYYYMMDD or YYMMDD format
-    Returns:    tbase     - list of int, temporal baseline in days
+    Parameters: date_list - list(str), date in YYYYMMDD or YYMMDD format
+                ref_date  - str, reference date in YYYYMMDD format
+    Returns:    tbase     - list(int), temporal baseline in days
                 dateDict  - dict with key   - string, date in YYYYMMDD format
                                       value - int, temporal baseline in days
     """
-    # date str to dt object
     date_list = yyyymmdd(date_list)
-    date_format = get_date_str_format(str(date_list))
-    dates = [dt.datetime.strptime(i, date_format) for i in date_list]
+    ref_date = ref_date if ref_date else date_list[0]
+    ref_date = yyyymmdd(ref_date)
 
-    # dt object to time difference in days
+    # date str to dt object
+    dt_fmt = get_date_str_format(str(date_list))
+    dt_list = [dt.datetime.strptime(i, dt_fmt) for i in date_list]
+    ref_dt = dt.datetime.strptime(ref_date, get_date_str_format(ref_date))
+
+    # list: dt object to time difference in days
     tbase = []
-    for date in dates:
-        date_delta = date - dates[0]
-        tbase_i = date_delta.days + date_delta.seconds / (24 * 60 * 60)
-        tbase.append(tbase_i)
+    for dt_i in dt_list:
+        delta_dt = dt_i - ref_dt
+        tbase.append(delta_dt.days + delta_dt.seconds / (24 * 60 * 60))
 
-    # Dictionary: key - date, value - temporal baseline
+    # dict: key - date, value - temporal baseline
     dateDict = {}
     for i, date_str in enumerate(date_list):
         dateDict[date_str] = tbase[i]
     return tbase, dateDict
 
 
-def date_list2vector(date_list):
+def date_list2vector(date_list, seconds=0):
     """Get time in datetime format: datetime.datetime(2006, 5, 26, 0, 0)
+
     Parameters: date_list  - list of string, date in YYYYMMDD or YYMMDD format
+                seconds    - float, float or str, acquisition time of the day info in seconds.
     Returns:    dates      - list of datetime.datetime objects, i.e. datetime.datetime(2010, 10, 20, 0, 0)
                 datevector - list of float, years, i.e. 2010.8020547945205
     """
     date_list = yyyymmdd(date_list)
     date_format = get_date_str_format(str(date_list))
     dates = [dt.datetime.strptime(i, date_format) for i in date_list]
+
+    # add time of the day info if:
+    # 1) seconds arg is valid AND
+    # 2) no time info from dates arg
+    if seconds and 'T' not in date_format:
+        dates = [x + dt.timedelta(seconds=float(seconds)) for x in dates]
 
     # date in year - float format
     datevector = []

--- a/src/mintpy/utils/time_func.py
+++ b/src/mintpy/utils/time_func.py
@@ -15,8 +15,9 @@ from mintpy.utils import ptime
 MODEL_EXAMPLE = """time function configuration:
     model = {
         'polynomial' : 2,                    # int, polynomial degree with 1 (linear), 2 (quadratic), 3 (cubic), etc.
-        'periodic'   : [1.0, 0.5],           # list of float, period(s) in years. 1.0 (annual), 0.5 (semiannual), etc.
-        'stepDate'   : ['20061014'],         # list of str, date(s) in YYYYMMDD.
+        'periodic'   : [1.0, 0.5],           # list(float), period(s) in years. 1.0 (annual), 0.5 (semiannual), etc.
+        'stepDate'   : ['20061014'],         # list(str), date(s) for the onset of step in YYYYMMDD.
+        'polyline'   : ['20190101'],         # list(str), date(s) for the onset of extra line segments in YYYYMMDD.
         'exp'        : {'20181026': [60],    # dict, key for onset time in YYYYMMDD(THHMM) and value for char times in integer days.
                         ...
                         },
@@ -77,6 +78,7 @@ def inps2model(inps, date_list=None, print_msg=True):
                                 polynomial=1,
                                 periodic=[1.0, 0.5],
                                 stepDate=['20110311', '20120928T1733'],
+                                polyline=['20190101'],
                                 exp=[['20170910', '60', '200'], ['20171026', '200']],
                                 log=[['20170910', '60', '200'], ['20171026', '200']],
                             )
@@ -99,6 +101,7 @@ def inps2model(inps, date_list=None, print_msg=True):
     model['polynomial'] = inps.polynomial
     model['periodic']   = inps.periodic
     model['stepDate']   = inps.stepDate
+    model['polyline']   = inps.polyline
 
     if inps.periodic:
         # check 1 - positive value
@@ -110,6 +113,12 @@ def inps2model(inps, date_list=None, print_msg=True):
         for d_step in inps.stepDate:
             if not (ymin < ptime.yyyymmdd2years(d_step) < ymax):
                 raise ValueError(f'input step date ({d_step}) exceeds date limit: ({dmin} / {dmax})!')
+
+    if inps.polyline:
+        # check 1 - min/max limit
+        for d_start in inps.polyline:
+            if not (ymin < ptime.yyyymmdd2years(d_start) < ymax):
+                raise ValueError(f'input step date ({d_start}) exceeds date limit: ({dmin} / {dmax})!')
 
     for func_name, strs_list in zip(['exp', 'log'], [inps.exp, inps.log]):
         func_dict = dict()
@@ -179,6 +188,7 @@ def get_num_param(model):
         model['polynomial'] + 1
         + len(model['periodic']) * 2
         + len(model['stepDate'])
+        + len(model['polyline'])
         + sum(len(val) for key, val in model['exp'].items())
         + sum(len(val) for key, val in model['log'].items())
     )
@@ -190,11 +200,12 @@ def get_num_param(model):
 
 def get_design_matrix4time_func(date_list, model=None, ref_date=None, seconds=0):
     """Design matrix (function model) for time functions parameter estimation.
+
     Parameters: date_list - list of str in YYYYMMDD format, size=num_date
                 model     - dict of time functions, e.g. {cfg}
                 ref_date  - reference date from date_list
                 seconds   - float or str, acquisition time of the day info in seconds.
-    Returns:    A         - 2D array of design matrix in size of (num_date, num_param)
+    Returns:    A         - 2D np.ndarray of design matrix in size of (num_date, num_param)
                             num_param = (poly_deg + 1) + 2*len(periodic) + len(steps) + len(exp_taus) + len(log_taus)
     """.format(cfg=MODEL_EXAMPLE)
 
@@ -216,14 +227,16 @@ def get_design_matrix4time_func(date_list, model=None, ref_date=None, seconds=0)
     poly_deg   = model.get('polynomial', 0)
     periods    = model.get('periodic', [])
     steps      = model.get('stepDate', [])
+    polylines  = model.get('polyline', [])
     exps       = model.get('exp', dict())
     logs       = model.get('log', dict())
     num_period = len(periods)
     num_step   = len(steps)
+    num_pline  = len(polylines)
     num_exp    = sum(len(val) for key, val in exps.items())
     num_log    = sum(len(val) for key, val in logs.items())
 
-    num_param = (poly_deg + 1) + (2 * num_period) + num_step + num_exp + num_log
+    num_param = (poly_deg + 1) + (2 * num_period) + num_step + num_pline + num_exp + num_log
     if num_param <= 1:
         raise ValueError('NO time functions specified!')
 
@@ -250,6 +263,12 @@ def get_design_matrix4time_func(date_list, model=None, ref_date=None, seconds=0)
     if num_step > 0:
         c1 = c0 + num_step
         A[:, c0:c1] = get_design_matrix4step_func(date_list, steps, seconds=seconds)
+        c0 = c1
+
+    # update polyline term(s)
+    if num_pline > 0:
+        c1 = c0 + num_pline
+        A[:, c0:c1] = get_design_matrix4polyline(date_list, polylines, seconds=seconds)
         c0 = c1
 
     # update exponential term(s)
@@ -279,9 +298,9 @@ def get_design_matrix4polynomial_func(yr_diff, degree):
         k=2 makes c2 the acceleration;
         k=3 makes c3 the acceleration rate;
 
-    Parameters: yr_diff: time difference from ref_date in decimal years
-                degree : polynomial models: 0=offset, 1=linear, 2=quadratic, 3=cubic, etc.
-    Returns:    A      : 2D array of poly-coeff. in size of (num_date, degree+1)
+    Parameters: yr_diff - time difference from ref_date in decimal years
+                degree  - polynomial models: 0=offset, 1=linear, 2=quadratic, 3=cubic, etc.
+    Returns:    A       - 2D np.ndarray of poly-coeff. in size of (num_date, degree+1)
     """
     A = np.zeros([len(yr_diff), degree + 1], dtype=np.float32)
     for i in range(degree+1):
@@ -291,10 +310,11 @@ def get_design_matrix4polynomial_func(yr_diff, degree):
 
 
 def get_design_matrix4periodic_func(yr_diff, periods):
-    """design matrix/function model of periodic velocity estimation
-    Parameters: yr_diff : 1D array of time difference from ref_date in decimal years
-                periods : list of period in years: 1=annual, 0.5=semiannual, etc.
-    Returns:    A       : 2D array of periodic sine & cosine coeff. in size of (num_date, 2*num_period)
+    """design matrix/function model of periodic velocity estimation.
+
+    Parameters: yr_diff - 1D array of time difference from ref_date in decimal years
+                periods - list of period in years: 1=annual, 0.5=semiannual, etc.
+    Returns:    A       - 2D np.ndarray of periodic sine & cosine coeff. in size of (num_date, 2*num_period)
     """
     num_date = len(yr_diff)
     num_period = len(periods)
@@ -309,10 +329,11 @@ def get_design_matrix4periodic_func(yr_diff, periods):
 
 
 def get_design_matrix4step_func(date_list, step_date_list, seconds=0):
-    """design matrix/function model of coseismic velocity estimation
-    Parameters: date_list      : list of dates in YYYYMMDD format
-                step_date_list : Heaviside step function(s) with date in YYYYMMDD
-    Returns:    A              : 2D array of zeros & ones in size of (num_date, num_step)
+    """design matrix/function model of coseismic velocity estimation.
+
+    Parameters: date_list      - list of dates in YYYYMMDD format
+                step_date_list - Heaviside step function(s) with date in YYYYMMDD
+    Returns:    A              - 2D np.ndarray of 1 & 0 in size of (num_date, num_step)
     """
     num_date = len(date_list)
     num_step = len(step_date_list)
@@ -322,6 +343,35 @@ def get_design_matrix4step_func(date_list, step_date_list, seconds=0):
     t_steps = ptime.yyyymmdd2years(step_date_list)
     for i, t_step in enumerate(t_steps):
         A[:, i] = np.array(t > t_step).flatten()
+
+    return A
+
+
+def get_design_matrix4polyline(date_list, start_date_list, seconds=0):
+    """design matrix/function model of polyline (polygonal chain)
+
+    The polyline can be described as:
+    d = c + v * t,                                   for t <= t1
+      =     ...     + p1 * (t - t1),                 for t1 < t <= t2
+      =     ...     +      ...      + p2 * (t - t2), for t2 < t ...
+      ...
+
+    Parameters: date_list       - list of dates in YYYYMMDD format
+                start_date_list - str, start date(s) for extra line segments in YYYYMMDD format
+    Returns:    A               - 2D np.ndarray in size of (num_date, 3)
+    """
+    # str --> float in years
+    t = np.array(ptime.yyyymmdd2years(date_list, seconds=seconds))
+    t_start_list = ptime.yyyymmdd2years(start_date_list)
+
+    # construct the design matrix
+    num_date = len(t)
+    num_start = len(t_start_list)
+    A = np.zeros((num_date, num_start), dtype=np.float32)
+    for i, t_start in enumerate(t_start_list):
+        tbase = t - t_start
+        tbase[tbase < 0] = 0
+        A[:, i] = tbase
 
     return A
 
@@ -340,15 +390,15 @@ def get_design_matrix4exp_func(date_list, exp_dict, seconds=0):
         tau_i       char time      of i-th exp term (relaxation time)
         H(t-T_i)    Heaviside func of i-th exp term (ensuring the exp func is one-sided)
 
-    Parameters: date_list      : list of dates in YYYYMMDD format
-                exp_dict       : dict of exp func(s) info as:
-                                 {{onset_time1} : [{char_time11,...,char_time1N}],
-                                  {onset_time2} : [{char_time21,...,char_time2N}],
-                                  ...
-                                  }
-                                 where onset_time is string  in YYYYMMDD format and
-                                       char_time  is float32 in decimal days
-    Returns:    A              : 2D array of zeros & ones in size of (num_date, num_exp)
+    Parameters: date_list - list of dates in YYYYMMDD format
+                exp_dict  - dict of exp func(s) info as:
+                            {{onset_time1} : [{char_time11,...,char_time1N}],
+                             {onset_time2} : [{char_time21,...,char_time2N}],
+                             ...
+                             }
+                            where onset_time is string  in YYYYMMDD format and
+                                  char_time  is float32 in decimal days
+    Returns:    A         - 2D np.ndarray of zeros & ones in size of (num_date, num_exp)
     """
     num_date = len(date_list)
     num_exp  = sum(len(val) for key, val in exp_dict.items())
@@ -385,15 +435,15 @@ def get_design_matrix4log_func(date_list, log_dict, seconds=0):
         tau_i       char time      of i-th log term (relaxation time)
         H(t-T_i)    Heaviside func of i-th log term (ensuring the log func is one-sided)
 
-    Parameters: date_list      : list of dates in YYYYMMDD format
-                log_dict       : dict of log func(s) info as:
-                                 {{onset_time1} : [{char_time11,...,char_time1N}],
-                                  {onset_time2} : [{char_time21,...,char_time2N}],
-                                  ...
-                                  }
-                                 where onset_time is string  in YYYYMMDD format and
-                                       char_time  is float32 in decimal days
-    Returns:    A              : 2D array of zeros & ones in size of (num_date, num_log)
+    Parameters: date_list - list of dates in YYYYMMDD format
+                log_dict  - dict of log func(s) info as:
+                            {{onset_time1} : [{char_time11,...,char_time1N}],
+                             {onset_time2} : [{char_time21,...,char_time2N}],
+                             ...
+                             }
+                            where onset_time is string  in YYYYMMDD format and
+                                  char_time  is float32 in decimal days
+    Returns:    A         - 2D np.ndarray of zeros & ones in size of (num_date, num_log)
     """
     num_date = len(date_list)
     num_log  = sum(len(log_dict[x]) for x in log_dict)
@@ -412,7 +462,11 @@ def get_design_matrix4log_func(date_list, log_dict, seconds=0):
             log_tau /= 365.25
 
             olderr = np.seterr(invalid='ignore', divide='ignore')
-            A[:, i] = np.array(t > log_T).flatten() * np.nan_to_num(np.log(1 + (t - log_T) / log_tau), nan=0, neginf=0)
+            A[:, i] = np.array(t > log_T).flatten() * np.nan_to_num(
+                np.log(1 + (t - log_T) / log_tau),
+                nan=0,
+                neginf=0,
+            )
             np.seterr(**olderr)
             i += 1
 

--- a/src/mintpy/utils/time_func.py
+++ b/src/mintpy/utils/time_func.py
@@ -118,7 +118,7 @@ def inps2model(inps, date_list=None, print_msg=True):
         # check 1 - min/max limit
         for d_start in inps.polyline:
             if not (ymin < ptime.yyyymmdd2years(d_start) < ymax):
-                raise ValueError(f'input step date ({d_start}) exceeds date limit: ({dmin} / {dmax})!')
+                raise ValueError(f'input polyline date ({d_start}) exceeds date limit: ({dmin} / {dmax})!')
 
     for func_name, strs_list in zip(['exp', 'log'], [inps.exp, inps.log]):
         func_dict = dict()


### PR DESCRIPTION
**Description of proposed changes**

This PR add the `timeseries2velocity.py --polyline` option (and for `tsview.py` as well). Given one or multiple dates, this option will estimate an additional linear slope starting from the specified date, to catch the linear velocity change of a time-series. The result is saved in the velocity.h5 file as a dataset named `velocityPost{YYYYMMDD}`, which is the linear velocity during this segment time period, i.e. the sum of the velocity for the entire period (from the regular polynomial fitting), plus all the additional velocity change before & during the current segment periods.

Detailed changes are as below:

+ `utils.time_func`: construct a design matrix for polyline fitting with the manually specified starting date for each additional line segment

+ `utils.arg_utils.add_timefunc_argument()`: add `--polyline` option

+ `timeseries2velocity`:
   - `model2hdf5_dataset()`: support the polyline function and save the total/cumulative velocity for each polyline segment for easy visualization and interpretation.
   - check input `--polynomial` and `--polyline` options

+ `cli.timeseries2velocity`: add example usage

@yuankailiu I would appreciate it if you could take a look at these changes above when you got a chance?

Other changes not relevant to `--polyline`:

+ `utils.ptime`:
   - `date_list2tbase()`: add `ref_date` arg
   - `date_list2vector()`: add `seconds` arg

+ `utils.arg_utils.add_figure_argument()`: add `--cbar-ticks` option for accurate control on the colorbar tick positions.

+ `simulation.iono.lalo_ground2iono()`: more comments

+ `tsview`: printout msg minor adjustment
   - remove redundant print cmd. Now the tsview cmd msg will always be printed out.
   - always printout the save fig/txt file info, as it's very informative

+ `objects.gps`: change the default folder to store the site list file from `./` to `./GPS`.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2091/workflows/7cc1e074-2b09-4cf2-a5ff-ddddded9faa7/jobs/2096) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.