### PR TITLE
`diff`: support `unw/off - timeseries`

### DIFF
--- a/src/mintpy/cli/diff.py
+++ b/src/mintpy/cli/diff.py
@@ -18,6 +18,7 @@ EXAMPLE = """example:
   diff.py  timeseries.h5  inputs/ERA5.h5  -o timeseries_ERA5.h5  --force
   diff.py  timeseries_ERA5_ramp_demErr.h5  ../GIANT/Stack/LS-PARAMS.h5 -o mintpy_giant.h5
   diff.py  reconUnwrapIfgram.h5  ./inputs/ifgramStack.h5  -o diffUnwrapIfgram.h5
+  diff.py  filt_20220905_20230220.unw  ./inputs/ERA5.h5 -o filt_20220905_20230220_ERA5.unw
 
   # multiple files
   diff.py  waterMask.h5  maskSantiago.h5  maskFernandina.h5  -o maskIsabela.h5
@@ -51,7 +52,7 @@ def cmd_line_parse(iargs=None):
     # check
     # check: number of files == 2 for time-series and ifgram stack
     ftype = readfile.read_attribute(inps.file1)['FILE_TYPE']
-    if ftype in ['timeseries', 'ifgramStack']:
+    if ftype in ['timeseries', 'ifgramStack', '.unw']:
         if len(inps.file2) > 1:
             raise SystemExit(f'ERROR: ONLY ONE file2 is inputed for {ftype} type!')
 

--- a/src/mintpy/cli/geocode.py
+++ b/src/mintpy/cli/geocode.py
@@ -127,12 +127,12 @@ def cmd_line_parse(iargs=None):
 
     # check: --lookup (lookup table existence)
     if not inps.lookupFile:
-        # grab default lookup table
-        inps.lookupFile = ut.get_lookup_file(inps.lookupFile)
-
         # use isce-2 lat/lon.rdr file
         if not inps.lookupFile and inps.latFile:
             inps.lookupFile = inps.latFile
+
+        # grab default lookup table
+        inps.lookupFile = ut.get_lookup_file(inps.lookupFile)
 
         # final check
         if not inps.lookupFile:

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -6,6 +6,7 @@
 
 
 import os
+import shutil
 import time
 
 import numpy as np
@@ -17,7 +18,7 @@ from mintpy.objects import (
     ifgramStack,
     timeseries,
 )
-from mintpy.utils import readfile, writefile
+from mintpy.utils import ptime, readfile, writefile
 
 
 #####################################################################################
@@ -54,6 +55,212 @@ def check_reference(atr1, atr2):
     return ref_date, ref_y, ref_x
 
 
+def diff_timeseries(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
+    """Calculate the difference between two time-series files.
+
+    Parameters: file1         - str, path of file1
+                file2         - str, path of file2
+                out_file      - str, path of output file
+                force_diff    - bool, overwrite existing output file
+                max_num_pixel - float, maximum number of pixels for each block
+    Returns:    out_file      - str, path of output file
+    """
+
+    # basic info
+    atr1 = readfile.read_attribute(file1)
+    atr2 = readfile.read_attribute(file2)
+    k1 = atr1['FILE_TYPE']
+    k2 = atr2['FILE_TYPE']
+    date_list1 = timeseries(file1).get_date_list()
+    if k2 == 'timeseries':
+        date_list2 = timeseries(file2).get_date_list()
+        unit_fac = 1.
+    elif k2 == 'giantTimeseries':
+        date_list2 = giantTimeseries(file2).get_date_list()
+        unit_fac = 0.001
+
+    # check reference point
+    ref_date, ref_y, ref_x = check_reference(atr1, atr2)
+
+    # check dates shared by two timeseries files
+    date_list_shared = [i for i in date_list1 if i in date_list2]
+    date_flag_shared = np.ones((len(date_list1)), dtype=np.bool_)
+    if date_list_shared != date_list1:
+        print(f'WARNING: {file2} does not contain all dates in {file1}')
+        if force_diff:
+            date_list_ex = list(set(date_list1) - set(date_list_shared))
+            print('Continue and enforce the differencing for their shared dates only.')
+            print(f'\twith following dates are ignored for differencing:\n{date_list_ex}')
+            date_flag_shared[np.array([date_list1.index(i) for i in date_list_ex])] = 0
+        else:
+            raise Exception('To enforce the differencing anyway, use --force option.')
+
+    # instantiate the output file
+    writefile.layout_hdf5(out_file, ref_file=file1)
+
+    # block-by-block IO
+    length, width = int(atr1['LENGTH']), int(atr1['WIDTH'])
+    num_box = int(np.ceil(len(date_list1) * length * width / max_num_pixel))
+    box_list = cluster.split_box2sub_boxes(
+        box=(0, 0, width, length),
+        num_split=num_box,
+        dimension='y',
+        print_msg=True,
+    )
+
+    if ref_y and ref_x:
+        ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
+        ref_val = readfile.read(file2, datasetName=date_list_shared, box=ref_box)[0] * unit_fac
+
+    for i, box in enumerate(box_list):
+        if num_box > 1:
+            print(f'\n------- processing patch {i+1} out of {num_box} --------------')
+            print(f'box: {box}')
+
+        # read data2 (consider different reference_date/pixel)
+        print(f'read from file: {file2}')
+        data2 = readfile.read(file2, datasetName=date_list_shared, box=box)[0] * unit_fac
+
+        if ref_y and ref_x:
+            print(f'* referencing data from {os.path.basename(file2)} to y/x: {ref_y}/{ref_x}')
+            data2 -= np.tile(ref_val.reshape(-1, 1, 1), (1, data2.shape[1], data2.shape[2]))
+
+        if ref_date:
+            print(f'* referencing data from {os.path.basename(file2)} to date: {ref_date}')
+            ref_ind = date_list_shared.index(ref_date)
+            data2 -= np.tile(data2[ref_ind, :, :], (data2.shape[0], 1, 1))
+
+        # read data1
+        print(f'read from file: {file1}')
+        data = readfile.read(file1, box=box)[0]
+
+        # apply differencing
+        mask = data == 0.
+        data[date_flag_shared] -= data2
+        data[mask] = 0.                   # Do not change zero phase value
+        del data2
+
+        # write the block
+        block = [0, data.shape[0], box[1], box[3], box[0], box[2]]
+        writefile.write_hdf5_block(out_file, data=data, datasetName=k1, block=block)
+
+    return out_file
+
+
+def diff_ifgram_stack(file1, file2, out_file):
+    """Calculate the difference between two ifgramStack files.
+
+    Parameters: file1    - str, path of file1
+                file2    - str, path of file2
+                out_file - str, path of output file
+    Returns:    out_file - str, path of output file
+    """
+
+    obj1 = ifgramStack(file1)
+    obj1.open()
+    obj2 = ifgramStack(file2)
+    obj2.open()
+    ds_names = list(set(obj1.datasetNames) & set(obj2.datasetNames))
+    if len(ds_names) == 0:
+        raise ValueError('no common dataset between two files!')
+    ds_name = [i for i in IFGRAM_DSET_NAMES if i in ds_names][0]
+
+    # read data
+    print(f'reading {ds_name} from file {file1} ...')
+    data1 = readfile.read(file1, datasetName=ds_name)[0]
+    print(f'reading {ds_name} from file {file2} ...')
+    data2 = readfile.read(file2, datasetName=ds_name)[0]
+
+    # consider reference pixel
+    if 'unwrapphase' in ds_name.lower():
+        print(f'referencing to pixel ({obj1.refY},{obj1.refX}) ...')
+        ref1 = data1[:, obj1.refY, obj1.refX]
+        ref2 = data2[:, obj2.refY, obj2.refX]
+        for i in range(data1.shape[0]):
+            data1[i,:][data1[i, :] != 0.] -= ref1[i]
+            data2[i,:][data2[i, :] != 0.] -= ref2[i]
+
+    # operation and ignore zero values
+    data1[data1 == 0] = np.nan
+    data2[data2 == 0] = np.nan
+    data = data1 - data2
+    del data1, data2
+    data[np.isnan(data)] = 0.
+
+    # write to file
+    ds_dict = {ds_name : data}
+    writefile.write(ds_dict, out_file=out_file, ref_file=file1)
+
+    return out_file
+
+
+def diff_ifgram_and_timeseries(unw_file, ts_file, cor_file):
+    """Calculate the difference between two unwrapped interferogram files.
+
+    Parameters: unw_file - str, path of the interferogram file
+                ts_file  - str, path of the time-series file, e.g. ERA5.h5, SET.h5
+                cor_file - str, path of output corrected interferogram file
+    Returns:    cor_file - str, path of output corrected interferogram file
+    """
+
+    atr = readfile.read_attribute(unw_file)
+    dunit = atr.get('UNIT', 'radian')
+    dname = 'phase' if dunit.startswith('rad') else ''
+
+    # read data
+    print(f'read {dname} from {unw_file}')
+    data, atr = readfile.read(unw_file, datasetName=dname)
+    date1, date2 = ptime.yyyymmdd(atr['DATE12'].split('-'))
+
+    # read the correction
+    print(f'calc {dname} for {date1}-{date2} from {ts_file}')
+    delay  = readfile.read(ts_file, datasetName=date2)[0]
+    delay -= readfile.read(ts_file, datasetName=date1)[0]
+    if dunit.startswith('rad'):
+        print(f'convert {dname} from radian to meter')
+        delay *= -4. * np.pi / float(atr['WAVELENGTH'])
+
+    # apply the correction (and re-referencing)
+    data -= delay
+    if 'REF_Y' in atr.keys():
+        ref_y, ref_x = int(atr['REF_Y']), int(atr['REF_X'])
+        data -= data[ref_y, ref_x]
+        print(f're-referencing to pixel ({ref_y}, {ref_x})')
+
+    if atr['FILE_TYPE'] == '.unw':
+        print(f'read magnitude from {unw_file}')
+        mag = readfile.read(unw_file, datasetName='magnitude')[0]
+        ds_dict = {'magnitude': mag, 'phase': data}
+    else:
+        ds_dict = data
+
+    print(f'write corrected data to {cor_file}')
+    writefile.write(ds_dict, cor_file, atr)
+
+    # prepare ISCE metadata file by
+    # 1. copy and rename metadata files
+    # 2. update file path inside files
+    for ext in ['xml', 'vrt']:
+        unw_meta_file = f'{unw_file}.{ext}'
+        cor_meta_file = f'{cor_file}.{ext}'
+
+        if os.path.isfile(unw_meta_file):
+            # copy
+            shutil.copy2(unw_meta_file, cor_meta_file)
+            print(f'copy {unw_meta_file} to {cor_meta_file} and update the filename')
+
+            # update file path
+            meta_file = f'{cor_file}.{ext}'
+            with open(meta_file) as f:
+                s = f.read()
+            s = s.replace(os.path.basename(unw_file),
+                          os.path.basename(cor_file))
+            with open(meta_file, 'w') as f:
+                f.write(s)
+
+    return cor_file
+
+
 def diff_file(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
     """calculate/write file1 - file2
 
@@ -76,123 +283,13 @@ def diff_file(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
     if k1 == 'timeseries':
         if k2 not in ['timeseries', 'giantTimeseries']:
             raise Exception('Input multiple dataset files are not the same file type!')
-
-        atr1 = readfile.read_attribute(file1)
-        atr2 = readfile.read_attribute(file2[0])
-        dateList1 = timeseries(file1).get_date_list()
-        if k2 == 'timeseries':
-            dateList2 = timeseries(file2[0]).get_date_list()
-            unit_fac = 1.
-        elif k2 == 'giantTimeseries':
-            dateList2 = giantTimeseries(file2[0]).get_date_list()
-            unit_fac = 0.001
-
-        # check reference point
-        ref_date, ref_y, ref_x = check_reference(atr1, atr2)
-
-        # check dates shared by two timeseries files
-        dateListShared = [i for i in dateList1 if i in dateList2]
-        dateShared = np.ones((len(dateList1)), dtype=np.bool_)
-        if dateListShared != dateList1:
-            print(f'WARNING: {file2} does not contain all dates in {file1}')
-            if force_diff:
-                dateListEx = list(set(dateList1) - set(dateListShared))
-                print('Continue and enforce the differencing for their shared dates only.')
-                print(f'\twith following dates are ignored for differencing:\n{dateListEx}')
-                dateShared[np.array([dateList1.index(i) for i in dateListEx])] = 0
-            else:
-                raise Exception('To enforce the differencing anyway, use --force option.')
-
-        # instantiate the output file
-        writefile.layout_hdf5(out_file, ref_file=file1)
-
-        # block-by-block IO
-        length, width = int(atr1['LENGTH']), int(atr1['WIDTH'])
-        num_box = int(np.ceil(len(dateList1) * length * width / max_num_pixel))
-        box_list = cluster.split_box2sub_boxes(box=(0, 0, width, length),
-                                               num_split=num_box,
-                                               dimension='y',
-                                               print_msg=True)
-
-        if ref_y and ref_x:
-            ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
-            ref_val = readfile.read(file2[0],
-                                    datasetName=dateListShared,
-                                    box=ref_box)[0] * unit_fac
-
-        for i, box in enumerate(box_list):
-            if num_box > 1:
-                print(f'\n------- processing patch {i+1} out of {num_box} --------------')
-                print(f'box: {box}')
-
-            # read data2 (consider different reference_date/pixel)
-            print(f'read from file: {file2[0]}')
-            data2 = readfile.read(file2[0],
-                                  datasetName=dateListShared,
-                                  box=box)[0] * unit_fac
-
-            if ref_y and ref_x:
-                print(f'* referencing data from {os.path.basename(file2[0])} to y/x: {ref_y}/{ref_x}')
-                data2 -= np.tile(ref_val.reshape(-1, 1, 1), (1, data2.shape[1], data2.shape[2]))
-
-            if ref_date:
-                print(f'* referencing data from {os.path.basename(file2[0])} to date: {ref_date}')
-                ref_ind = dateListShared.index(ref_date)
-                data2 -= np.tile(data2[ref_ind, :, :], (data2.shape[0], 1, 1))
-
-            # read data1
-            print(f'read from file: {file1}')
-            data = readfile.read(file1, box=box)[0]
-
-            # apply differencing
-            mask = data == 0.
-            data[dateShared] -= data2
-            data[mask] = 0.               # Do not change zero phase value
-            del data2
-
-            # write the block
-            block = [0, data.shape[0], box[1], box[3], box[0], box[2]]
-            writefile.write_hdf5_block(out_file,
-                                       data=data,
-                                       datasetName=k1,
-                                       block=block)
+        diff_timeseries(file1, file2[0], out_file, force_diff, max_num_pixel)
 
     elif all(i == 'ifgramStack' for i in [k1, k2]):
-        obj1 = ifgramStack(file1)
-        obj1.open()
-        obj2 = ifgramStack(file2[0])
-        obj2.open()
-        ds_names = list(set(obj1.datasetNames) & set(obj2.datasetNames))
-        if len(ds_names) == 0:
-            raise ValueError('no common dataset between two files!')
-        ds_name = [i for i in IFGRAM_DSET_NAMES if i in ds_names][0]
+        diff_ifgram_stack(file1, file2[0], out_file)
 
-        # read data
-        print(f'reading {ds_name} from file {file1} ...')
-        data1 = readfile.read(file1, datasetName=ds_name)[0]
-        print(f'reading {ds_name} from file {file2[0]} ...')
-        data2 = readfile.read(file2[0], datasetName=ds_name)[0]
-
-        # consider reference pixel
-        if 'unwrapphase' in ds_name.lower():
-            print(f'referencing to pixel ({obj1.refY},{obj1.refX}) ...')
-            ref1 = data1[:, obj1.refY, obj1.refX]
-            ref2 = data2[:, obj2.refY, obj2.refX]
-            for i in range(data1.shape[0]):
-                data1[i,:][data1[i, :] != 0.] -= ref1[i]
-                data2[i,:][data2[i, :] != 0.] -= ref2[i]
-
-        # operation and ignore zero values
-        data1[data1 == 0] = np.nan
-        data2[data2 == 0] = np.nan
-        data = data1 - data2
-        del data1, data2
-        data[np.isnan(data)] = 0.
-
-        # write to file
-        dsDict = {}
-        dsDict[ds_name] = data
-        writefile.write(dsDict, out_file=out_file, ref_file=file1)
+    elif k1 in ['.unw', 'displacement', '.off'] and k2 == 'timeseries':
+        diff_ifgram_and_timeseries(unw_file=file1, ts_file=file2[0], cor_file=out_file)
 
     else:
         # get common dataset list
@@ -205,13 +302,14 @@ def diff_file(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
         if len(ds_names) < 1:
             raise ValueError(f'No common datasets found among files:\n{[file1] + file2}')
 
-        # loop over each file
+        # loop over each dataset
         dsDict = {}
         for ds_name in ds_names:
             print(f'differencing {ds_name} ...')
             data = readfile.read(file1, datasetName=ds_name)[0]
             dtype = data.dtype
 
+            # loop over each file2
             for i, fname in enumerate(file2):
                 # ignore ds_name if input file has single dataset
                 ds_name2read = None if len(ds_names_list[i+1]) == 1 else ds_name

--- a/src/mintpy/iono_tec.py
+++ b/src/mintpy/iono_tec.py
@@ -12,7 +12,7 @@ import time
 import h5py
 import numpy as np
 
-import mintpy
+import mintpy.cli.diff
 from mintpy.constants import SPEED_OF_LIGHT
 from mintpy.objects import ionex, timeseries
 from mintpy.simulation import iono
@@ -279,22 +279,6 @@ def vtec2iono_ramp_timeseries(date_list, vtec_list, geom_file, iono_file, sub_te
     return iono_file
 
 
-def correct_timeseries(dis_file, iono_file, cor_dis_file):
-    """Correct time-series for the solid Earth tides."""
-    # diff.py can handle different reference in space and time
-    # between the absolute iono ramp and the double referenced time-series
-    print('\n------------------------------------------------------------------------------')
-    print('correcting relative delay for input time-series using diff.py')
-
-    iargs = [dis_file, iono_file, '-o', cor_dis_file]
-    print('diff.py', ' '.join(iargs))
-
-    import mintpy.cli.diff
-    mintpy.cli.diff.main(iargs)
-
-    return cor_dis_file
-
-
 def run_iono_tec(inps):
     """Calculate and/or correct for the ionospheric delay using TEC from GIM."""
 
@@ -318,10 +302,13 @@ def run_iono_tec(inps):
             update_mode=inps.update_mode,
         )
 
-    ## correct
-    #correct_timeseries(dis_file=inps.dis_file,
-    #                   iono_file=inps.iono_file,
-    #                   cor_dis_file=inps.cor_dis_file)
+    ## correct (using diff.py)
+    ## diff.py can handle different reference in space and time
+    ## e.g. the absolute delay and the double referenced time-series
+    #print('correcting delay for using diff.py')
+    #iargs = [inps.dis_file, inps.iono_file, '-o', inps.cor_dis_file, '--force']
+    #print('diff.py', ' '.join(iargs))
+    #mintpy.cli.diff.main(iargs)
 
     # used time
     m, s = divmod(time.time() - start_time, 60)

--- a/src/mintpy/legacy/tropo_pyaps.py
+++ b/src/mintpy/legacy/tropo_pyaps.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     raise ImportError('Cannot import pyaps!')
 
+import mintpy.cli.diff
 from mintpy.objects import geometry, timeseries
 from mintpy.utils import ptime, readfile, utils as ut, writefile
 
@@ -485,19 +486,6 @@ def get_delay_timeseries(inps, atr):
     return
 
 
-def correct_timeseries(dis_file, tropo_file, cor_dis_file):
-    # diff.py can handle different reference in space and time
-    # between the absolute tropospheric delay and the double referenced time-series
-    print('\n------------------------------------------------------------------------------')
-    print('correcting relative delay for input time-series using diff.py')
-    from mintpy import diff
-
-    iargs = [dis_file, tropo_file, '-o', cor_dis_file, '--force']
-    print('diff.py', ' '.join(iargs))
-    diff.main(iargs)
-    return cor_dis_file
-
-
 ###############################################################
 def main(iargs=None):
     inps = cmd_line_parse(iargs)
@@ -508,14 +496,21 @@ def main(iargs=None):
     if inps.trop_file:
         get_delay_timeseries(inps, atr)
 
-    if atr and atr['FILE_TYPE'] == 'timeseries':
-        inps.outfile = correct_timeseries(
-            inps.timeseries_file,
-            inps.trop_file,
-            inps.outfile,
-        )
+    if inps.dis_file:
+        print('\n'+'-'*80)
+        print('Applying tropospheric correction to displacement file...')
+        if ut.run_or_skip(inps.cor_dis_file, [inps.dis_file, inps.tropo_file]) == 'run':
+            # diff.py can handle different reference in space and time
+            # e.g. the absolute delay and the double referenced time-series
+            print('correcting delay for using diff.py')
+            iargs = [inps.timeseries_file, inps.tropo_file, '-o', inps.outfile, '--force']
+            print('diff.py', ' '.join(iargs))
+            mintpy.cli.diff.main(iargs)
+
+        else:
+            print(f'Skip re-applying and use existed corrected displacement file: {inps.cor_dis_file}.')
     else:
-        print('No input timeseries file, skip correcting tropospheric delays.')
+        print('No input displacement file, skip correcting tropospheric delays.')
 
     return inps.outfile
 

--- a/src/mintpy/solid_earth_tides.py
+++ b/src/mintpy/solid_earth_tides.py
@@ -18,6 +18,7 @@ from matplotlib import pyplot as plt
 
 plt.rcParams.update({'font.size': 12})
 
+import mintpy.cli.diff
 from mintpy.objects import timeseries
 from mintpy.objects.resample import resample
 from mintpy.utils import ptime, readfile, utils as ut, writefile
@@ -27,7 +28,7 @@ from mintpy.utils import ptime, readfile, utils as ut, writefile
 def get_datetime_list(ts_file, date_wise_acq_time=False):
     """Prepare exact datetime for each acquisition in the time-series file.
 
-    Parameters: ts_file            - str, path of the time-series HDF5 file
+    Parameters: ts_file            - str, path of the time-series HDF5 or .unw file
                 date_wise_acq_time - bool, use the exact date-wise acquisition time
     Returns:    sensingMid         - list of datetime.datetime objects
                 date_list          - list(str), dates in YYYYMMDD
@@ -141,9 +142,13 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_comp='enu2los',
         atr = readfile.read_attribute(ts_file)
         dt_objs, date_list = get_datetime_list(ts_file, date_wise_acq_time=date_wise_acq_time)
     else:
-        atr = readfile.read_attribute(geom_file)
-        # text list file
-        date_list = ptime.read_date_txt(ts_file)
+        if ts_file.endswith(('.unw', '.geo', '.rdr', '.bip')):
+            atr = readfile.read_attribute(ts_file)
+            date_list = ptime.yyyymmdd(atr['DATE12'].split('-'))
+        else:
+            # text list file
+            atr = readfile.read_attribute(geom_file)
+            date_list = ptime.read_date_txt(ts_file)
         utc_sec = dt.timedelta(seconds=float(atr['CENTER_LINE_UTC']))
         dt_objs = [dt.datetime.strptime(x, '%Y%m%d') + utc_sec for x in date_list]
 
@@ -216,22 +221,6 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_comp='enu2los',
     return ts_set
 
 
-def correct_timeseries(dis_file, set_file, cor_dis_file):
-    """Correct time-series for the solid Earth tides."""
-    # diff.py can handle different reference in space and time
-    # between the absolute solid Earth tides and the double referenced time-series
-    print('\n------------------------------------------------------------------------------')
-    print('correcting relative delay for input time-series using diff.py')
-
-    iargs = [dis_file, set_file, '-o', cor_dis_file]
-    print('diff.py', ' '.join(iargs))
-
-    import mintpy.cli.diff
-    mintpy.cli.diff.main(iargs)
-
-    return cor_dis_file
-
-
 ###############################################################
 def run_solid_earth_tides(inps):
     start_time = time.time()
@@ -247,13 +236,13 @@ def run_solid_earth_tides(inps):
         verbose=inps.verbose,
     )
 
-    # correct SET
-    if inps.dis_file.endswith('.h5'):
-        correct_timeseries(
-            dis_file=inps.dis_file,
-            set_file=inps.set_file,
-            cor_dis_file=inps.cor_dis_file,
-        )
+    # correct SET (using diff.py)
+    # diff.py can handle different reference in space and time
+    # e.g. the absolute phase and the double referenced time-series
+    print('correcting tide for using diff.py')
+    iargs = [inps.dis_file, inps.set_file, '-o', inps.cor_dis_file, '--force']
+    print('diff.py', ' '.join(iargs))
+    mintpy.cli.diff.main(iargs)
 
     # used time
     m, s = divmod(time.time() - start_time, 60)

--- a/src/mintpy/tropo_gacos.py
+++ b/src/mintpy/tropo_gacos.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 from skimage.transform import resize
 
+import mintpy.cli.diff
 from mintpy.objects import timeseries
 from mintpy.utils import ptime, readfile, utils as ut, writefile
 
@@ -243,39 +244,6 @@ def calculate_delay_timeseries(tropo_file, dis_file, geom_file, gacos_dir):
     return tropo_file
 
 
-def correct_timeseries(dis_file, tropo_file, cor_dis_file):
-    # diff.py can handle different reference in space and time
-    # between the absolute tropospheric delay and the double referenced time-series
-    print('\n------------------------------------------------------------------------------')
-    print('correcting relative delay for input time-series using diff.py')
-
-    iargs = [dis_file, tropo_file, '-o', cor_dis_file, '--force']
-    print('diff.py', ' '.join(iargs))
-
-    import mintpy.cli.diff
-    mintpy.cli.diff.main(iargs)
-
-    return cor_dis_file
-
-
-def correct_single_ifgram(dis_file, tropo_file, cor_dis_file):
-    print('\n------------------------------------------------------------------------------')
-    print('correcting relative delay for input interferogram')
-
-    print(f'read data from {dis_file}')
-    data, atr = readfile.read(dis_file, datasetName='phase')
-    date1, date2 = ptime.yyyymmdd(atr['DATE12'].split('-'))
-
-    print(f'calc tropospheric delay for {date1}-{date2} from {tropo_file}')
-    tropo  = readfile.read(tropo_file, datasetName=f'timeseries-{date2}')[0]
-    tropo -= readfile.read(tropo_file, datasetName=f'timeseries-{date1}')[0]
-    tropo *= -4. * np.pi / float(atr['WAVELENGTH'])
-
-    print(f'write corrected data to {cor_dis_file}')
-    writefile.write(data - tropo, cor_dis_file, atr)
-    return cor_dis_file
-
-
 ############################################################################
 def run_tropo_gacos(inps):
 
@@ -286,20 +254,12 @@ def run_tropo_gacos(inps):
         geom_file=inps.geom_file,
         gacos_dir=inps.gacos_dir)
 
-    # correct tropo delay from dis time-series
-    ftype = readfile.read_attribute(inps.dis_file)['FILE_TYPE']
-    if ftype == 'timeseries':
-        correct_timeseries(
-            dis_file=inps.dis_file,
-            tropo_file=inps.tropo_file,
-            cor_dis_file=inps.cor_dis_file)
-
-    elif ftype == '.unw':
-        correct_single_ifgram(
-            dis_file=inps.dis_file,
-            tropo_file=inps.tropo_file,
-            cor_dis_file=inps.cor_dis_file)
-    else:
-        print(f'ERROR: input file {ftype} is not timeseries nor .unw, correction is not supported yet!')
+    # correct tropo delay (using diff.py)
+    # diff.py can handle different reference in space and time
+    # e.g. the absolute delay and the double referenced time-series
+    print('correcting delay for using diff.py')
+    iargs = [inps.dis_file, inps.tropo_file, '-o', inps.cor_dis_file, '--force']
+    print('diff.py', ' '.join(iargs))
+    mintpy.cli.diff.main(iargs)
 
     return

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -951,7 +951,7 @@ def _get_file_base_and_ext(fname):
     fext = fext.lower()
 
     # ignore certain meaningless file extensions
-    while fext in ['.geo', '.rdr', '.full', '.mli', '.wgs84', '.grd']:
+    while fext in ['.geo', '.rdr', '.full', '.mli', '.wgs84', '.grd', '.bil', '.bip']:
         fbase, fext = os.path.splitext(fbase)
     # set fext to fbase if nothing left
     fext = fext if fext else fbase


### PR DESCRIPTION
**Description of proposed changes**

+ `diff.py`:
   - support the differencing between a *.unw (or offset file with FILE_TYPE of displacement) file and a time-series file, as used frequently in phase correction procedures, by adding a sub-function `diff_ifgram_and_timeseries()`
   - split `diff_timeseries()` and `diff_ifgram_stack()` out of `diff_file()` for clarity.
   - prepare isce metadata file, to be consistent with mask.py and subset.py

+ call `diff.py` to handle the correction procedure in the following scripts:
   - iono_tec.py
   - legacy/tropo_pyaps.py
   - solid_earth_tides.py
   - tropo_gacos.py
   - tropo_pyaps3.py

+ `cli/geocode.py`: if `--lat-file` is specified, honor this manually set file as the default lookupFile, rather than searching for the default file patterns, which could be NOT consistent with input files.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2150/workflows/0a5e9b98-faac-437e-b4da-faa36e210592/jobs/2157) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.