### PR TITLE
hdfeos5: calc/write latitude/longitude if missing in geometry file

### DIFF
--- a/src/mintpy/cli/save_hdfeos5.py
+++ b/src/mintpy/cli/save_hdfeos5.py
@@ -92,6 +92,10 @@ def cmd_line_parse(iargs=None):
     if inps.subset and 'Y_FIRST' not in meta.keys():
         raise SystemExit('ERROR: --subset mode is NOT supported for time-series in radar-coordinates!')
 
+    # check: coordinate
+    if not 'Y_FIRST' in meta.keys():
+        raise ValueError(f'Input file {inps.ts_file} is NOT geocoded!')
+
     return inps
 
 

--- a/src/mintpy/save_hdfeos5.py
+++ b/src/mintpy/save_hdfeos5.py
@@ -390,9 +390,22 @@ def write_hdf5_file(metadata, out_file, ts_file, tcoh_file, scoh_file, mask_file
 
         geom_obj = geometry(geom_file)
         geom_obj.open(print_msg=False)
-        for dsName in geom_obj.datasetNames:
+
+        # add latitude/longitude if missing, e.g. ARIA/HyP3
+        dsNames = geom_obj.datasetNames + ['latitude', 'longitude']
+        dsNames = list(set(dsNames))
+
+        for dsName in dsNames:
             # read
-            data = geom_obj.read(datasetName=dsName, print_msg=False)
+            if dsName in geom_obj.datasetNames:
+                data = geom_obj.read(datasetName=dsName, print_msg=False)
+            elif dsName == 'latitude':
+                data = ut.get_lat_lon(metadata, dimension=2)[0]
+            elif dsName == 'longitude':
+                data = ut.get_lat_lon(metadata, dimension=2)[1]
+            else:
+                raise ValueError(f'Un-recognized dataset name: {dsName}!')
+
             # write
             dset = create_hdf5_dataset(group, dsName, data)
 

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -126,9 +126,10 @@ def auto_figure_size(ds_shape, scale=1.0, disp_cbar=False, disp_slider=False,
                     max_figsize_height / fig_shape[1])
 
     # fig_shape/scale --> fig_size
-    fig_size = [i*fig_scale*scale for i in fig_shape]
+    fig_size = [x*fig_scale*scale for x in fig_shape]
+    fig_size = [float(f'{x:.1f}') for x in fig_size]
     if print_msg:
-        print(f'figure size : [{fig_size[0]:.2f}, {fig_size[1]:.2f}]')
+        print(f'figure size : [{fig_size[0]}, {fig_size[1]}]')
 
     return fig_size
 

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1263,6 +1263,8 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
         # ignore Std because it shares the same unit as base parameter
         # e.g. velocityStd and velocity
         datasetName = datasetName.replace('Std','')
+        # use the last segment if / is used, e.g. HDF-EOS5
+        datasetName = datasetName.split('/')[-1]
     ftype = atr['FILE_TYPE'].replace('.', '')
     if ftype == 'ifgramStack':
         if datasetName and datasetName in DSET_UNIT_DICT.keys():

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -981,11 +981,20 @@ def update_figure_setting(inps):
                 data_shape,
                 fig_size4plot,
                 inps.fig_num)
-        inps.fig_num = np.ceil(float(inps.dsetNum) / float(inps.fig_row_num * inps.fig_col_num)).astype(int)
+        inps.fig_num = float(inps.dsetNum) / float(inps.fig_row_num * inps.fig_col_num)
+        inps.fig_num = np.ceil(inps.fig_num).astype(int)
         vprint('dataset number: '+str(inps.dsetNum))
         vprint('row     number: '+str(inps.fig_row_num))
         vprint('column  number: '+str(inps.fig_col_num))
         vprint('figure  number: '+str(inps.fig_num))
+
+        # adjust figure size for single row plot, to avoid extra whitespace
+        if inps.fig_row_num == 1 and '--figsize' not in inps.argv:
+            inps.fig_size = pp.auto_figure_size(
+                ds_shape=(length, width*inps.fig_col_num),
+                disp_cbar=inps.disp_cbar,
+                print_msg=False)
+            vprint(f'row number is 1, adjust figure size to {inps.fig_size}')
 
         if not inps.font_size:
             inps.font_size = 12
@@ -1199,8 +1208,8 @@ def plot_subplot4figure(i, inps, ax, data, metadata):
         # get title
         subplot_title = None
         if inps.key in TIMESERIES_KEY_NAMES or inps.dset[0].startswith('bperp'):
-            # support / for py2-mintpy
-            date_str = inps.dset[i].replace('/','-').split('-')[1]
+            # support "/" in the dataset names, e.g. HDF-EOS5 and py2-mintpy formats
+            date_str = inps.dset[i].replace('/','-').split('-')[-1]
             try:
                 subplot_title = dt.datetime.strptime(date_str, '%Y%m%d').isoformat()[0:10]
             except:


### PR DESCRIPTION
**Description of proposed changes**

+ save_hdfeos5: always write latitude/longitude dataset, and calculate based on metadata if missing in the geometry file, such as ARIA. Related to #1049.

+ cli/save_hdfeos5: check the coordinate of input file

+ improved UNIT and fig title handling for HDF-EOS5 product:
   - utils.readfile.read_attribute(): while grab the UNIT, use the last segment of dataset name if "/" is used
   - view.plot_subplot4figure(): use the last segment as the auto figure title, instead of the 2nd one, to be more generic

+ view: improved auto figsize for subplots when there is only one row of subplots

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2225/workflows/63f49761-b636-485e-aded-bae88fc7f225/jobs/2233) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.