### PR TITLE
mask: replace --threshold with --vmin/vmax

### DIFF
--- a/src/mintpy/cli/mask.py
+++ b/src/mintpy/cli/mask.py
@@ -13,9 +13,9 @@ from mintpy.utils.arg_utils import create_argument_parser
 
 ############################################################
 EXAMPLE = """example:
-  mask.py  velocity.h5     -m Mask.h5
-  mask.py  timeseries.h5   -m temporalCoherence.h5  -t 0.7
-  mask.py  ifgramStack.h5  -m 100102_101120.cor     -t 0.9  -y  200 300  -x 300 400
+  mask.py  velocity.h5     -m maskTempCoh.h5
+  mask.py  timeseries.h5   -m temporalCoherence.h5  --vmin 0.7
+  mask.py  ifgramStack.h5  -m 100102_101120.cor     --vmin 0.9  -y  200 300  -x 300 400
 
   mask.py  filt_20060924_20090214.int -m waterMask.h5 -o filt_20060924_20090214_msk.int
   mask.py  filt_20060924_20090214.cor -m waterMask.h5 -o filt_20060924_20090214_msk.cor
@@ -30,21 +30,23 @@ def create_parser(subparsers=None):
 
     parser.add_argument('file', help='File to be masked')
     parser.add_argument('-m', '--mask', dest='mask_file', required=True,
-                        help='mask for pixels used in ramp estimation')
+                        help='mask out pixels with mask value == 0.')
     parser.add_argument('-o', '--outfile', help='Output file name.')
 
     # modify input mask
-    parser.add_argument('-t', dest='threshold', type=float,
-                        help='threshold value used for masking.\n' +
-                        'if not specified, only pixels with mask value equal to zero is masked out.')
-    parser.add_argument('--fill', dest='fill_value', type=float, default=math.nan,
-                        help="fill masked out area with input value. i.e. \n"
-                             "np.nan (default), 0, 1000, ... \n"
-                             "If np.nan and input data matrix is not float/complex, convert matrix data type to np.float32.")
+    parser.add_argument('--vmin','--mask-vmin', dest='mask_vmin', type=float,
+                        help='mask out pixels with mask value < vmin.')
+    parser.add_argument('--vmax','--mask-vmax', dest='mask_vmax', type=float,
+                        help='mask out pixels with mask value > vmax.')
     parser.add_argument('-x', dest='subset_x', type=int, nargs=2,
                         help='subset range in x/cross-track/column direction')
     parser.add_argument('-y', dest='subset_y', type=int, nargs=2,
                         help='subset range in y/along-track/row direction')
+    parser.add_argument('--fill', dest='fill_value', type=float, default=math.nan,
+                        help='fill masked out area with input value. i.e. \n'
+                             'np.nan (default), 0, 1000, ... \n'
+                             'If np.nan and input data matrix is not float/complex, '
+                             'convert matrix data type to np.float32.')
     return parser
 
 

--- a/src/mintpy/cli/view.py
+++ b/src/mintpy/cli/view.py
@@ -19,9 +19,9 @@ EXAMPLE = """example:
   view.py velocity.h5 velocity --wrap --wrap-range -2 2 -c cmy --lalo-label
   view.py velocity.h5 --ref-yx  210 566                              #change reference pixel for display
   view.py velocity.h5 --sub-lat 31.05 31.10 --sub-lon 130.05 130.10  #subset in lalo / yx
+  view.py velocity.h5 velocity --mask waterBody.h5 --mask-vmax 1
 
   view.py timeseries.h5
-  view.py timeseries.h5 -m no                   #do not use auto mask
   view.py timeseries.h5 --ref-date 20101120     #change reference date
   view.py timeseries.h5 --ex drop_date.txt      #exclude dates to plot
   view.py timeseries.h5 '*2017*' '*2018*'       #all acquisitions in 2017 and 2018
@@ -32,8 +32,6 @@ EXAMPLE = """example:
   view.py ifgramStack.h5 -n 6                   #the 6th slice
   view.py ifgramStack.h5 20171010_20171115      #all data      related with 20171010_20171115
   view.py ifgramStack.h5 'coherence*20171010*'  #all coherence related with 20171010
-  view.py ifgramStack.h5 unwrapPhase-20070927_20100217 --zero-mask --wrap     #wrapped phase
-  view.py ifgramStack.h5 unwrapPhase-20070927_20100217 --mask ifgramStack.h5  #mask using connected components
 
   # GPS (for one subplot in geo-coordinates only)
   view.py geo_velocity_msk.h5 velocity --show-gps --gps-label   #show locations of available GPS

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -28,9 +28,11 @@ class coordinate:
             (bounding) box of points indicate the lat/lon of the pixel UL corner.
 
     Example:
+        from mintpy.utils import readfile, utils as ut
         atr = readfile.read('velocity.h5')
-        coord = ut.coordinate(atr, lookup_file='inputs/geometryRadar.h5')  # for radar coord file
-        coord = ut.coordinate(atr)                                         # for geo   coord file
+        coord = ut.coordinate(atr)                                          # geo coord
+        coord = ut.coordinate(atr, lookup_file='inputs/geometryRadar.h5')   # radar coord
+        coord = ut.coordinate(atr, lookup_file=['lat.rdr', 'lon.rdr'])      # radar coord in isce2 format
         y, x = coord.geo2radar(lat, lon)[0:2]
         lat, lon = coord.radar2geo(y, x)[0:2]
     """
@@ -38,12 +40,10 @@ class coordinate:
     def __init__(self, metadata, lookup_file=None):
         """Define a coordinate object
         Parameters: metadata    - dict, source metadata
-                    lookup_file - list of 2 strings, or string, lookup table file(s)
-        Example:    from mintpy.utils import readfile, utils as ut
-                    atr = readfile.read_attribute('./velocity.h5')
-                    coord = ut.coordinate(atr, './inputs/geometryRadar.h5')
-                    coord.geo2radar(33.450, -90.22)
-                    coord.radar2geo(50, 200)
+                    lookup_file - str / list of 2 str, lookup table file(s)
+                                  'geometryRadar.h5'
+                                  ['lat.rdr', 'lon.rdr']
+        Returns:    mintpy.utils.utils.coordinate object
         """
         self.src_metadata = metadata
         if lookup_file is None:

--- a/src/mintpy/utils/isce_utils.py
+++ b/src/mintpy/utils/isce_utils.py
@@ -1006,7 +1006,7 @@ def unwrap_snaphu(int_file, cor_file, unw_file, defo_max=2.0, max_comp=32,
         cost_mode = 'DEFO'
 
     Parameters: int_file    - str, path to the wrapped interferogram file
-                cor_file    - str, path to the correlation file
+                cor_file    - str, path to the correlation file: phase sigma or complex correlation
                 unw_file    - str, path to the output unwrapped interferogram file
                 defo_max    - float, maximum number of cycles for the deformation phase
                 max_comp    - int, maximum number of connected components
@@ -1046,8 +1046,11 @@ def unwrap_snaphu(int_file, cor_file, unw_file, defo_max=2.0, max_comp=32,
     snp.setInput(int_file)
     snp.setOutput(unw_file)
     snp.setCorrfile(cor_file)
-    snp.setCorFileFormat('FLOAT_DATA')
     snp.setWidth(width)
+
+    atr_cor = readfile.read_attribute(cor_file)
+    if int(atr_cor.get('BANDS', 1)) == 1:
+        snp.setCorFileFormat('FLOAT_DATA')
 
     # runtime options
     snp.setCostMode(cost_mode)

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1785,14 +1785,15 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
     if mask is not None:
         mask[np.isnan(mask)] = 0
 
-        # vmin/max
+        # vmin/vmax: create mask based on the input thresholds
         if vmin is not None:
-            mask[mask < vmin] = 0
+            mask = mask >= vmin
             vprint(f'hide pixels with mask value < {vmin}')
         if vmax is not None:
-            mask[mask > vmax] = 0
+            mask = mask <= vmax
             vprint(f'hide pixels with mask value > {vmax}')
 
+        # set to bool type
         mask = mask != 0
 
     return mask, mask_file

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -581,6 +581,12 @@ def read_binary_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
 
         band = min(band, num_band)
 
+        # check file size
+        fsize = os.path.getsize(fname)
+        dsize = np.dtype(data_type).itemsize * length * width * num_band
+        if dsize != fsize:
+            warnings.warn(f'file size ({fsize}) does NOT match with metadata ({dsize})!')
+
     # ROI_PAC
     elif processor in ['roipac']:
         # data structure - auto


### PR DESCRIPTION
**Description of proposed changes**

+ `mask.py`: replace the `-t / --threshold` option with the `--vmin / --mask-vmin` option, to be less ambiguous, as vmin includes the direction for thresholding.

+ `mask.py`: add `--vmax / --mask-vmax` option

+ `utils.isce_utils.unwrap_snaphu`: support 2-band corr file, by checking the number of bands for the input correlation files, and set the file format accordingly, to support both the phase sigma and complex correlation files.

+ `utils.readfile.read_binary_file()`: add file/dset size checking

+ `view`: bugfix for `--mask-vmin/vmax` options
   - `utils.plot.read_mask()`: when `--mask-vmin/vmax` options are specified, create mask via thresholding the 2D matrix of the mask file, instead of updating mask on top of the 2D matrix of the mask file.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2150) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.