### PR TITLE
seq. closure phase: bring back spatial referencing for ARIA products

### DIFF
--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1191,6 +1191,15 @@ class ifgramStack:
         print(f'reading {ds_name} to compute closure phases')
         phase = self.read(datasetName=ds_name, box=box, print_msg=False)
 
+        # apply spatial referencing to ARIA products
+        processor = self.metadata.get('mintpy.load.processor', 'isce')
+        if ds_name == 'unwrapPhase' and processor in ['aria']:
+            print(f'apply spatial referencing to {processor} products')
+            ref_phase = self.get_reference_phase(dropIfgram=False)
+            for i in range(phase.shape[0]):
+                mask = phase[i] != 0.
+                phase[i][mask] -= ref_phase[i]
+
         ## calculate the 3D complex seq closure phase
         cp_w = np.zeros((num_cp, box_len, box_wid), dtype=np.complex64)
         for i in range(num_cp):

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1191,7 +1191,10 @@ class ifgramStack:
         print(f'reading {ds_name} to compute closure phases')
         phase = self.read(datasetName=ds_name, box=box, print_msg=False)
 
-        # apply spatial referencing to ARIA products
+        # apply spatial referencing (for ARIA only)
+        # to avoid the abnormal result as shown in https://github.com/insarlab/MintPy/pull/1063
+        # This may be caused by the phase stitching during product preparation via ARIA-tools,
+        # which could have broken the temporal consistency of the native unwrapped phase.
         processor = self.metadata.get('mintpy.load.processor', 'isce')
         if ds_name == 'unwrapPhase' and processor in ['aria']:
             print(f'apply spatial referencing to {processor} products')


### PR DESCRIPTION
**Description of proposed changes**

This PR brings back the spatial referencing while calculating the sequential closure phase (which was removed in #922), for ARIA products only, to avoid the abnormal closure phase calculation result, as shown below. This is happening to ARIA products only, there is negligible impact on the interferogram stack processed with ISCE-2 from SLC (as @yjzhenglamarmota and I have tested before). 

My guess is that the phase stitching applied during ARIA product preparation in ARIA-tools broke the temporal consistency of the native unwrapped phase (when used without spatial referencing). What do you think @sssangha @mgovorcin @dbekaert?

### [San Francisco Bay SenDT042](https://github.com/insarlab/MintPy/blob/main/docs/demo_dataset.md#sentinel-1-on-san-francisco-bay-with-aria) (downloaded from ARIA and processed with ARIA-tools)

+ Without spatial referencing

<img width="1212" alt="Screenshot 2023-08-08 at 13 55 17" src="https://github.com/insarlab/MintPy/assets/13143710/3f3bae6d-2a85-4dc3-9d92-ba9ad867fefe">

+ With spatial referencing

<img width="1212" alt="Screenshot 2023-08-08 at 13 55 07" src="https://github.com/insarlab/MintPy/assets/13143710/2af36d03-3b15-4eaa-9a78-ac459fa37e5c">

### [Sierra Negra SenDT128 dataset](https://zenodo.org/record/4743058) (processed with isce2/topsStack)

+ Without spatial referencing

<img width="1212" alt="Screenshot 2023-08-08 at 14 25 18" src="https://github.com/insarlab/MintPy/assets/13143710/ef376daf-7eb9-4dba-b357-87ee680a5425">

+ With spatial referencing

<img width="1212" alt="Screenshot 2023-08-08 at 14 25 27" src="https://github.com/insarlab/MintPy/assets/13143710/d226f03b-d26c-4478-b27a-277001441bf4">

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2266/workflows/1a40ff8a-88a7-4d43-8c5d-2c1cc58b9239/jobs/2274) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.