### PR TITLE
tropo_pyaps3: bugfix for hyp3 product

### DIFF
--- a/src/mintpy/prep_hyp3.py
+++ b/src/mintpy/prep_hyp3.py
@@ -14,7 +14,7 @@ from mintpy.utils import readfile, utils1 as ut, writefile
 
 
 #########################################################################
-def add_hyp3_metadata(fname,meta,is_ifg=True):
+def add_hyp3_metadata(fname, meta, is_ifg=True):
     '''Read/extract attribute data from HyP3 metadata file and add to metadata dictionary
     Inputs:
         *unw_phase.tif, *corr.tif file name, *dem.tif, *inc_map.tif, e.g.
@@ -56,6 +56,10 @@ def add_hyp3_metadata(fname,meta,is_ifg=True):
     W = float(meta['X_FIRST'])
     S = N + float(meta['Y_STEP']) * int(meta['LENGTH'])
     E = W + float(meta['X_STEP']) * int(meta['WIDTH'])
+
+    # convert UTM to lat/lon
+    N, W = ut.utm2latlon(meta, W, N)
+    S, E = ut.utm2latlon(meta, E, S)
 
     if meta['ORBIT_DIRECTION'] == 'ASCENDING':
         meta['LAT_REF1'] = str(S)

--- a/src/mintpy/tropo_pyaps3.py
+++ b/src/mintpy/tropo_pyaps3.py
@@ -279,8 +279,8 @@ def get_bounding_box(meta, geom_file=None):
         # e.g. meters for UTM projection from ASF HyP3
         y_unit = meta.get('Y_UNIT', 'degrees').lower()
         if not y_unit.startswith('deg'):
-            lat0, lon0 = ut.to_latlon(meta['OG_FILE_PATH'], lon0, lat0)
-            lat1, lon1 = ut.to_latlon(meta['OG_FILE_PATH'], lon1, lat1)
+            lat0, lon0 = ut.utm2latlon(meta, easting=lon0, northing=lat0)
+            lat1, lon1 = ut.utm2latlon(meta, easting=lon1, northing=lat1)
 
     else:
         # radar coordinates
@@ -560,10 +560,6 @@ def calc_delay_timeseries(inps):
     elif 'Y_FIRST' in geom_obj.metadata:
         # for lookup table in geo-coded (gamma, roipac) and obs. in geo-coord
         inps.lat, inps.lon = ut.get_lat_lon(geom_obj.metadata)
-
-        # convert coordinates to lat/lon, e.g. from UTM for ASF HyPP3
-        if not geom_obj.metadata.get('Y_UNIT', 'degrees').startswith('deg'):
-            inps.lat, inps.lon = ut.to_latlon(inps.atr['OG_FILE_PATH'], inps.lon, inps.lat)
 
     else:
         # for lookup table in geo-coded (gamma, roipac) and obs. in radar-coord

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -465,8 +465,8 @@ def prepare_geo_los_geometry(geom_file, unit='rad'):
         E = W + x_step * width
 
         # SNWE in meter --> degree
-        lat0, lon0 = to_latlon(atr['OG_FILE_PATH'], W, N)
-        lat1, lon1 = to_latlon(atr['OG_FILE_PATH'], E, S)
+        lat0, lon0 = utm2latlon(atr, W, N)
+        lat1, lon1 = utm2latlon(atr, E, S)
         lat_step = (lat1 - lat0) / length
         lon_step = (lon1 - lon0) / width
 

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -403,6 +403,7 @@ def get_lat_lon(meta, geom_file=None, box=None, dimension=2, ystep=1, xstep=1):
 
         # UTM to lat/lon
         if not meta['Y_UNIT'].startswith('deg') and 'UTM_ZONE' in meta.keys():
+            print('UTM coordinates detected, convert UTM into lat/lon')
             lats, lons = utm2latlon(meta, easting=lons, northing=lats)
 
     else:


### PR DESCRIPTION
**Description of proposed changes**

+ tropo_pyaps3: bugfix for hyp3 products in UTM coordinates:
   - calc_delay_timeseries(): remove the call of `ut.to_latlon()` while preparing the pixel-wised 2D lat/lon matrices, as `ut.get_lat_lon()` handled the UTM/latlon conversion already since #1052

+ replace `ut.to_latlon()` with `ut.utm2latlon()` as the latter also support non-gdal files, in the following occurrences:
   - tropo_pyaps3.get_bounding_box()
   - utils.utils.prepare_geo_los_geometry()

+ utils.utils0.get_lat_lon(): print out UTM/latlon conversion message, to help future tracking/diagnose

+ prep_hyp3: convert UTM to lat/lon for LAT/LON_REF1/2/3/4

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2257/workflows/b108d178-d076-437c-85c4-f48547d0cc7a/jobs/2265) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.