### PR TITLE
fix zero step size bug in unwrap_error_phase_closure

### DIFF
--- a/src/mintpy/unwrap_error_phase_closure.py
+++ b/src/mintpy/unwrap_error_phase_closure.py
@@ -122,7 +122,8 @@ def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None,
     # calculate number of nonzero closure phase
     ds_size = (C.shape[0] * 2 + C.shape[1]) * length * width * 4
     num_loop = int(np.ceil(ds_size * 2 / (max_memory * 1024**3)))
-    step = int(np.rint(length / num_loop / 10) * 10)
+    # ensure a min step size of 10
+    step = int(np.ceil(length / num_loop / 10)) * 10
     num_loop = int(np.ceil(length / step))
     num_nonzero_closure = np.zeros((length, width), dtype=np.float32)
     msg = 'calculating the number of triplets with non-zero integer ambiguity of closure phase ...'


### PR DESCRIPTION
**Description of proposed changes**

+ unwrap_error_phase_closure: replace np.rint() with np.ceil() to ensure non-zero step size, which could happen for long time-series with highly redundant networks (#1025).

**Reminders**

- [x] Fix #1025
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2283/workflows/da0d0747-47a1-4b87-83dc-a80f77d03cc6/jobs/2291) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.