### PR TITLE
bugfix in `save_gdal` for boolean type & `cluster.split_box2sub_boxes` for tiny last step

### DIFF
--- a/src/mintpy/dem_error.py
+++ b/src/mintpy/dem_error.py
@@ -492,12 +492,11 @@ def correct_dem_error(inps):
 
     # split in row/line direction based on the input memory limit
     num_box = int(np.ceil((num_epoch * length * width * 4) * 2.5 / (inps.maxMemory * 1024**3)))
-    box_list = cluster.split_box2sub_boxes(
+    box_list, num_box = cluster.split_box2sub_boxes(
         box=(0, 0, width, length),
         num_split=num_box,
         dimension='y',
     )
-    num_box = len(box_list)
 
     # 3.2 prepare the input arguments for *_patch()
     data_kwargs = {

--- a/src/mintpy/dem_error.py
+++ b/src/mintpy/dem_error.py
@@ -497,6 +497,7 @@ def correct_dem_error(inps):
         num_split=num_box,
         dimension='y',
     )
+    num_box = len(box_list)
 
     # 3.2 prepare the input arguments for *_patch()
     data_kwargs = {

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -107,13 +107,12 @@ def diff_timeseries(file1, file2, out_file, force_diff=False, max_num_pixel=2e8)
     # block-by-block IO
     length, width = int(atr1['LENGTH']), int(atr1['WIDTH'])
     num_box = int(np.ceil(len(date_list1) * length * width / max_num_pixel))
-    box_list = cluster.split_box2sub_boxes(
+    box_list, num_box = cluster.split_box2sub_boxes(
         box=(0, 0, width, length),
         num_split=num_box,
         dimension='y',
         print_msg=True,
     )
-    num_box = len(box_list)
 
     for i, box in enumerate(box_list):
         if num_box > 1:
@@ -190,13 +189,12 @@ def diff_timeseries_and_velocity(file1, file2, out_file, max_num_pixel=2e8):
     # block-by-block IO
     length, width = int(atr1['LENGTH']), int(atr1['WIDTH'])
     num_box = int(np.ceil(len(date_list) * length * width / max_num_pixel))
-    box_list = cluster.split_box2sub_boxes(
+    box_list, num_box = cluster.split_box2sub_boxes(
         box=(0, 0, width, length),
         num_split=num_box,
         dimension='y',
         print_msg=True,
     )
-    num_box = len(box_list)
 
     for i, box in enumerate(box_list):
         box_wid = box[2] - box[0]

--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -113,6 +113,7 @@ def diff_timeseries(file1, file2, out_file, force_diff=False, max_num_pixel=2e8)
         dimension='y',
         print_msg=True,
     )
+    num_box = len(box_list)
 
     for i, box in enumerate(box_list):
         if num_box > 1:
@@ -195,6 +196,7 @@ def diff_timeseries_and_velocity(file1, file2, out_file, max_num_pixel=2e8):
         dimension='y',
         print_msg=True,
     )
+    num_box = len(box_list)
 
     for i, box in enumerate(box_list):
         box_wid = box[2] - box[0]

--- a/src/mintpy/objects/cluster.py
+++ b/src/mintpy/objects/cluster.py
@@ -30,9 +30,10 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
     """Divide the input box into `num_split` different sub_boxes.
 
     :param box: [x0, y0, x1, y1]: list[int] of size 4
-    :param num_split: int, the number of sub_boxes to split a box into
+    :param num_split: int, the initial number of sub_boxes to split a box into
     :param dimension: str = 'y' or 'x', the dimension along which to split the boxes
     :return: sub_boxes: list(list(4 int)), the splited sub boxes
+    :return: num_split: int, the final number of splitted sub_boxes
     """
     import numpy as np
 
@@ -80,7 +81,7 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
         print(f'split along {dimension} dimension ({dim_size:d}) into {num_split:d} boxes')
         print(f'    with each box up to {step:d} in {dimension} dimension')
 
-    return sub_boxes
+    return sub_boxes, num_split
 
 
 def set_num_threads(num_threads=None, print_msg=True):
@@ -239,8 +240,12 @@ class DaskCluster:
         # split the primary box into sub boxes for workers AND
         # update the number of workers based on split result
         box = func_data["box"]
-        sub_boxes = split_box2sub_boxes(box, num_split=self.num_worker, dimension='x', print_msg=False)
-        self.num_worker = len(sub_boxes)
+        sub_boxes, self.num_worker = split_box2sub_boxes(
+            box,
+            num_split=self.num_worker,
+            dimension='x',
+            print_msg=False,
+        )
         print(f'split patch into {self.num_worker} sub boxes in x direction for workers to process')
 
         # start a bunch of workers from the cluster

--- a/src/mintpy/objects/cluster.py
+++ b/src/mintpy/objects/cluster.py
@@ -50,8 +50,14 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
     else:
         dim_size = width
     step = int(np.ceil(dim_size / num_split))
-    step = max(step, 10)                       # constain the min step size
-    num_split = int(np.ceil(dim_size / step))  # trim the final number of boxes
+    # condition: step >= 10
+    step = max(step, 10)
+    # update num_split based on the final step size
+    num_split = int(np.ceil(dim_size / step))
+    # if the last step is too small, merge it into the 2nd last one
+    last_step = dim_size - step * (num_split - 1)
+    if last_step < step * 0.05 or last_step < 5:
+        num_split -= 1
 
     # get list of boxes
     sub_boxes = []
@@ -59,13 +65,15 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
         if dimension == 'y':
             r0 = y0 + step * i
             r1 = y0 + step * (i + 1)
-            r1 = min(r1, y1)
+            if i == num_split - 1:
+                r1 = y1
             sub_boxes.append([x0, r0, x1, r1])
 
         else:
             c0 = x0 + step * i
             c1 = x0 + step * (i + 1)
-            c1 = min(c1, x1)
+            if i == num_split - 1:
+                c1 = x1
             sub_boxes.append([c0, y0, c1, y1])
 
     if print_msg:

--- a/src/mintpy/objects/cluster.py
+++ b/src/mintpy/objects/cluster.py
@@ -39,7 +39,7 @@ def split_box2sub_boxes(box, num_split, dimension='x', print_msg=False):
 
     dimension = dimension.lower()
     if num_split <= 1:
-        return [box]
+        return [box], num_split
 
     # basic info
     x0, y0, x1, y1 = box

--- a/src/mintpy/objects/resample.py
+++ b/src/mintpy/objects/resample.py
@@ -457,13 +457,12 @@ class resample:
 
             # split dest_box (in grid)
             # and update num_box based on the actual dest_box_list
-            self.dest_box_list = split_box2sub_boxes(
+            self.dest_box_list, self.num_box = split_box2sub_boxes(
                 box=(0, 0, self.width, self.length),
                 num_split=self.num_box,
                 dimension='y',
                 print_msg=True,
             )
-            self.num_box = len(self.dest_box_list)
 
             # dest_box --> src_box / src_def / dest_def
             for i, dest_box in enumerate(self.dest_box_list):

--- a/src/mintpy/reference_date.py
+++ b/src/mintpy/reference_date.py
@@ -97,6 +97,7 @@ def change_timeseries_ref_date(ts_file, ref_date, outfile=None, max_memory=4.0, 
         dimension='y',
         print_msg=True,
     )
+    num_box = len(box_list)
 
     # updating existing file or write new file
     if outfile == ts_file:

--- a/src/mintpy/reference_date.py
+++ b/src/mintpy/reference_date.py
@@ -91,13 +91,12 @@ def change_timeseries_ref_date(ts_file, ref_date, outfile=None, max_memory=4.0, 
 
     # get list of boxes for block-by-block IO
     num_box = int(np.ceil((num_date * length * width * 4 * 2) / (max_memory * 1024**3)))
-    box_list = split_box2sub_boxes(
+    box_list, num_box = split_box2sub_boxes(
         box=(0, 0, width, length),
         num_split=num_box,
         dimension='y',
         print_msg=True,
     )
-    num_box = len(box_list)
 
     # updating existing file or write new file
     if outfile == ts_file:

--- a/src/mintpy/save_gdal.py
+++ b/src/mintpy/save_gdal.py
@@ -8,6 +8,7 @@
 import os
 import warnings
 
+import numpy as np
 from osgeo import gdal, osr
 
 from mintpy.utils import plot as pp, readfile, utils0 as ut
@@ -54,6 +55,11 @@ def write_gdal(data, meta, out_file, out_fmt='GTiff'):
         msg = 'No EPSG or UTM_ZONE metadata found! '
         msg += 'Assume EPSG = 4326 (WGS84) and continue.'
         warnings.warn(msg)
+
+    # convert boolean to uint8, as GDAL does not have a direct analogue to boolean
+    if data.dtype == 'bool':
+        print('convert data from boolean to uint8, as GDAL does not support boolean')
+        data = np.array(data, dtype=np.uint8)
 
     # write file
     driver = gdal.GetDriverByName(out_fmt)

--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -211,6 +211,7 @@ def run_timeseries2time_func(inps):
                                            num_split=num_box,
                                            dimension='y',
                                            print_msg=True)
+    num_box = len(box_list)
 
     # loop for block-by-block IO
     for i, box in enumerate(box_list):

--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -207,11 +207,12 @@ def run_timeseries2time_func(inps):
     if inps.uncertaintyQuantification == 'bootstrap':
         memoryAll += inps.bootstrapCount * num_param * length * width * 4
     num_box = int(np.ceil(memoryAll * 3 / (inps.maxMemory * 1024**3)))
-    box_list = cluster.split_box2sub_boxes(box=(0, 0, width, length),
-                                           num_split=num_box,
-                                           dimension='y',
-                                           print_msg=True)
-    num_box = len(box_list)
+    box_list, num_box = cluster.split_box2sub_boxes(
+        box=(0, 0, width, length),
+        num_split=num_box,
+        dimension='y',
+        print_msg=True,
+    )
 
     # loop for block-by-block IO
     for i, box in enumerate(box_list):


### PR DESCRIPTION
**Description of proposed changes**

+ `save_gdal.py`: convert numpy array from boolean to uint8, as GDAL does not support boolean data type, such as used in all the mask files.

+ `objects.cluster.split_box2sub_boxes()`: avoid the tiny last step (<5% of the normal step, or <5 pixels), by merging it into the 2nd last one. This happens to very large datasets sometimes. For example, if the last step has a size of 1, a 3D matrix will be turned into 2D, resulting in a reshape error.

+ `objects.cluster.split_box2sub_boxes()`: return the final number of sub_boxes, in addition to the current list of sub_boxes, for easier usage (as it may be different from the initial num_box as identified in #940). Update the usage in all occurrences:
   - objects.resample
   - dem_error
   - diff
   - reference_date
   - timeseries2velocity

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2189) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.