### PR TITLE
`diff.py` btw. time-series and velocity + other changes

### DIFF
--- a/src/mintpy/cli/diff.py
+++ b/src/mintpy/cli/diff.py
@@ -13,12 +13,16 @@ from mintpy.utils.arg_utils import create_argument_parser
 
 #####################################################################################
 EXAMPLE = """example:
+  # same file types
   diff.py  velocity.h5    velocity_demErr.h5
   diff.py  timeseries.h5  inputs/ERA5.h5  -o timeseries_ERA5.h5
   diff.py  timeseries.h5  inputs/ERA5.h5  -o timeseries_ERA5.h5  --force
   diff.py  timeseries_ERA5_ramp_demErr.h5  ../GIANT/Stack/LS-PARAMS.h5 -o mintpy_giant.h5
   diff.py  reconUnwrapIfgram.h5  ./inputs/ifgramStack.h5  -o diffUnwrapIfgram.h5
+
+  # different file types
   diff.py  filt_20220905_20230220.unw  ./inputs/ERA5.h5 -o filt_20220905_20230220_ERA5.unw
+  diff.py  timeseries.h5 ./inputs/ITRF14.h5 -o timeseries_ITRF14.h5
 
   # multiple files
   diff.py  waterMask.h5  maskSantiago.h5  maskFernandina.h5  -o maskIsabela.h5

--- a/src/mintpy/cli/image_stitch.py
+++ b/src/mintpy/cli/image_stitch.py
@@ -41,14 +41,12 @@ def create_parser(subparsers=None):
                              '(i.e., for two coherence maps), use this flag')
 
     # plot options
-    parser.add_argument('--unit', dest='disp_unit', type=float, default=1.,
-                        help='convert unit (float) when plotting.')
-    parser.add_argument('--vmin', dest='disp_vmin', type=float, default=None,
-                        help='vmin (float) when plotting.')
-    parser.add_argument('--vmax', dest='disp_vmax', type=float, default=None,
-                        help='vmax (float) when plotting.')
-    parser.add_argument('--cmap', dest='disp_cmap', type=str, default=None,
-                        help='cmap (str) when plotting.')
+    parser.add_argument('--scale', dest='disp_scale', type=float, default=1.,
+                        help='scale the data when plotting.')
+    parser.add_argument('-v','--vlim', dest='disp_vlim', type=float, default=None, nargs=2,
+                        help='vmin and vmax when plotting.')
+    parser.add_argument('-c','--cmap', dest='disp_cmap', type=str, default=None,
+                        help='colormap when plotting.')
     parser.add_argument('--nodisplay', dest='disp_fig', action='store_false',
                         help='do not display the result plotting.')
     return parser
@@ -74,10 +72,9 @@ def main(iargs=None):
         out_file=inps.outfile,
         apply_offset=inps.apply_offset,
         disp_fig=inps.disp_fig,
-        unit=inps.disp_unit,
-        vmin=inps.disp_vmin,
-        vmax=inps.disp_vmax,
-        cmap=inps.disp_cmap
+        disp_scale=inps.disp_scale,
+        disp_vlim=inps.disp_vlim,
+        disp_cmap=inps.disp_cmap,
     )
 
 

--- a/src/mintpy/cli/image_stitch.py
+++ b/src/mintpy/cli/image_stitch.py
@@ -41,6 +41,14 @@ def create_parser(subparsers=None):
                              '(i.e., for two coherence maps), use this flag')
 
     # plot options
+    parser.add_argument('--unit', dest='disp_unit', type=float, default=1.,
+                        help='convert unit (float) when plotting.')
+    parser.add_argument('--vmin', dest='disp_vmin', type=float, default=None,
+                        help='vmin (float) when plotting.')
+    parser.add_argument('--vmax', dest='disp_vmax', type=float, default=None,
+                        help='vmax (float) when plotting.')
+    parser.add_argument('--cmap', dest='disp_cmap', type=str, default=None,
+                        help='cmap (str) when plotting.')
     parser.add_argument('--nodisplay', dest='disp_fig', action='store_false',
                         help='do not display the result plotting.')
     return parser
@@ -66,6 +74,10 @@ def main(iargs=None):
         out_file=inps.outfile,
         apply_offset=inps.apply_offset,
         disp_fig=inps.disp_fig,
+        unit=inps.disp_unit,
+        vmin=inps.disp_vmin,
+        vmax=inps.disp_vmax,
+        cmap=inps.disp_cmap
     )
 
 

--- a/src/mintpy/cli/spatial_filter.py
+++ b/src/mintpy/cli/spatial_filter.py
@@ -43,7 +43,7 @@ def create_parser(subparsers=None):
     parser.add_argument('-f', dest='filter_type', default='lowpass_gaussian',
                         choices=['lowpass_gaussian', 'highpass_gaussian',
                                  'lowpass_avg', 'highpass_avg',
-                                 'sobel', 'roberts', 'canny', 'double_difference'],
+                                 'sobel', 'roberts', 'canny', 'double_difference', 'median'],
                         help='Filter type (default: %(default)s).\n' +
                              'Check Bekaert et al. (2020) for double_difference;\n' +
                              'Check scikit-image as below for the other filters:\n' +
@@ -52,7 +52,8 @@ def create_parser(subparsers=None):
                         help='Filter parameters for filters. Default:\n' +
                              '    Sigma         for low/high pass gaussian filter, default: 3.0\n' +
                              '    Kernel Size   for low/high pass average  filter, default: 5\n' +
-                             '    Kernel Radius for double difference local and regional filters, default: 1 10\n')
+                             '    Kernel Radius for double difference local and regional filters, default: 1 10\n'+
+                             '    Kernel Radius for median filters, default: 5\n')
     parser.add_argument('-o', '--outfile',default=None, help='Output file name.')
     return parser
 

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -98,6 +98,8 @@ def diff_timeseries(file1, file2, out_file, force_diff=False, max_num_pixel=2e8)
     if ref_y and ref_x:
         ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
         ref_val = readfile.read(file2, datasetName=date_list_shared, box=ref_box)[0] * unit_fac
+    else:
+        ref_val = None
 
     # instantiate the output file
     writefile.layout_hdf5(out_file, ref_file=file1)
@@ -121,7 +123,7 @@ def diff_timeseries(file1, file2, out_file, force_diff=False, max_num_pixel=2e8)
         print(f'read from file: {file2}')
         data2 = readfile.read(file2, datasetName=date_list_shared, box=box)[0] * unit_fac
 
-        if ref_y and ref_x:
+        if ref_val is not None:
             print(f'* referencing data from {os.path.basename(file2)} to y/x: {ref_y}/{ref_x}')
             data2 -= np.tile(ref_val.reshape(-1, 1, 1), (1, data2.shape[1], data2.shape[2]))
 
@@ -170,7 +172,7 @@ def diff_timeseries_and_velocity(file1, file2, out_file, max_num_pixel=2e8):
         ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
         ref_val = readfile.read(file2, datasetName='velocity', box=ref_box)[0]
     else:
-        ref_val = 0.
+        ref_val = None
 
     # check dataset names in the time-func file
     ds_names = readfile.get_dataset_list(file2)
@@ -210,7 +212,7 @@ def diff_timeseries_and_velocity(file1, file2, out_file, max_num_pixel=2e8):
         print(f'read velocity from file2: {file2}')
         velo = readfile.read(file2, datasetName='velocity', box=box)[0]
 
-        if ref_y and ref_x:
+        if ref_val is not None:
             print(f'* referencing velocity to y/x: {ref_y}/{ref_x} with value of {ref_val*100:.2f} cm/year')
             velo -= ref_val
 

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -189,6 +189,8 @@ def diff_timeseries_velocity(file1, file2, out_file, max_num_pixel=2e8):
     if ref_y and ref_x:
         ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
         ref_val = readfile.read(file2, datasetName='velocity', box=ref_box)[0] * unit_fac
+    else:
+        ref_val = 0.
 
     for i, box in enumerate(box_list):
         if num_box > 1:
@@ -197,9 +199,7 @@ def diff_timeseries_velocity(file1, file2, out_file, max_num_pixel=2e8):
 
         # read data2 (consider different reference_date/pixel)
         print(f'read from file: {file2}')
-
-        ### from here
-        velo = readfile.read(file2, datasetName='velocity', box=box)[0] * unit_fac
+        velo = readfile.read(file2, datasetName=k2, box=box)[0] * unit_fac
         print(f'* referencing data from {os.path.basename(file2)} to y/x: {ref_y}/{ref_x}')
         velo -= ref_val   # reference pixel in velocity
         num_pixel = velo.size

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -160,8 +160,6 @@ def diff_timeseries_and_velocity(file1, file2, out_file, max_num_pixel=2e8):
     # basic info
     atr1 = readfile.read_attribute(file1)
     atr2 = readfile.read_attribute(file2)
-    k1 = atr1['FILE_TYPE']
-    k2 = atr2['FILE_TYPE']
     date_list = timeseries(file1).get_date_list()
     num_date = len(date_list)
 
@@ -244,7 +242,7 @@ def diff_timeseries_and_velocity(file1, file2, out_file, max_num_pixel=2e8):
 
         # write the block
         block = [0, num_date, box[1], box[3], box[0], box[2]]
-        writefile.write_hdf5_block(out_file, data=data, datasetName=k1, block=block)
+        writefile.write_hdf5_block(out_file, data=data, datasetName='timeseries', block=block)
 
     return out_file
 

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -18,7 +18,7 @@ from mintpy.objects import (
     ifgramStack,
     timeseries,
 )
-from mintpy.utils import ptime, readfile, writefile
+from mintpy.utils import ptime, readfile, time_func, writefile
 
 
 #####################################################################################
@@ -138,6 +138,107 @@ def diff_timeseries(file1, file2, out_file, force_diff=False, max_num_pixel=2e8)
         mask = data == 0.
         data[date_flag_shared] -= data2
         data[mask] = 0.                   # Do not change zero phase value
+        del data2
+
+        # write the block
+        block = [0, data.shape[0], box[1], box[3], box[0], box[2]]
+        writefile.write_hdf5_block(out_file, data=data, datasetName=k1, block=block)
+
+    return out_file
+
+
+def diff_timeseries_velocity(file1, file2, out_file, max_num_pixel=2e8):
+    """Calculate the difference between a time-series file and a velocity file.
+
+    Parameters: file1         - str, path of file1 (time series)
+                file2         - str, path of file2 (velocity)
+                out_file      - str, path of output file
+                max_num_pixel - float, maximum number of pixels for each block
+    Returns:    out_file      - str, path of output file
+    """
+
+    # basic info
+    atr1 = readfile.read_attribute(file1)
+    atr2 = readfile.read_attribute(file2)
+    k1 = atr1['FILE_TYPE']
+    k2 = atr2['FILE_TYPE']
+    date_list1 = timeseries(file1).get_date_list()
+    date_list2 = list(date_list1)
+    unit_fac = 1.  # also in meter as timeseries
+
+    # check reference point
+    ref_date, ref_y, ref_x = check_reference(atr1, atr2)
+
+    # check dates shared by two timeseries files
+    dateListShared = [i for i in date_list1 if i in date_list2]
+    dateShared = np.ones((len(date_list1)), dtype=np.bool_)
+
+    # instantiate the output file
+    writefile.layout_hdf5(out_file, ref_file=file1)
+
+    # block-by-block IO
+    length, width = int(atr1['LENGTH']), int(atr1['WIDTH'])
+    num_box = int(np.ceil(len(date_list1) * length * width / max_num_pixel))
+    box_list = cluster.split_box2sub_boxes(
+        box=(0, 0, width, length),
+        num_split=num_box,
+        dimension='y',
+        print_msg=True,
+    )
+
+    if ref_y and ref_x:
+        ref_box = (ref_x, ref_y, ref_x + 1, ref_y + 1)
+        ref_val = readfile.read(file2, datasetName='velocity', box=ref_box)[0] * unit_fac
+
+    for i, box in enumerate(box_list):
+        if num_box > 1:
+            print(f'\n------- processing patch {i+1} out of {num_box} --------------')
+            print(f'box: {box}')
+
+        # read data2 (consider different reference_date/pixel)
+        print(f'read from file: {file2}')
+
+        ### from here
+        velo = readfile.read(file2, datasetName='velocity', box=box)[0] * unit_fac
+        print(f'* referencing data from {os.path.basename(file2)} to y/x: {ref_y}/{ref_x}')
+        velo -= ref_val   # reference pixel in velocity
+        num_pixel = velo.size
+        # read velocity datasets
+        ds_names_list = readfile.get_dataset_list(file2)
+
+        ######### Re-construct the time series from velocity file #########
+        #   here is a crude option, m to be only the linear, annual, semiannual functions
+        #   To-do: need a proper new function to get m = timeseries2velocity.hdf5_dataset2model()
+        # build time_func dictionary:
+        model = dict()
+        model['polynomial'] = 1
+        model['periodic']   = []
+        model['stepDate']   = []
+        for ds_name in ds_names_list:
+            if   ds_name in ['velocity']:           model['polynomial'] = 1
+            elif ds_name in ['annualPhase']:        model['periodic'].append(1.0)
+            elif ds_name in ['semiAnnualPhase']:    model['periodic'].append(0.5)
+            else: print(f' * skip unsupported dataset {ds_name} in the velocity file. under development...')
+        print(f'* reconstructing timeseries from {file2} with model {model}')
+        G_fit  = time_func.get_design_matrix4time_func(date_list=dateListShared, model=model)
+        m      = np.vstack([np.zeros(num_pixel), velo.flatten()])
+        ts_fit = np.matmul(G_fit, m)
+        data2  = ts_fit.reshape(-1, velo.shape[0], velo.shape[1])
+        ###################################################################
+
+        if ref_date:
+            print(f'* referencing data from {os.path.basename(file2)} to date: {ref_date}')
+            ref_ind = dateListShared.index(ref_date)
+            data2 -= np.tile(data2[ref_ind, :, :], (data2.shape[0], 1, 1))
+
+        # read data1
+        print(f'read from file: {file1}')
+        data = readfile.read(file1, box=box)[0]
+
+        # apply differencing
+        mask = data == 0.
+        data[dateShared] -= data2
+        data[mask] = 0.               # Do not change zero phase value
         del data2
 
         # write the block
@@ -281,9 +382,13 @@ def diff_file(file1, file2, out_file, force_diff=False, max_num_pixel=2e8):
     print(f'the 1st input file is: {k1}')
 
     if k1 == 'timeseries':
-        if k2 not in ['timeseries', 'giantTimeseries']:
+        if k2 not in ['timeseries', 'giantTimeseries', 'velocity']:
+            print('If the first file is timeseries, the following file must be either timeseries or velocity.')
             raise Exception('Input multiple dataset files are not the same file type!')
-        diff_timeseries(file1, file2[0], out_file, force_diff, max_num_pixel)
+        if k2 in ['timeseries', 'giantTimeseries']:
+            diff_timeseries(file1, file2[0], out_file, force_diff, max_num_pixel)
+        elif k2 == 'velocity':
+            diff_timeseries_velocity(file1, file2[0], out_file, max_num_pixel)
 
     elif all(i == 'ifgramStack' for i in [k1, k2]):
         diff_ifgram_stack(file1, file2[0], out_file)

--- a/src/mintpy/image_stitch.py
+++ b/src/mintpy/image_stitch.py
@@ -183,22 +183,23 @@ def stitch_two_matrices(mat1, atr1, mat2, atr2, apply_offset=True, print_msg=Tru
     return mat, atr, mat11, mat22, mat_diff
 
 
-def plot_stitch(mat11, mat22, mat, mat_diff, unit=1, vmin=None, vmax=None, cmap=None, out_fig=None):
+def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None, disp_scale=1, disp_vlim=None, disp_cmap=None):
     """plot stitching result"""
 
     # plot settings
     titles = ['file 1', 'file 2', 'stitched', 'difference']
+    if disp_scale != 1:
+        print(f'scale the data by a factor of {disp_scale} for plotting')
     mat_mli = multilook_data(mat, 20, 20, method='mean')
-    if not vmin and not vmax:
-        vmin = np.nanmin(mat_mli)
-        vmax = np.nanmax(mat_mli)
+    vmin = disp_vlim[0] if disp_vlim else np.nanmin(mat_mli) * disp_scale
+    vmax = disp_vlim[1] if disp_vlim else np.nanmax(mat_mli) * disp_scale
 
     fig_size = pp.auto_figure_size(ds_shape=mat.shape, scale=1.4, disp_cbar=True, print_msg=True)
 
     # plot
     fig, axs = plt.subplots(nrows=2, ncols=2, figsize=fig_size, sharex=True, sharey=True)
     for ax, data, title in zip(axs.flatten(), [mat11, mat22, mat, mat_diff], titles):
-        im = ax.imshow(data * unit, vmin=vmin, vmax=vmax, cmap=cmap, interpolation='nearest')
+        im = ax.imshow(data * disp_scale, vmin=vmin, vmax=vmax, cmap=disp_cmap, interpolation='nearest')
         ax.set_title(title, fontsize=12)
         ax.tick_params(which='both', direction='in', labelsize=12, left=True, right=True, top=True, bottom=True)
     fig.tight_layout()
@@ -215,7 +216,8 @@ def plot_stitch(mat11, mat22, mat, mat_diff, unit=1, vmin=None, vmax=None, cmap=
     return
 
 
-def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_value=None, unit=1, vmin=None, vmax=None, cmap=None):
+def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_value=None,
+                 disp_scale=1, disp_vlim=None, disp_cmap=None):
     """Stitch all input files into one
     """
     fext = os.path.splitext(fnames[0])[1]
@@ -280,9 +282,15 @@ def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_val
             # plot
             if apply_offset:
                 print('plot stitching & shifting result ...')
-                suffix = f'{i}{i+1}'
-                out_fig = f'{os.path.splitext(out_file)[0]}_{suffix}.png'
-                plot_stitch(mat11, mat22, mat, mat_diff, unit, vmin, vmax, cmap, out_fig=out_fig)
+                out_fig = f'{os.path.splitext(out_file)[0]}_{i}{i+1}.png'
+                plot_stitch(
+                    mat11, mat22,
+                    mat, mat_diff,
+                    out_fig=out_fig,
+                    disp_scale=disp_scale,
+                    disp_vlim=disp_vlim,
+                    disp_cmap=disp_cmap,
+                )
 
         dsDict[ds_name_out] = mat
 

--- a/src/mintpy/image_stitch.py
+++ b/src/mintpy/image_stitch.py
@@ -183,20 +183,22 @@ def stitch_two_matrices(mat1, atr1, mat2, atr2, apply_offset=True, print_msg=Tru
     return mat, atr, mat11, mat22, mat_diff
 
 
-def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None):
+def plot_stitch(mat11, mat22, mat, mat_diff, unit=1, vmin=None, vmax=None, cmap=None, out_fig=None):
     """plot stitching result"""
 
     # plot settings
     titles = ['file 1', 'file 2', 'stitched', 'difference']
     mat_mli = multilook_data(mat, 20, 20, method='mean')
-    vmin = np.nanmin(mat_mli)
-    vmax = np.nanmax(mat_mli)
+    if not vmin and not vmax:
+        vmin = np.nanmin(mat_mli)
+        vmax = np.nanmax(mat_mli)
+
     fig_size = pp.auto_figure_size(ds_shape=mat.shape, scale=1.4, disp_cbar=True, print_msg=True)
 
     # plot
     fig, axs = plt.subplots(nrows=2, ncols=2, figsize=fig_size, sharex=True, sharey=True)
     for ax, data, title in zip(axs.flatten(), [mat11, mat22, mat, mat_diff], titles):
-        im = ax.imshow(data, vmin=vmin, vmax=vmax, interpolation='nearest')
+        im = ax.imshow(data * unit, vmin=vmin, vmax=vmax, cmap=cmap, interpolation='nearest')
         ax.set_title(title, fontsize=12)
         ax.tick_params(which='both', direction='in', labelsize=12, left=True, right=True, top=True, bottom=True)
     fig.tight_layout()
@@ -213,7 +215,7 @@ def plot_stitch(mat11, mat22, mat, mat_diff, out_fig=None):
     return
 
 
-def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_value=None):
+def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_value=None, unit=1, vmin=None, vmax=None, cmap=None):
     """Stitch all input files into one
     """
     fext = os.path.splitext(fnames[0])[1]
@@ -280,7 +282,7 @@ def stitch_files(fnames, out_file, apply_offset=True, disp_fig=True, no_data_val
                 print('plot stitching & shifting result ...')
                 suffix = f'{i}{i+1}'
                 out_fig = f'{os.path.splitext(out_file)[0]}_{suffix}.png'
-                plot_stitch(mat11, mat22, mat, mat_diff, out_fig=out_fig)
+                plot_stitch(mat11, mat22, mat, mat_diff, unit, vmin, vmax, cmap, out_fig=out_fig)
 
         dsDict[ds_name_out] = mat
 

--- a/src/mintpy/objects/gps.py
+++ b/src/mintpy/objects/gps.py
@@ -441,7 +441,7 @@ class GPS:
 
         if display:
             import matplotlib.pyplot as plt
-            fig, ax = plt.subplots(nrows=3, ncols=1, sharex=True)
+            _, ax = plt.subplots(nrows=3, ncols=1, sharex=True)
             ax[0].scatter(self.dates, self.dis_e, s=2**2, label='East')
             ax[1].scatter(self.dates, self.dis_n, s=2**2, label='North')
             ax[2].scatter(self.dates, self.dis_u, s=2**2, label='Up')
@@ -546,9 +546,9 @@ class GPS:
             dates = np.array(sorted(list(set(self.dates) & set(ref_obj.dates))))
             dis = np.zeros(dates.shape, np.float32)
             std = np.zeros(dates.shape, np.float32)
-            for i in range(len(dates)):
-                idx1 = np.where(self.dates == dates[i])[0][0]
-                idx2 = np.where(ref_obj.dates == dates[i])[0][0]
+            for i, date_i in enumerate(dates):
+                idx1 = np.where(self.dates == date_i)[0][0]
+                idx2 = np.where(ref_obj.dates == date_i)[0][0]
                 dis[i] = self.dis_los[idx1] - ref_obj.dis_los[idx2]
                 std[i] = (self.std_los[idx1]**2 + ref_obj.std_los[idx2]**2)**0.5
         else:

--- a/src/mintpy/objects/gps.py
+++ b/src/mintpy/objects/gps.py
@@ -132,7 +132,7 @@ def get_gps_los_obs(meta, obs_type, site_names, start_date, end_date, gps_comp='
                                 e.g. enu2los, hz2los, up2los
                 horz_az_angle - float, azimuth angle of the horizontal motion in degree
                                 measured from the north with anti-clockwise as positive
-                model         - time function model, defualt=None.  Ex. model={'polynomial': 1, 'periodic': [1.0, 0.5]}
+                model         - dict, time function model, e.g. {'polynomial': 1, 'periodic': [1.0, 0.5]}
                 print_msg     - bool, print verbose info
                 redo          - bool, ignore existing CSV file and re-calculate
     Returns:    site_obs      - 1D np.ndarray(), GPS LOS velocity or displacement in m or m/yr

--- a/src/mintpy/spatial_filter.py
+++ b/src/mintpy/spatial_filter.py
@@ -50,7 +50,9 @@ def filter_data(data, filter_type, filter_par=None):
         data_filt = data - lp_data
 
     elif filter_type == "lowpass_gaussian":
-        # Kai: watch out NaN holes (https://stackoverflow.com/questions/18697532/gaussian-filtering-a-image-with-nan-in-python)
+        # ORIGNAL: data_filt = filters.gaussian(data, sigma=filter_par)
+        #   nan pixels can enlarge to big holes depending on the size of your gaussian kernel
+        #   we can do normalized convolution (https://stackoverflow.com/a/36307291/7128154) as below:
         V=np.array(data)
         V[np.isnan(data)]=0
         VV=filters.gaussian(V, sigma=filter_par)
@@ -58,10 +60,10 @@ def filter_data(data, filter_type, filter_par=None):
         W=np.ones_like(data)
         W[np.isnan(data)]=0
         WW=filters.gaussian(W, sigma=filter_par)
+        WW[WW==0]=np.nan
 
         data_filt = VV/WW
         data_filt[np.isnan(data)] = np.nan
-        #data_filt = filters.gaussian(data, sigma=filter_par)
 
     elif filter_type == "highpass_gaussian":
         lp_data = filters.gaussian(data, sigma=filter_par)

--- a/src/mintpy/spatial_filter.py
+++ b/src/mintpy/spatial_filter.py
@@ -50,11 +50,25 @@ def filter_data(data, filter_type, filter_par=None):
         data_filt = data - lp_data
 
     elif filter_type == "lowpass_gaussian":
-        data_filt = filters.gaussian(data, sigma=filter_par)
+        # Kai: watch out NaN holes (https://stackoverflow.com/questions/18697532/gaussian-filtering-a-image-with-nan-in-python)
+        V=np.array(data)
+        V[np.isnan(data)]=0
+        VV=filters.gaussian(V, sigma=filter_par)
+
+        W=np.ones_like(data)
+        W[np.isnan(data)]=0
+        WW=filters.gaussian(W, sigma=filter_par)
+
+        data_filt = VV/WW
+        data_filt[np.isnan(data)] = np.nan
+        #data_filt = filters.gaussian(data, sigma=filter_par)
 
     elif filter_type == "highpass_gaussian":
         lp_data = filters.gaussian(data, sigma=filter_par)
         data_filt = data - lp_data
+
+    elif filter_type == "median":
+        data_filt = filters.median(data, morphology.disk(filter_par))
 
     elif filter_type == "double_difference":
         """Amplifies the local deformation signal by reducing the influence
@@ -133,6 +147,14 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
             filter_par = [1, 10]
         local, regional = int(filter_par[0]), int(filter_par[1])
         print(f'filter parameter: local / regional kernel sizes = {local} / {regional}')
+
+    elif filter_type == 'median':
+        if not filter_par:
+            filter_par = 5
+        elif isinstance(filter_par, list):
+            filter_par = filter_par[0]
+        print(f'filter parameter:  median radius of {filter_par} pixels')
+
 
     # output filename
     if not fname_out:

--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -641,3 +641,34 @@ def model2hdf5_dataset(model, m=None, m_std=None, mask=None, ds_shape=None, resi
             i += 1
 
     return ds_dict, ds_name_dict, ds_unit_dict
+
+
+def hdf5_dataset2model(ds_dict, ds_name_dict, ds_unit_dict):
+    """ New function, incomplete.
+
+    Prepare the estimated model parameters into a list of dicts for HDF5 dataset writing.
+    Parameters: model        - dict,
+                m            - 2D np.ndarray in (num_param, num_pixel) where num_pixel = 1 or length * width
+                m_std        - 2D np.ndarray in (num_param, num_pixel) where num_pixel = 1 or length * width
+                mask         - 1D np.ndarray in (num_pixel), mask of valid pixels
+                ds_shape     - tuple of 2 int in (length, width)
+    Returns:    ds_dict      - dict, dictionary of dataset values,     input for writefile.write_hdf5_block()
+                ds_name_dict - dict, dictionary of dataset initiation, input for writefile.layout_hdf5()
+                ds_unit_dict - dict, dictionary of dataset unit,       input for writefile.layout_hdf5()
+    Examples:   # read input model parameters into dict
+                model = read_inps2model(inps, date_list=inps.date_list)
+                # for time series cube
+                ds_name_dict, ds_name_dict = model2hdf5_dataset(model, ds_shape=(200,300))[1:]
+                ds_dict = model2hdf5_dataset(model, m, m_std, mask=mask)[0]
+                # for time series point
+                ds_unit_dict = model2hdf5_dataset(model)[2]
+                ds_dict = model2hdf5_dataset(model, m, m_std)[0]
+    """
+    # deformation model info
+    poly_deg   = model['polynomial']
+    num_period = len(model['periodic'])
+    num_step   = len(model['stepDate'])
+    num_exp    = sum(len(val) for key, val in model['exp'].items())
+
+
+    return model, m, m_std

--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -644,7 +644,7 @@ def model2hdf5_dataset(model, m=None, m_std=None, mask=None, ds_shape=None, resi
 
 
 def hdf5_dataset2model(ds_dict, ds_name_dict, ds_unit_dict):
-    """ New function, incomplete.
+    """ New function, just a place holder now, incomplete.
 
     Prepare the estimated model parameters into a list of dicts for HDF5 dataset writing.
     Parameters: model        - dict,
@@ -663,12 +663,12 @@ def hdf5_dataset2model(ds_dict, ds_name_dict, ds_unit_dict):
                 # for time series point
                 ds_unit_dict = model2hdf5_dataset(model)[2]
                 ds_dict = model2hdf5_dataset(model, m, m_std)[0]
-    """
+
     # deformation model info
     poly_deg   = model['polynomial']
     num_period = len(model['periodic'])
     num_step   = len(model['stepDate'])
     num_exp    = sum(len(val) for key, val in model['exp'].items())
 
-
-    return model, m, m_std
+    """
+    return

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1798,10 +1798,10 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
         # numTriNonzeroIntAmbiguity: keep pixels in 0, i.e. 0 -> 1, the rest -> 0
         if os.path.basename(mask_file).startswith('numTriNonzeroIntAmbiguity'):
             if vmin is None and vmax is None:
-                vprint(f'keep pixels with numTriNonzeroIntAmbiguity == 0 and mask out the rest')
+                vprint('keep pixels with numTriNonzeroIntAmbiguity == 0 and mask out the rest')
                 mask = mask_data == 0
             else:
-                vprint(f'--mask-vmin/vmax is specified, skip translating numTriNonzeroIntAmbiguity values')
+                vprint('--mask-vmin/vmax is specified, skip translating numTriNonzeroIntAmbiguity values')
 
         # nan: mask out pixels in nan
         mask[np.isnan(mask_data)] = 0

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1745,6 +1745,9 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
                     print_msg=print_msg,
                 )[0]
                 vprint('read mask from file:', os.path.basename(mask_file))
+                # Kai: handle 0 in when 'numTriNonzeroIntAmbiguity.h5' as mask_file
+                if os.path.basename(mask_file).startswith('numTriNonzeroIntAmbiguity'):
+                    prior_good = np.array(mask == 0)
 
             else:
                 mask_file = None
@@ -1793,8 +1796,12 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
             mask = mask <= vmax
             vprint(f'hide pixels with mask value > {vmax}')
 
-        # set to bool type
-        mask = mask != 0
+        # Kai: handle zero when mask_file='numTriNonzeroIntAmbiguity.h5'
+        if os.path.basename(mask_file).startswith('numTriNonzeroIntAmbiguity'):
+            mask = (mask != 0) + prior_good
+        else:
+            # set to bool type
+            mask = mask != 0
 
     return mask, mask_file
 

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1725,8 +1725,8 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
             else:
                 mask_file = None
 
-    # Read mask file if inputed
-    mask = None
+    # read mask_data from file if inputed
+    mask_data = None
     if os.path.isfile(str(mask_file)):
         try:
             atr_msk = readfile.read_attribute(mask_file)
@@ -1738,16 +1738,13 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
                     dsName = f'connectComponent-{date12}'
 
                 # read mask data
-                mask = readfile.read(
+                mask_data = readfile.read(
                     mask_file,
                     box=box,
                     datasetName=dsName,
                     print_msg=print_msg,
                 )[0]
                 vprint('read mask from file:', os.path.basename(mask_file))
-                # Kai: handle 0 in when 'numTriNonzeroIntAmbiguity.h5' as mask_file
-                if os.path.basename(mask_file).startswith('numTriNonzeroIntAmbiguity'):
-                    prior_good = np.array(mask == 0)
 
             else:
                 mask_file = None
@@ -1764,44 +1761,53 @@ def read_mask(fname, mask_file=None, datasetName=None, box=None, xstep=1, ystep=
     elif k in ['HDFEOS']:
         if datasetName.split('-')[0] in TIMESERIES_DSET_NAMES:
             mask_file = fname
-            mask = readfile.read(fname, datasetName='mask', print_msg=print_msg)[0]
+            mask_data = readfile.read(fname, datasetName='mask', print_msg=print_msg)[0]
             vprint(f'read {k} contained mask dataset.')
 
     elif fname.endswith('PARAMS.h5'):
         mask_file = fname
         with h5py.File(fname, 'r') as f:
-            mask = f['cmask'][:] == 1.
+            mask_data = f['cmask'][:] == 1.
         vprint(f'read {os.path.basename(fname)} contained cmask dataset')
 
     # multilook
-    if mask is not None and xstep * ystep > 1:
+    if mask_data is not None and xstep * ystep > 1:
         # output size if x/ystep > 1
-        xsize = int(mask.shape[1] / xstep)
-        ysize = int(mask.shape[0] / ystep)
+        xsize = int(mask_data.shape[1] / xstep)
+        ysize = int(mask_data.shape[0] / ystep)
 
         # sampling
-        mask = mask[int(ystep/2)::ystep,
-                    int(xstep/2)::xstep]
-        mask = mask[:ysize, :xsize]
+        mask_data = mask_data[int(ystep/2)::ystep,
+                              int(xstep/2)::xstep]
+        mask_data = mask_data[:ysize, :xsize]
 
-    # set to bool type
-    if mask is not None:
-        mask[np.isnan(mask)] = 0
+    # convert mask_data to mask (via thresholding, value translation, etc.)
+    if mask_data is None:
+        mask = None
+    else:
+        mask = np.array(mask_data)
 
         # vmin/vmax: create mask based on the input thresholds
         if vmin is not None:
-            mask = mask >= vmin
+            mask = mask_data >= vmin
             vprint(f'hide pixels with mask value < {vmin}')
         if vmax is not None:
-            mask = mask <= vmax
+            mask = mask_data <= vmax
             vprint(f'hide pixels with mask value > {vmax}')
 
-        # Kai: handle zero when mask_file='numTriNonzeroIntAmbiguity.h5'
+        # numTriNonzeroIntAmbiguity: keep pixels in 0, i.e. 0 -> 1, the rest -> 0
         if os.path.basename(mask_file).startswith('numTriNonzeroIntAmbiguity'):
-            mask = (mask != 0) + prior_good
-        else:
-            # set to bool type
-            mask = mask != 0
+            if vmin is None and vmax is None:
+                vprint(f'keep pixels with numTriNonzeroIntAmbiguity == 0 and mask out the rest')
+                mask = mask_data == 0
+            else:
+                vprint(f'--mask-vmin/vmax is specified, skip translating numTriNonzeroIntAmbiguity values')
+
+        # nan: mask out pixels in nan
+        mask[np.isnan(mask_data)] = 0
+
+        # ensure output in bool type
+        mask = mask != 0
 
     return mask, mask_file
 


### PR DESCRIPTION
**Description of proposed changes**

Several modifications.

1. `diff.py`: does (timeseries) - (velocity) = (timeseries_new)
   + implemented by function `diff_timeseries_velocity()`
   + this commit is motivated by doing correction based on `inputs/ITRF.h5` velocity model in the time-series domain. Thus, the commit only allows a time function model `m` to identify linear, annual, and semiannual functions. Later, we can write a new ts2velo.hdf5_dataset2model() to produce this m based on the dataset_list names in general velocity files.

2. `spatial_filter.py`: add a median filter from `skimage.filters.median`
3. `image_stitch.py`: allow for vmin/vmax, cmap, and display unit
4. `plot.py`: numTriNonzeroIntAmbiguity.h5 mask out the non-zero values (non-zero is bad pixels) for mask creating
5. `gps.py` object: GPS time function fit with a user-defined model

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
