### PR TITLE
`load2hdf5 --compression` & `view --faultline-min-dist`

### DIFF
--- a/src/mintpy/legacy/load2hdf5.py
+++ b/src/mintpy/legacy/load2hdf5.py
@@ -47,6 +47,8 @@ def create_parser():
     # output
     parser.add_argument('--dname','--dset-name', dest='dset_name', help='output dataset name(s)')
     parser.add_argument('--meta', dest='metadata', nargs='*', help='add custom metadata')
+    parser.add_argument('--comp','--compression', dest='compression', choices={None, 'lzf', 'gzip'},
+                        default=None, help='compression while writing to HDF5 file (default: %(default)s).')
 
     parser.add_argument('-o', '--output', dest='outfile', required=True, help='output HDF5 file name')
     parser.add_argument('--force', dest='force', action='store_true', help='enforce output data overwrite.')
@@ -132,7 +134,7 @@ def main(iargs=None):
     # write
     atr['LENGTH'] = box[3] - box[1]
     atr['WIDTH'] = box[2] - box[0]
-    writefile.write(dsDict, out_file=inps.outfile, metadata=atr)
+    writefile.write(dsDict, out_file=inps.outfile, metadata=atr, compression=inps.compression)
 
     return inps.outfile
 

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -289,6 +289,9 @@ def add_map_argument(parser):
     mapg.add_argument('--faultline-lw', '--faultline-linewidth', dest='faultline_linewidth',
                       metavar='NUM', type=float, default=0.5,
                       help='Faultline linewidth (default: %(default)s).')
+    mapg.add_argument('--faultline-min-dist','--faultline-min-len', dest='faultline_min_dist',
+                      metavar='NUM', type=float, default=0.1,
+                      help='Show fault segments with length >= X km (default: %(default)s).')
 
     # lalo label
     mapg.add_argument('--lalo-label', dest='lalo_label', action='store_true',

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -521,6 +521,7 @@ def plot_slice(ax, data, metadata, inps):
                 faultline_file=inps.faultline_file,
                 SNWE=SNWE,
                 linewidth=inps.faultline_linewidth,
+                min_dist=inps.faultline_min_dist,
                 print_msg=inps.print_msg,
             )
 
@@ -731,6 +732,10 @@ def plot_slice(ax, data, metadata, inps):
 
     # 3.5 Tick labels
     if inps.disp_tick:
+        # move x-axis tick label to the top if colorbar is at the bottom
+        if inps.cbar_loc == 'bottom':
+            ax.tick_params(labelbottom=False, labeltop=True)
+
         # manually turn ON to enable tick labels for UTM with cartopy
         # link: https://github.com/SciTools/cartopy/issues/491
         ax.xaxis.set_visible(True)


### PR DESCRIPTION
**Description of proposed changes**

+ legacy/load2hdf5: add --compression option

+ view: add --faultline-min-dist option to trim the plotted fault lines

+ view: set x-axis label to the top for horizontal colorbar at the bottom

+ utils.plot.auto_adjust_xaxis_date: consider axes width while determining every_year

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2259/workflows/23d5ad56-2e0e-4938-90b0-6ad1bf4945b1/jobs/2267) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.