### PR TITLE
tsview --figsize-img & relaxed subset tmpl reading

### DIFF
--- a/src/mintpy/cli/tsview.py
+++ b/src/mintpy/cli/tsview.py
@@ -35,10 +35,9 @@ def create_parser(subparsers=None):
         name, synopsis=synopsis, description=synopsis, epilog=epilog, subparsers=subparsers)
 
     parser.add_argument('file', nargs='+',
-                        help='time-series file to display\n'
-                             'i.e.: timeseries_ERA5_ramp_demErr.h5 (MintPy)\n'
-                             '      LS-PARAMS.h5 (GIAnT)\n'
-                             '      S1_IW12_128_0593_0597_20141213_20180619.he5 (HDF-EOS5)')
+                        help='time-series file to display, e.g.:\n'
+                             'timeseries_ERA5_ramp_demErr.h5 (MintPy)\n'
+                             'S1_IW12_128_0593_0597_20141213_20180619.he5 (HDF-EOS5)')
     parser.add_argument('--label', dest='file_label', nargs='*',
                         help='labels to display for multiple input files')
     parser.add_argument('--ylim', dest='ylim', nargs=2, metavar=('YMIN', 'YMAX'), type=float,
@@ -103,7 +102,7 @@ def create_parser(subparsers=None):
     # other groups
     parser = arg_utils.add_data_disp_argument(parser)
     parser = arg_utils.add_dem_argument(parser)
-    parser = arg_utils.add_figure_argument(parser)
+    parser = arg_utils.add_figure_argument(parser, figsize_img=True)
     parser = arg_utils.add_gps_argument(parser)
     parser = arg_utils.add_mask_argument(parser)
     parser = arg_utils.add_map_argument(parser)

--- a/src/mintpy/subset.py
+++ b/src/mintpy/subset.py
@@ -63,25 +63,37 @@ def read_subset_template2box(template_file):
     Parameters: template_file - str, path to the template file
     Returns     pix/geo_box   - tuple of 4 int or None
     """
+    # initiate output
+    pix_box, geo_box = None, None
+
+    # read template file into dict
     tmpl = readfile.read_template(template_file)
 
-    # subset.lalo -> geo_box
-    try:
-        opts = [i.strip().replace('[','').replace(']','') for i in tmpl['mintpy.subset.lalo'].split(',')]
-        lat0, lat1 = sorted(float(i.strip()) for i in opts[0].split(':'))
-        lon0, lon1 = sorted(float(i.strip()) for i in opts[1].split(':'))
-        geo_box = (lon0, lat1, lon1, lat0)
-    except:
-        geo_box = None
+    # dict: yx -> pix_box
+    key = 'mintpy.subset.yx'
+    if key in tmpl.keys():
+        # ignore common typo: [ ]
+        opt_str = tmpl[key].replace('[','').replace(']','')
+        # convert : to ,
+        opt_str = opt_str.replace(':',',')
 
-    # subset.yx -> pix_box
-    try:
-        opts = [i.strip().replace('[','').replace(']','') for i in tmpl['mintpy.subset.yx'].split(',')]
-        y0, y1 = sorted(int(i.strip()) for i in opts[0].split(':'))
-        x0, x1 = sorted(int(i.strip()) for i in opts[1].split(':'))
-        pix_box = (x0, y0, x1, y1)
-    except:
-        pix_box = None
+        opt_str_list = [i.strip() for i in opt_str.split(',')]
+        if len(opt_str_list) == 4:
+            y0, y1, x0, x1 = (int(i) for i in opt_str_list)
+            pix_box = (x0, y0, x1, y1)
+
+    # dict: lalo -> geo_box
+    key = 'mintpy.subset.lalo'
+    if key in tmpl.keys():
+        # ignore common typo: [ ]
+        opt_str = tmpl[key].replace('[','').replace(']','')
+        # convert : to ,
+        opt_str = opt_str.replace(':',',')
+
+        opt_str_list = [i.strip() for i in opt_str.split(',')]
+        if len(opt_str_list) == 4:
+            lat0, lat1, lon0, lon1 = (float(i) for i in opt_str_list)
+            geo_box = (lon0, lat1, lon1, lat0)
 
     return pix_box, geo_box
 

--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -680,7 +680,8 @@ class timeseriesViewer():
 
         self, self.atr = read_init_info(self)
 
-        # input figsize for the point time-series plot
+        # input figsize for the image/point time-series plot
+        self.figsize_img = self.fig_size_img
         self.figsize_pts = self.fig_size
         self.pts_marker = 'r^'
         self.pts_marker_size = 6.
@@ -836,7 +837,7 @@ class timeseriesViewer():
         # call view.py to plot
         self.img, self.cbar_img = view.plot_slice(self.ax_img, img_data, self.atr, self)[2:4]
         self.fig_img.canvas.manager.set_window_title(self.figname_img)
-        self.fig_img.tight_layout(rect=(0,0,1,0.97))
+        self.fig_img.tight_layout(rect=(0, 0.16, 1, 0.97))
 
         return self.img, self.cbar_img
 
@@ -844,7 +845,7 @@ class timeseriesViewer():
     def plot_init_time_slider(self, init_idx=-1, ref_idx=None):
         """Plot the initial slider."""
         # initiate axes
-        self.fig_img.subplots_adjust(bottom=0.16)
+        #self.fig_img.subplots_adjust(bottom=0.16)
         self.ax_tslider = self.fig_img.add_axes([0.125, 0.05, 0.75, 0.03])
 
         # plot slider

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -130,7 +130,7 @@ def add_dem_argument(parser):
     return parser
 
 
-def add_figure_argument(parser):
+def add_figure_argument(parser, figsize_img=False):
     """Argument group parser for figure options"""
     fig = parser.add_argument_group('Figure', 'Figure settings for display')
     fig.add_argument('--fontsize', dest='font_size',
@@ -186,6 +186,9 @@ def add_figure_argument(parser):
                      help='display Sentinel-1 A/B and IPF info in title.')
 
     # size, subplots number and space
+    if figsize_img:
+        fig.add_argument('--figsize-img', dest='fig_size_img', metavar=('WID', 'LEN'), type=float, nargs=2,
+                         help='figure size in inches for the image/map (for tsview.py) figure')
     fig.add_argument('--figsize', dest='fig_size', metavar=('WID', 'LEN'), type=float, nargs=2,
                      help='figure size in inches - width and length')
     fig.add_argument('--dpi', dest='fig_dpi', metavar='DPI', type=int, default=300,


### PR DESCRIPTION
**Description of proposed changes**

+ `tsview`: add `--figsize-img` option to be able to customize the map figure size. Make this arg optional so that other existing functionalities won't be affected.

+ `subset.read_subset_template2box`:
   - support mix separator/delimiter of `:` and `,` so that values from `isce-proc` also work
   - replace `try/except` with `if` judgment

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2248/workflows/feeda3c2-5bf5-42ca-b81a-2193aca23c12/jobs/2256) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.