### PR TITLE
bugfix in `multilook` and `image_stitch` for non-hdf5 files

### DIFF
--- a/src/mintpy/multilook.py
+++ b/src/mintpy/multilook.py
@@ -186,6 +186,7 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', max_memory
             outfile = f'{fbase}_{lks_y}alks_{lks_x}rlks{fext}'
         else:
             outfile = os.path.basename(infile)
+    # use outfile for file extension, to support non-hdf5 infile and hdf5 outfile
     fext = os.path.splitext(outfile)[1]
 
     # update metadata
@@ -205,6 +206,7 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', max_memory
         # split in Y/row direction for IO for HDF5 only
         if fext in ['.h5', '.he5']:
             # calc step size with memory usage up to 4 GB
+            # use outfile as h5py may be be able to handle infile (non-hdf5)
             with h5py.File(outfile, 'r') as f:
                 ds_size = np.prod(f[dsName].shape) * 4
             num_step = int(np.ceil(ds_size * 4 / (max_memory * 1024**3)))

--- a/src/mintpy/multilook.py
+++ b/src/mintpy/multilook.py
@@ -180,12 +180,13 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', max_memory
         return outfile
 
     # output file name
-    fbase, fext = os.path.splitext(infile)
     if not outfile:
         if os.getcwd() == os.path.dirname(os.path.abspath(infile)):
+            fbase, fext = os.path.splitext(infile)
             outfile = f'{fbase}_{lks_y}alks_{lks_x}rlks{fext}'
         else:
             outfile = os.path.basename(infile)
+    fext = os.path.splitext(outfile)[1]
 
     # update metadata
     atr = attr.update_attribute4multilook(atr, lks_y, lks_x, box=box)
@@ -204,7 +205,7 @@ def multilook_file(infile, lks_y, lks_x, outfile=None, method='mean', max_memory
         # split in Y/row direction for IO for HDF5 only
         if fext in ['.h5', '.he5']:
             # calc step size with memory usage up to 4 GB
-            with h5py.File(infile, 'r') as f:
+            with h5py.File(outfile, 'r') as f:
                 ds_size = np.prod(f[dsName].shape) * 4
             num_step = int(np.ceil(ds_size * 4 / (max_memory * 1024**3)))
             row_step = int(np.rint(length / num_step / 10) * 10)


### PR DESCRIPTION
**Description of proposed changes**

+ multilook.py: Fix the bug when input file is binary (non-hdf5) and output file is hdf5.

+ image_stitch.py: support non-hdf5 geometry file, such as los.geo as produced by topsApp

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2181) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.