### PR TITLE
Fix the `pad_width` integral type error for `spatial_filter.py -f double_difference`

### DIFF
--- a/src/mintpy/utils/isce_utils.py
+++ b/src/mintpy/utils/isce_utils.py
@@ -385,10 +385,13 @@ def extract_alosStack_metadata(meta_file, geom_dir):
     meta['LON_REF3'] = str(data[-1-edge,  0+edge])
     meta['LON_REF4'] = str(data[-1-edge, -1-edge])
 
-    los_file = glob.glob(os.path.join(geom_dir, f'*_{rlooks}rlks_{alooks}alks.los'))[0]
-    data = np.memmap(los_file, dtype='float32', mode='r', shape=(length*2, width))[0:length*2:2, :]
-    inc_angle = data[int(length/2), int(width/2)]
-    meta['CENTER_INCIDENCE_ANGLE'] = str(inc_angle)
+    # CENTER_INCIDENCE_ANGLE is optional
+    los_files = glob.glob(os.path.join(geom_dir, f'*_{rlooks}rlks_{alooks}alks.los'))
+    if len(los_files) > 0:
+        los_file = los_files[0]
+        data = np.memmap(los_file, dtype='float32', mode='r', shape=(length*2, width))[0:length*2:2, :]
+        inc_angle = data[int(length/2), int(width/2)]
+        meta['CENTER_INCIDENCE_ANGLE'] = str(inc_angle)
 
     pointingDirection = {'right': -1, 'left' :1}
     meta['ANTENNA_SIDE'] = str(pointingDirection[track.pointingDirection])

--- a/src/mintpy/utils/isce_utils.py
+++ b/src/mintpy/utils/isce_utils.py
@@ -388,8 +388,7 @@ def extract_alosStack_metadata(meta_file, geom_dir):
     # CENTER_INCIDENCE_ANGLE is optional
     los_files = glob.glob(os.path.join(geom_dir, f'*_{rlooks}rlks_{alooks}alks.los'))
     if len(los_files) > 0:
-        los_file = los_files[0]
-        data = np.memmap(los_file, dtype='float32', mode='r', shape=(length*2, width))[0:length*2:2, :]
+        data = np.memmap(los_files[0], dtype='float32', mode='r', shape=(length*2, width))[0:length*2:2, :]
         inc_angle = data[int(length/2), int(width/2)]
         meta['CENTER_INCIDENCE_ANGLE'] = str(inc_angle)
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1322,7 +1322,7 @@ def auto_no_data_value(meta):
 
         # known file types
         # isce2: dense offsets from topsApp.py
-        if processor == 'isce' and fbase.endswith('dense_offsets') and fext == '.bil' and num_band == 2:
+        if processor == 'isce' and fname.endswith('dense_offsets.bil') and num_band == 2:
             no_data_value = -10000.
 
         else:

--- a/src/mintpy/utils/writefile.py
+++ b/src/mintpy/utils/writefile.py
@@ -171,7 +171,8 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None,
                 data_list = [data_list[0], data_list[0]]
                 meta['BANDS'] = 2
 
-        elif fext in ['.cor', '.hgt']:
+        elif fext in ['.cor']:
+            # remove .hgt as it can be float64 in isce2.
             meta['DATA_TYPE'] = 'float32'
             meta['INTERLEAVE'] = 'BIL'
             if meta.get('PROCESSOR', 'isce') == 'roipac':


### PR DESCRIPTION
**Description of proposed changes**

+ `spatial_filter.py`: Fix the `np.pad()` `pad_width` integral type error while using the double_difference filter, as described in #1014.

+ `writefile.write()`: do not overwrite format for `.hgt` file, as it can be float64 in isce2. Plus, the two-band format in roipac is weird anyway and not used much anymore [in the last 3+ years if I remember correctly].

+ `isce_utils.extract_alosStack_metadata()`: make los_file optional, because 1) attribute CENTER_INCIDENCE_ANGLE is not essential, i.e. optional; and 2) los_file does not exist sometimes, as in the post-processing of alos2App

**Reminders**

- [x] Fix #1014
- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2158/workflows/3bcd5cae-5bb5-4c95-85b6-99a99bfe75e8/jobs/2166) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.