### PR TITLE
dep/doc: add tab completion via `argcomplete`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -230,7 +230,7 @@ export HDF5_USE_FILE_LOCKING=FALSE     # request that HDF5 file locks should NOT
 
 #### d. Tab complete sub-commands ####
 
-If you run mintpy in sub-commands style, e.g. <code>mintpy view</code> instead of <code>view.py</code>, we recommend activating the tab completion: 
+If you run mintpy in sub-commands style, e.g. <code>mintpy view</code> instead of <code>view.py</code>, we recommend activating the tab completion:
 
 ```bash
 activate-global-python-argcomplete --user

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,25 +21,25 @@ mamba install -c conda-forge mintpy
 <details>
 <p><summary>via docker</summary></p>
 
-Docker allows one to run MintPy in a dedicated container, which is essentially an efficient virtual machine, and to be independent of platform OS. First, install <a href="https://docs.docker.com/install">docker</a> if you have not already done so. Then run the following to pull the latest stable released constainer image version from <a href="https://github.com/insarlab/MintPy/pkgs/container/mintpy">MintPy GitHub Container Registry</a> to your local machine:
+Docker allows one to run MintPy in a dedicated container, which is essentially an efficient virtual machine, and to be independent of the platform OS. First, install <a href="https://docs.docker.com/install">docker</a> if you have not already done so. Then run the following to pull the latest stable released container image version from <a href="https://github.com/insarlab/MintPy/pkgs/container/mintpy">MintPy GitHub Container Registry</a> to your local machine:
 
 ```bash
 docker pull ghcr.io/insarlab/mintpy:latest
 ```
 
-<p>Check <a href="./docker.md">docker.md</a> for more details on Docker container image usage, e.g. pulling development version and running in shell or Jupyter server.</p>
+<p>Check <a href="./docker.md">docker.md</a> for more details on Docker container image usage, e.g. pulling the development version and running in a shell or Jupyter server.</p>
 </details>
 
 <details>
 <p><summary>via apt (Linux Debian)</summary></p>
 
-MintPy is available in the main archive of the <a href="https://tracker.debian.org/pkg/mintpy">Debian</a> GNU/Linux OS. It can be installed by using your favourite package manager or running the following command:
+MintPy is available in the main archive of the <a href="https://tracker.debian.org/pkg/mintpy">Debian</a> GNU/Linux OS. It can be installed by using your favorite package manager or running the following command:
 
 ```bash
 apt install mintpy
 ```
 
-The same procedure, in priciple, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.
+The same procedure, in principle, can be used in <a href="https://ubuntu.com">Ubuntu</a> and all the other <a href="https://wiki.debian.org/Derivatives/Census">Debian derivatives</a>. Check the <a href="https://salsa.debian.org/debian-gis-team/mintpy/-/blob/master/debian/README.Debian">Debian GIS Project</a> page for more detailed usage.
 </details>
 </p>
 
@@ -69,7 +69,7 @@ git clone https://github.com/insarlab/MintPy.git
 Install <a href="https://docs.conda.io/en/latest/miniconda.html">miniconda</a> if you have not already done so. You may need to close and restart the shell for changes to take effect.
 
 ```bash
-# use wget or curl to download in command line or click from the web browser
+# use wget or curl to download in the command line or click from the web browser
 # for macOS, use Miniconda3-latest-MacOSX-x86_64.sh instead.
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/tools/miniconda3
@@ -163,13 +163,13 @@ export MANPATH=/opt/local/share/man:${MANPATH}
 # Finished adapting your PATH environment variable for use with MacPorts.
 ```
 
-Update the port tree with the following command. If your network prevent the use of rsync or svn via http of port tree, try <a href="https://trac.macports.org/wiki/howto/PortTreeTarball">Portfile Sync via a Snapshot Tarball</a>.
+Update the port tree with the following command. If your network prevents the use of rsync or svn via HTTP of the port tree, try <a href="https://trac.macports.org/wiki/howto/PortTreeTarball">Portfile Sync via a Snapshot Tarball</a>.
 
 ```
 sudo port selfupdate
 ```
 
-Install the dependencies by running:
+Install the dependencies by running the following:
 
 ```bash
 # install dependencies with macports
@@ -205,7 +205,7 @@ Same as the <a href="#21-install-on-linux">instruction for Linux</a>, except for
 
 Set up an account for ERA5 to download weather re-analysis datasets for tropospheric delay correction as described in <a href="https://github.com/insarlab/pyaps#2-account-setup-for-era5">insarlab/PyAPS</a>.
 
-<code>WEATHER_DIR</code>: Optionally, if you defined an environment variable named <code>WEATHER_DIR</code> to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different dataset that cover the same date/time.
+<code>WEATHER_DIR</code>: Optionally, if you defined an environment variable named <code>WEATHER_DIR</code> to contain the path to a directory, MintPy will download the GAM files into the indicated directory. Also, MintPy will look for the GAM files in the directory before downloading a new one to prevent downloading multiple copies if you work with different datasets that cover the same date/time.
 
 #### b. Dask for parallel processing ####
 
@@ -214,7 +214,7 @@ We recommend setting the <code>temporary-directory</code> in your <a href="https
 ```yaml
 temporary-directory: /tmp  # Directory for local disk like /tmp, /scratch, or /local
 
-# If you are sharing the same machine with others, use the following instead to avoid permission issues with others.
+# If you share the same machine with others, use the following instead to avoid permission issues.
 # temporary-directory: /tmp/{replace_this_with_your_user_name}
 ```
 
@@ -227,3 +227,47 @@ export VRT_SHARED_SOURCE=0             # do not share dataset while using GDAL V
 export HDF5_DISABLE_VERSION_CHECK=2    # supress the HDF5 version warning message (0 for abort; 1/2 for printout/suppress warning message)
 export HDF5_USE_FILE_LOCKING=FALSE     # request that HDF5 file locks should NOT be used
 ```
+
+#### d. Tab complete sub-commands ####
+
+If you run mintpy in sub-commands style, e.g. <code>mintpy view</code> instead of <code>view.py</code>, we recommend activating the tab completion: 
+
+```bash
+activate-global-python-argcomplete --user
+```
+
+For macOS bash users, there is a <a href="https://kislyuk.github.io/argcomplete/#global-completion">version compatibility issue</a>, which can be fixed as below.
+
+<p>
+<details>
+<p><summary>Click to expand for more details</summary></p>
+
+macOS ships with an older version of the bash shell, but <code>argcomplete</code> requires the newer version, which can be installed as below.
+
+```bash
+# check the current bash version: argcomplete requires bash>=4.2
+echo $BASH_VERSION
+
+# install via mamba
+mamba install bash
+
+# add the path to /etc/shells file
+echo "${CONDA_PREFIX}/bin/bash" | sudo tee -a /etc/shells
+
+# change your shell via chsh
+chsh -s "${CONDA_PREFIX}/bin/bash"
+
+# check the current bash version
+echo $BASH_VERSION
+```
+
+Then run <code>activate-global-python-argcomplete --user</code> again. You may need to add the following to your <code>~/.bash_profile</code> file.
+
+```bash
+# bash completion
+if [ -f ~/.bash_completion ]; then
+    . ~/.bash_completion
+fi
+```
+</details>
+</p>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -105,7 +105,7 @@ conda activate mintpy
 <details open>
 <p><summary>via pip [recommended]</summary></p>
 
-We recommend installing mintpy in the "editable" mode. This mode installs the package without copying files to your interpreter directory (e.g. the <code>site-packages</code> directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
+We recommend installing MintPy in the "editable" mode. This mode installs the package without copying files to your interpreter directory (e.g. the <code>site-packages</code> directory), thus, one could "edit" the source code and have changes take effect immediately without having to rebuild and reinstall.
 
 ```bash
 python -m pip install -e ~/tools/MintPy
@@ -230,13 +230,16 @@ export HDF5_USE_FILE_LOCKING=FALSE     # request that HDF5 file locks should NOT
 
 #### d. Tab complete sub-commands ####
 
-If you run mintpy in sub-commands style, e.g. <code>mintpy view</code> instead of <code>view.py</code>, we recommend activating the tab completion:
+We recommend activating the <a href="https://kislyuk.github.io/argcomplete/">tab completion</a> as below if you:
+1. Use bash or zsh shells
+2. On Linux or macOS
+3. Run MintPy in sub-commands style, e.g. <code>mintpy view</code> instead of <code>view.py</code>
 
 ```bash
 activate-global-python-argcomplete --user
 ```
 
-For macOS bash users, there is a <a href="https://kislyuk.github.io/argcomplete/#global-completion">version compatibility issue</a>, which can be fixed as below.
+On macOS, there is a <a href="https://kislyuk.github.io/argcomplete/#global-completion">bash version compatibility</a> issue, which can be fixed as below. If you use the default zsh shell, no fix is needed.
 
 <p>
 <details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 # docs/requirements4rtd.txt for readthedocs, which uses pip with limited memory usage
 python>=3.6
 pip
+argcomplete
 cartopy
 cvxopt
 dask>=1.0

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     # dependencies
     python_requires=">=3.6",
     install_requires=[
+        "argcomplete",
         "cartopy",
         "cvxopt",
         "dask>=1.0",
@@ -74,14 +75,12 @@ setup(
         "utm",
     ],
     extras_require={
-        "cli": ["argcomplete"],
         "extra": ["gdal"],
         "fractal": ["pyfftw"],
         "gbis": ["geoid"],                          # not available on pypi
         "isce": ["isce"],                           # not available on pypi
         "kite": ["kite"],
         "all": [
-            "cli",
             "extra",
             "fractal",
             "gbis",


### PR DESCRIPTION
**Description of proposed changes**

+ add `argcomplete` to the dependency for tab completion capability, which is implemented in #823 and described in #1041. This package is light (only depends on pure Python), and available on pip and conda-forge (as noarch package).
   - requirements.txt: add argcomplete
   - setup.py: move argcomplete from optional to required

+ docs/installation.md: add "tab complete sub-commands" as another sub-section in Post-Installation Setup.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2277/workflows/218deb04-7c97-44fd-9add-15044815f908/jobs/2285) (green)
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.