### PR TITLE
tsview: improved auto figsize for geocoded TS file

### DIFF
--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -486,7 +486,7 @@ def get_model_param_str(model, ds_dict, disp_unit='cm'):
             ds_unit_dict[ds_name] = '/'.join(units)
 
     # list of dataset names
-    ds_names = [x for x in ds_dict.keys() if not x.endswith('Std')]
+    ds_names = [x for x in ds_dict.keys() if not x.endswith('Std') and x not in ['intercept']]
     w_key = max(len(x) for x in ds_names)
     w_val = max(len(f'{x[0]:.2f}') for x in ds_dict.values())
 
@@ -692,8 +692,13 @@ class timeseriesViewer():
 
         # Figure 1 - Cumulative Displacement Map
         if not self.figsize_img:
+            if self.geo_box and self.fig_coord == 'geo':
+                w, n, e, s = self.geo_box
+                ds_shape = (e - w, n - s)
+            else:
+                ds_shape = self.ts_data[0].shape[-2:]
             self.figsize_img = pp.auto_figure_size(
-                ds_shape=self.ts_data[0].shape[-2:],
+                ds_shape=ds_shape,
                 disp_cbar=True,
                 disp_slider=True,
                 print_msg=False)

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -164,6 +164,8 @@ def update_inps_with_file_metadata(inps, metadata):
     if not inps.outfile:
         # ignore whitespaces in the filename
         fbase = inps.fig_title.replace(' ', '')
+        if not inps.disp_whitespace:
+            fbase += '_nws'
         inps.outfile = [f'{fbase}{inps.fig_ext}']
 
     inps = update_figure_setting(inps)


### PR DESCRIPTION
**Description of proposed changes**

+ tsview:
   - `timeseriesViewer.plot()`: consider the SNWE for geocoded file when plotting in geo coordinate, for a more suited figure size
   - `get_model_param_str()`: do not show the intercept in the model fitting result, as it's not useful

+ view
   - `update_inps_with_file_metadata()`: add "_nws" suffix if showing a single subplot without whitespace
   - display pi symbol if min/max is very close 1e-3 via the following changes:
      - `utils.plot.auto_adjust_colormap_lut_and_disp_limit()`: convert near-pi value to pi if they are very close <1e-3
      - `utils.plot.plot_colorbar()`: display pi symbol on the colorbar if displaying limits are very close to -pi/pi (<1e-3)

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2323) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.