### PR TITLE
fix the UTM_ZONE confusion

### DIFF
--- a/docs/api/attributes.md
+++ b/docs/api/attributes.md
@@ -51,7 +51,7 @@ The following attributes vary for each interferogram:
 +  SUBSET_XMIN/XMAX/YMIN/YMAX = start/end column/row number of subset in the original coverage
 +  MODIFICATION_TIME = dataset modification time, exists in ifgramStack.h5 file for 3D dataset, used for "--update" option of unwrap error corrections.
 +  NCORRLOOKS = number of independent looks, as explained in [SNAPHU](https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/snaphu.conf.full)
-+  UTM_ZONE = UTM zone, e.g. 60S, for geocoded file with UTM projection only.
++  UTM_ZONE = UTM zone, comprises a zone number and a hemisphere, e.g. 11N, 60S, for geocoded file with UTM projection only.
 +  EPSG = EPSG code for coordinate systems, for geocoded files only.
 
 ### Reference ###

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -260,17 +260,16 @@ def touch(fname_list, times=None):
 def utm_zone2epsg_code(utm_zone):
     """Convert UTM Zone string to EPSG code.
 
-    Parameters: utm_zone  - str, atr['UTM_ZONE']
+    Parameters: utm_zone  - str, atr['UTM_ZONE'], comprises a zone number
+                            and a hemisphere, e.g. 11N, 36S, etc.
     Returns:    epsg_code - str, EPSG code
     Examples:   epsg_code = utm_zone2epsg_code('11N')
     """
     from pyproj import CRS
-
-    # N is the first letter in the northern hemisphere
     crs = CRS.from_dict({
         'proj': 'utm',
         'zone': int(utm_zone[:-1]),
-        'south': utm_zone[-1].upper() < 'N',
+        'south': utm_zone[-1].upper() == 'S',
     })
     epsg_code = crs.to_authority()[1]
     return epsg_code
@@ -318,8 +317,8 @@ def utm2latlon(meta, easting, northing):
     """
     import utm
     zone_num = int(meta['UTM_ZONE'][:-1])
-    lat_band = meta['UTM_ZONE'][-1].upper()
-    lat, lon = utm.to_latlon(easting, northing, zone_num, lat_band)
+    northern = meta['UTM_ZONE'][-1].upper() == 'N'
+    lat, lon = utm.to_latlon(easting, northing, zone_num, northern=northern)
     return lat, lon
 
 
@@ -330,11 +329,9 @@ def latlon2utm(lat, lon):
                 lon      - scalar or 1/2D np.ndarray, WGS 84 coordiantes in x direction
     Returns:    easting  - scalar or 1/2D np.ndarray, UTM    coordiantes in x direction
                 northing - scalar or 1/2D np.ndarray, UTM    coordiantes in y direction
-                zone_num - int, UTM zone number, from 1 to 60
-                lat_band - str, MGRS latitude band, C-X omitting I and O
     """
     import utm
-    return utm.from_latlon(lat, lon)
+    return utm.from_latlon(lat, lon)[:2]
 
 
 def snwe_to_wkt_polygon(snwe):


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes the previous confusion that UTM_ZONE should end with the hemisphere, not the latitude band, which is not part of UTM but part of MGRS, as described in https://github.com/insarlab/MintPy/pull/1052#discussion_r1280899939.

+ utils.utils0.utm_zone2epsg_code(): revert back the south arg feeding from UTM_ZONE

+ utils.utils0.utm2latlon(): use the `northern` arg instead of the latitude band, to match the meaning of UTM_ZONE metadata

+ utils.utils0.latlon2utm(): return east/north only, for simplicity and style consistency with utm2latlon.

+ docs/api/attributes.UTM_ZONE: add more description and examples

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2243) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.