### PR TITLE
fix bug in gdal -> mintpy corner coordinate convention

### DIFF
--- a/src/mintpy/prep_aria.py
+++ b/src/mintpy/prep_aria.py
@@ -180,8 +180,8 @@ def extract_metadata(stack):
     x_step = abs(transform[1])
     y_step = abs(transform[5]) * -1.
 
-    W = transform[0] - x_step / 2.
-    N = transform[3] - y_step / 2.
+    W = transform[0]
+    N = transform[3]
     E = W + x_step * ds.RasterXSize
     S = N + y_step * ds.RasterYSize
 

--- a/src/mintpy/prep_gmtsar.py
+++ b/src/mintpy/prep_gmtsar.py
@@ -59,8 +59,8 @@ def get_lalo_ref(ifg_dir, prm_dict, fbases=['corr', 'phase', 'phasefilt', 'unwra
     if not (1e-7 < x_step < 1.):
         raise ValueError('File {} is NOT geocoded!')
 
-    W = transform[0] - x_step / 2.
-    N = transform[3] - y_step / 2.
+    W = transform[0]
+    N = transform[3]
     E = W + x_step * ds.RasterXSize
     S = N + y_step * ds.RasterYSize
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1634,7 +1634,10 @@ def read_gdal_vrt(fname):
     atr['INTERLEAVE'] = ENVI_BAND_INTERLEAVE[interleave]
 
     # transformation contains gridcorners
-    # (lines/pixels or lonlat and the spacing 1/-1 or deltalon/deltalat)
+    #   lines/pixels with a spacing of 1/-1 OR lonlat with a spacing of deltalon/deltalat
+    # GDAL uses the upper-left corner of the upper-left pixel as the first coordinate,
+    #   which is the same as ROI_PAC and MintPy
+    #   link: https://gdal.org/tutorials/geotransforms_tut.html
     transform = ds.GetGeoTransform()
     x0 = transform[0]
     y0 = transform[3]

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1587,6 +1587,8 @@ def read_envi_hdr(fname):
     atr['DATA_TYPE'] = DATA_TYPE_ENVI2NUMPY[atr.get('data type', '4')]
     atr['BYTE_ORDER'] = ENVI_BYTE_ORDER[atr.get('byte order', '1')]
 
+    # ENVI seems to use the center of the upper-left pixel as the first coordinates
+    # link: https://www.l3harrisgeospatial.com/docs/OverviewMapInformationInENVI.html
     if 'map info' in atr.keys():
         map_info = [i.replace('{','').replace('}','').strip() for i in atr['map info'].split(',')]
         x_step = abs(float(map_info[5]))

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1643,8 +1643,8 @@ def read_gdal_vrt(fname):
 
     atr['X_STEP'] = x_step
     atr['Y_STEP'] = y_step
-    atr['X_FIRST'] = x0 - x_step / 2.
-    atr['Y_FIRST'] = y0 - y_step / 2.
+    atr['X_FIRST'] = x0
+    atr['Y_FIRST'] = y0
 
     # projection / coordinate unit
     srs = osr.SpatialReference(wkt=ds.GetProjection())


### PR DESCRIPTION
**Description of proposed changes**

Through the ARIA products workflow, or whenever loading a gdal file in general, an erroneous shift appears to be applied to the accessed geotransform and the derived `x_first` and `y_first` fields. Specifically, an extra half pixel shift (to the north and west) is applied when the gdal geotransform object already reports the coordinates of the [upper left pixel](https://gdal.org/tutorials/geotransforms_tut.html).

I've tracked this bug in a few scripts, but would like advise on where else I should look to track down potential persistent issues.

**Reminders**

- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.