### PR TITLE
read_attribute: translate DATA_TYPE ci2 to float32 for roipac

### DIFF
--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1247,12 +1247,15 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             atr.update(read_gdal_vrt(metafile))
             atr['FILE_TYPE'] = fext
 
-        # DATA_TYPE for ISCE products
+        # DATA_TYPE for ISCE/ROI_PAC products
         data_type_dict = {
-            'byte': 'int8',
-            'float': 'float32',
+            # isce2
+            'byte'  : 'int8',
+            'float' : 'float32',
             'double': 'float64',
             'cfloat': 'complex64',
+            # roipac
+            'ci2'   : 'float32',
         }
         data_type = atr.get('DATA_TYPE', 'none').lower()
         if data_type != 'none' and data_type in data_type_dict.keys():

--- a/tests/smallbaselineApp.py
+++ b/tests/smallbaselineApp.py
@@ -45,10 +45,18 @@ DSET_INFO = """
 """
 
 EXAMPLE = """example:
+  # regular tests
   $MINTPY_HOME/tests/smallbaselineApp.py
-  $MINTPY_HOME/tests/smallbaselineApp.py  --dir ~/test
-  $MINTPY_HOME/tests/smallbaselineApp.py  --dset KujuAlosAT422F650
-  $MINTPY_HOME/tests/smallbaselineApp.py  --nofresh
+
+  # fast tests
+  $MINTPY_HOME/tests/smallbaselineApp.py --nofresh
+  $MINTPY_HOME/tests/smallbaselineApp.py --dset KujuAlosAT422F650
+
+  # change the local test directory
+  $MINTPY_HOME/tests/smallbaselineApp.py --dir ~/test
+
+  # the most complete tests
+  $MINTPY_HOME/tests/smallbaselineApp.py --test-pyaps --test-isce
 """
 
 def create_parser():


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.readfile.read_attribute()`: translate `DATA_TYPE` value "ci2" to "float32" for roipac products. This is needed because #1044 removed the hardwired value for roipac, and `DATA_TYPE = CI2` exists in the KujuAlosAT422F650 example dataset (I do not remember how is this metadata saved here, as this metadata does not exist in ROI_PAC).

+ `tests/smallbaselineApp`: more comments on example usage

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2268/workflows/39c0d907-172c-4538-9930-94e770d1a798/jobs/2276) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.