### PR TITLE
add `view --interpolation` option

### DIFF
--- a/src/mintpy/cli/modify_network.py
+++ b/src/mintpy/cli/modify_network.py
@@ -221,7 +221,7 @@ def read_input_index_list(idxList, stackFile=None):
             print('Unrecoganized input: '+idx)
     idxListOut = sorted(set(idxListOut))
 
-    # remove index not existed in the input ifgram stack file
+    # remove index not existing in the input ifgram stack file
     if stackFile:
         obj = ifgramStack(stackFile)
         obj.open(print_msg=False)

--- a/src/mintpy/cli/prep_gamma.py
+++ b/src/mintpy/cli/prep_gamma.py
@@ -39,13 +39,13 @@ NOTE = """
   2) secondary .par file, e.g. 130129_4rlks.amp.par
   3) interferogram .off file, e.g. 130118-130129_4rlks.off
 
-  Other metadata files are recommended and can be generated from the above 3 if not existed, more specifically:
+  Other metadata files are recommended and can be generated from the above 3 if not existing, more specifically:
   4) baseline files, e.g. 130118-130129_4rlks.baseline and 130118-130129_4rlks.base_perp,
       which can be generated from file 1-3 with Gamma command base_orbit and base_perp.
   5) corner files, e.g. 130118_4rlks.amp.corner_full and 130118_4rlks.amp.corner,
       which can be generated from file 1 with Gamma command SLC_corners.
 
-  This script will read all these files (generate 4 and 5 if not existed), merge them into one, convert their name from
+  This script will read all these files (generate 4 and 5 if not existing), merge them into one, convert their name from
   Gamma style to ROI_PAC style, and write to an metadata file, same name as input binary data file with suffix .rsc,
   e.g. diff_filt_HDR_130118-130129_4rlks.unw.rsc
 

--- a/src/mintpy/modify_network.py
+++ b/src/mintpy/modify_network.py
@@ -82,7 +82,7 @@ def manual_select_pairs_to_remove(stackFile):
                 date12_click.append(date12)
                 ax.plot([datesNum[mIdx], datesNum[sIdx]], [pbase[mIdx], pbase[sIdx]], 'r', lw=4)
             else:
-                print(date12+' is not existed in input file')
+                print(date12+' does not exist in input file')
         plt.draw()
 
     fig.canvas.mpl_connect('button_press_event', onclick)

--- a/src/mintpy/objects/stackDict.py
+++ b/src/mintpy/objects/stackDict.py
@@ -751,7 +751,7 @@ class geometryDict:
                                           compression=compression)
 
             ###############################
-            # Generate Dataset if not existed in binary file: incidenceAngle, slantRangeDistance
+            # Generate Dataset if it doesn't exist as a binary file: incidenceAngle, slantRangeDistance
             for dsName in [i for i in ['incidenceAngle', 'slantRangeDistance'] if i not in self.dsNames]:
                 # Calculate data
                 data = None

--- a/src/mintpy/prep_gamma.py
+++ b/src/mintpy/prep_gamma.py
@@ -70,7 +70,7 @@ def get_perp_baseline(m_par_file, s_par_file, off_file, atr_dict={}):
 
 def get_lalo_ref(m_par_file, atr_dict={}):
     """Extract LAT/LON_REF1/2/3/4 from corner file, e.g. 130118_4rlks.amp.corner.
-    If it's not existed, call Gamma script - SLC_corners - to generate it from SLC par file
+    If it does not exist, call Gamma script - SLC_corners - to generate it from SLC par file
         e.g. 130118_4rlks.amp.par
 
     Parameters: m_par_file - str, path, reference date parameter file, i.e. 130118_4rlks.amp.par

--- a/src/mintpy/simulation/iono.py
+++ b/src/mintpy/simulation/iono.py
@@ -538,7 +538,7 @@ def read_sub_tec(tec_file, version=2.1, print_msg=True):
 
 def check_date_list_against_reference(date_list, dset_list, date_list_ref, fill_value=np.nan):
     """Check input date/dset_list against the reference date list:
-    1. remove dates that are not existed in the reference date list
+    1. remove dates that are not existing in the reference date list
     2. fill data of the missing dates
     """
     # remove dates not in date_list_ref

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -60,7 +60,11 @@ def add_data_disp_argument(parser):
     data.add_argument('--nd','--no-data-val','--no-data-value', dest='no_data_value', type=float,
                       help='Specify the no-data-value to be ignored and masked.')
 
-    data.add_argument('--interpolation', default='nearest', help='Matplotlib interpolation method')
+    data.add_argument('--interp','--interpolation', dest='interpolation', default='nearest',
+                      help='matplotlib interpolation method for imshow, e.g.:\n'
+                           'none, antialiased, nearest, bilinear, bicubic, spline16, sinc, etc. Check more at:\n'
+                           'https://matplotlib.org/stable/gallery/images_contours_and_fields/'
+                           'interpolation_methods.html')
     data.add_argument('--wrap', action='store_true',
                       help='re-wrap data to display data in fringes.')
     data.add_argument('--wrap-range', dest='wrap_range', type=float, nargs=2,

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -60,6 +60,7 @@ def add_data_disp_argument(parser):
     data.add_argument('--nd','--no-data-val','--no-data-value', dest='no_data_value', type=float,
                       help='Specify the no-data-value to be ignored and masked.')
 
+    data.add_argument('--interpolation', default='nearest', help='Matplotlib interpolation method')
     data.add_argument('--wrap', action='store_true',
                       help='re-wrap data to display data in fringes.')
     data.add_argument('--wrap-range', dest='wrap_range', type=float, nargs=2,

--- a/src/mintpy/utils/network.py
+++ b/src/mintpy/utils/network.py
@@ -781,7 +781,7 @@ def select_pairs_star(date_list, m_date=None, pbase_list=[], date_format='YYMMDD
     date8_list = sorted(ptime.yyyymmdd(date_list))
     date6_list = ptime.yymmdd(date8_list)
 
-    # Select reference date if not existed
+    # Select reference date if not chosen
     if not m_date:
         m_date = select_reference_date(date8_list, pbase_list)
         print('auto select reference date: '+m_date)
@@ -789,7 +789,7 @@ def select_pairs_star(date_list, m_date=None, pbase_list=[], date_format='YYMMDD
     # Check input reference date
     m_date8 = ptime.yyyymmdd(m_date)
     if m_date8 not in date8_list:
-        print('Input reference date is not existed in date list!')
+        print('Input reference date does not exist in date list!')
         print(f'Input reference date: {m_date8}')
         print(f'Input date list: {date8_list}')
         m_date8 = None

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -511,7 +511,7 @@ def plot_slice(ax, data, metadata, inps):
             inps.disp_ref_pixel = False
 
         im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
-                       extent=extent, origin='upper', interpolation='nearest',
+                       extent=extent, origin='upper', interpolation=inps.interpolation,
                        alpha=inps.transparency, animated=inps.animation, zorder=1)
 
         # Draw faultline using GMT lonlat file
@@ -625,7 +625,7 @@ def plot_slice(ax, data, metadata, inps):
         extent = (inps.pix_box[0]-0.5, inps.pix_box[2]-0.5,
                   inps.pix_box[3]-0.5, inps.pix_box[1]-0.5)
         im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
-                       extent=extent, interpolation='nearest', alpha=inps.transparency, zorder=1)
+                       extent=extent, interpolation=inps.interpolation, alpha=inps.transparency, zorder=1)
         ax.tick_params(labelsize=inps.font_size)
 
         # Plot Seed Point
@@ -1166,7 +1166,7 @@ def plot_subplot4figure(i, inps, ax, data, metadata):
               inps.pix_box[3]-0.5, inps.pix_box[1]-0.5)
 
     im = ax.imshow(data, cmap=inps.colormap, vmin=vlim[0], vmax=vlim[1],
-                   interpolation='nearest', alpha=inps.transparency,
+                   interpolation=inps.interpolation, alpha=inps.transparency,
                    extent=extent, zorder=1)
 
     # Plot Seed Point


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Adds the ability to specify a matplotlib  option on the command line for `view.py`, e.g. `mintpy view --interpolation nearest`.
After implementing this, I saw it was already on the wiki To Do list.

The other changes were small typos I had seen pop up on my spell checker. I can split them off if you don't want them in this PR.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
