### PR TITLE
`read_gdal`: switch back to gdal kwargs to leverage its subsetting capability

### DIFF
--- a/src/mintpy/modify_network.py
+++ b/src/mintpy/modify_network.py
@@ -329,7 +329,7 @@ def get_date12_to_drop(inps):
     date12ListKept = obj.get_date12_list(dropIfgram=True)
     date12ListDropped = sorted(list(set(date12ListAll) - set(date12ListKept)))
     if date12_to_drop == date12ListDropped:
-        print('Calculated date12 to drop is the same as exsiting marked input file, skip updating file.')
+        print('Calculated date12 to drop is the same as existing marked input file, skip updating file.')
         date12_to_drop = None
     elif date12_to_drop == date12ListAll:
         raise Exception('Zero interferogram left! Please adjust your setting and try again.')

--- a/src/mintpy/objects/gps.py
+++ b/src/mintpy/objects/gps.py
@@ -44,7 +44,7 @@ def dload_site_list(out_file=None, url=UNR_SITE_LIST_FILE, print_msg=True):
         os.makedirs(out_dir)
 
     if print_msg:
-        print(f'downloading site list from UNR Geod Lab: {url} to {os.path.dirname(out_file)}')
+        print(f'downloading site list from UNR Geod Lab: {url} to {out_file}')
     urlretrieve(url, out_file)
     return out_file
 

--- a/src/mintpy/objects/insar_vs_gps.py
+++ b/src/mintpy/objects/insar_vs_gps.py
@@ -18,7 +18,7 @@ from scipy.interpolate import griddata
 from mintpy.defaults.plot import *
 from mintpy.objects import giantTimeseries, timeseries
 from mintpy.objects.gps import GPS
-from mintpy.utils import plot as pp, readfile, utils as ut
+from mintpy.utils import readfile, utils as ut
 
 
 ############################## beginning of insar_vs_gps class ##############################

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -983,7 +983,7 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
             d1_list = [i for i in f.keys() if isinstance(f[i], h5py.Dataset) and f[i].ndim >= 2]
 
         # FILE_TYPE
-        # pre-defined/known dataset/group names > existing FILE_TYPE > exsiting dataset/group names
+        # pre-defined/known dataset/group names > existing FILE_TYPE > existing dataset/group names
         py2_mintpy_stack_files = ['interferograms', 'coherence', 'wrapped'] #obsolete mintpy format
         if any(i in d1_list for i in ['unwrapPhase', 'rangeOffset', 'azimuthOffset']):
             ftype = 'ifgramStack'

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -281,6 +281,7 @@ def read(fname, box=None, datasetName=None, print_msg=True, xstep=1, ystep=1, da
         data, atr = readfile.read('geometryRadar.h5', datasetName='bperp')
         data, atr = readfile.read('100120-110214.unw', box=(100,1100, 500, 2500))
     """
+    fname = os.fspath(fname)  # Convert from possible pathlib.Path
     # metadata
     dsname4atr = None   #used to determine UNIT
     if isinstance(datasetName, list):
@@ -963,13 +964,14 @@ def read_attribute(fname, datasetName=None, metafile_ext=None):
                          ...
     Returns:    atr : dict, attributes dictionary
     """
+    fname = os.fspath(fname)  # Convert from possible pathlib.Path
     fdir = os.path.dirname(fname)
     fbase, fext = os.path.splitext(os.path.basename(fname))
     fext = fext.lower()
     if not os.path.isfile(fname):
-        msg = f'input file not existed: {fname}\n'
+        msg = f'input file does not exist: {fname}\n'
         msg += 'current directory: '+os.getcwd()
-        raise Exception(msg)
+        raise FileNotFoundError(msg)
 
     # HDF5 files
     if fext in ['.h5', '.he5']:

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1996,12 +1996,10 @@ def read_gdal(fname, box=None, band=1, cpx_band='phase', xstep=1, ystep=1):
         box = (0, 0, ds.RasterXSize, ds.RasterYSize)
 
     # read
-    # Note: do not use gdal python kwargs because of error: 'BandRasterIONumPy', argument 3 of type 'double'
-    # Recommendation: use rasterio instead of gdal pytho
-    # Link: https://gdal.org/python/osgeo.gdal.Band-class.html#ReadAsArray
-    #kwargs = dict(xoff=box[0], win_xsize=box[2]-box[0],
-    #              yoff=box[1], win_ysize=box[3]-box[1])
-    data = bnd.ReadAsArray()[box[1]:box[3], box[0]:box[2]]
+    # Link: https://gdal.org/api/python/osgeo.gdal.html#osgeo.gdal.Band.ReadAsArray
+    kwargs = dict(xoff=int(box[0]), win_xsize=int(box[2]-box[0]),
+                  yoff=int(box[1]), win_ysize=int(box[3]-box[1]))
+    data = bnd.ReadAsArray(**kwargs)
 
     # adjust output band for complex data
     data_type = DATA_TYPE_GDAL2NUMPY[bnd.DataType]

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -990,15 +990,12 @@ def yes_or_no(question):
 
 def update_attribute_or_not(atr_new, atr_orig):
     """Compare new attributes with existing ones"""
-    update = False
     for key in atr_new.keys():
         value = str(atr_new[key])
-        if ((key in atr_orig.keys() and value == str(atr_orig[key]) and value != 'None')
+        if not ((key in atr_orig.keys() and value == str(atr_orig[key]) and value != 'None')
                 or (key not in atr_orig.keys() and value == 'None')):
-            next
-        else:
-            update = True
-    return update
+            return True
+    return False
 
 
 def which(program):

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -346,16 +346,6 @@ def snwe_to_wkt_polygon(snwe):
     polygon = "POLYGON((" + ",".join([f"{lon} {lat}" for lon, lat in zip(lons, lats)])  + "))"
     return polygon
 
-def snwe_to_wkt_polygon2(snwe):
-    """Convert the input bounding box in SNWE into WKT format POLYGON.
-
-    Parameters: snwe    - list of 4 float, south, north, west and east in degrees/meters
-    Returns:    polygon - str, WKT format POLYGON
-    """
-    from shapely import box
-    S, N, W, E = snwe
-    return box(W, S, E, N).wkt
-
 
 def get_lat_lon(meta, geom_file=None, box=None, dimension=2, ystep=1, xstep=1):
     """Extract precise pixel-wise lat/lon.

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -231,7 +231,7 @@ def azimuth_ground_resolution(atr):
 
 #################################### File Operation ##########################################
 def touch(fname_list, times=None):
-    """python equivalent function to Unix utily - touch
+    """python equivalent function to Unix utility - touch
     It sets the modification and access times of files to the current time of day.
     If the file doesn't exist, it is created with default permissions.
     Inputs/Output:
@@ -282,7 +282,7 @@ def to_latlon(infile, x, y):
         https://github.com/Turbo87/utm#utm-to-latitudelongitude
 
     Parameters: infile - str, GDAL supported file path
-                x/y    - scalar or 1/2D np.ndarray, coordiantes in x and y direction
+                x/y    - scalar or 1/2D np.ndarray, coordinates in x and y direction
     Returns:    y/x    - scalar or 1/2D np.ndarray, coordinates in latitutde and longitude
     """
     from osgeo import gdal
@@ -296,7 +296,7 @@ def to_latlon(infile, x, y):
     if (not srs.IsProjected()) and (srs.GetAttrValue('unit') == 'degree'):
         return y, x
 
-    # convert coordiantes using pyproj
+    # convert coordinates using pyproj
     # note that Transform.from_proj(x, y, always_xy=True) convert the x, y to lon, lat
     p_in = Proj(ds.GetProjection())
     p_out = Proj('epsg:4326')
@@ -310,10 +310,10 @@ def utm2latlon(meta, easting, northing):
 
     Parameters: meta     - dict, mintpy attributes that includes:
                            UTM_ZONE
-                easting  - scalar or 1/2D np.ndarray, UTM    coordiantes in x direction
-                northing - scalar or 1/2D np.ndarray, UTM    coordiantes in y direction
-    Returns:    lat      - scalar or 1/2D np.ndarray, WGS 84 coordiantes in y direction
-                lon      - scalar or 1/2D np.ndarray, WGS 84 coordiantes in x direction
+                easting  - scalar or 1/2D np.ndarray, UTM    coordinates in x direction
+                northing - scalar or 1/2D np.ndarray, UTM    coordinates in y direction
+    Returns:    lat      - scalar or 1/2D np.ndarray, WGS 84 coordinates in y direction
+                lon      - scalar or 1/2D np.ndarray, WGS 84 coordinates in x direction
     """
     import utm
     zone_num = int(meta['UTM_ZONE'][:-1])
@@ -325,10 +325,10 @@ def utm2latlon(meta, easting, northing):
 def latlon2utm(lat, lon):
     """Convert latitude/longitude in degrees to UTM easting/northing in meters.
 
-    Parameters: lat      - scalar or 1/2D np.ndarray, WGS 84 coordiantes in y direction
-                lon      - scalar or 1/2D np.ndarray, WGS 84 coordiantes in x direction
-    Returns:    easting  - scalar or 1/2D np.ndarray, UTM    coordiantes in x direction
-                northing - scalar or 1/2D np.ndarray, UTM    coordiantes in y direction
+    Parameters: lat      - scalar or 1/2D np.ndarray, WGS 84 coordinates in y direction
+                lon      - scalar or 1/2D np.ndarray, WGS 84 coordinates in x direction
+    Returns:    easting  - scalar or 1/2D np.ndarray, UTM    coordinates in x direction
+                northing - scalar or 1/2D np.ndarray, UTM    coordinates in y direction
     """
     import utm
     return utm.from_latlon(lat, lon)[:2]
@@ -345,6 +345,16 @@ def snwe_to_wkt_polygon(snwe):
     lons = [W, E, E, W, W]
     polygon = "POLYGON((" + ",".join([f"{lon} {lat}" for lon, lat in zip(lons, lats)])  + "))"
     return polygon
+
+def snwe_to_wkt_polygon2(snwe):
+    """Convert the input bounding box in SNWE into WKT format POLYGON.
+
+    Parameters: snwe    - list of 4 float, south, north, west and east in degrees/meters
+    Returns:    polygon - str, WKT format POLYGON
+    """
+    from shapely import box
+    S, N, W, E = snwe
+    return box(W, S, E, N).wkt
 
 
 def get_lat_lon(meta, geom_file=None, box=None, dimension=2, ystep=1, xstep=1):
@@ -514,7 +524,7 @@ def get_lalo_digit4display(meta, coord_unit='degree'):
 
 ###################################### Orbit ###########################################
 def xyz_to_local_radius(xyz):
-    """Calculate satellite height and ellpsoid local radius from orbital state vector.
+    """Calculate satellite height and ellipsoid local radius from orbital state vector.
 
     This is a simplified version of the following functions from ISCE-2:
     + isce.isceobj.Planet.xyz_to_llh()
@@ -525,7 +535,7 @@ def xyz_to_local_radius(xyz):
                 radius - float, Earth radius in m
     """
 
-    # paramters from isce.isceobj.Planet.AstronomicalHandbook
+    # parameters from isce.isceobj.Planet.AstronomicalHandbook
     a = 6378137.000       # WGS84 semimajor
     e2 = 0.0066943799901  # WGS84 eccentricity squared
 
@@ -914,7 +924,7 @@ def get_circular_mask(x, y, radius, shape):
 def circle_index(atr, circle_par):
     """Return Index of Elements within a Circle centered at input pixel
     Parameters: atr : dictionary
-                    containging the following attributes:
+                    containing the following attributes:
                     WIDT
                     LENGTH
                 circle_par : string in the format of 'y,x,radius'
@@ -979,7 +989,7 @@ def yes_or_no(question):
 
 
 def update_attribute_or_not(atr_new, atr_orig):
-    """Compare new attributes with exsiting ones"""
+    """Compare new attributes with existing ones"""
     update = False
     for key in atr_new.keys():
         value = str(atr_new[key])
@@ -1114,7 +1124,7 @@ def median_abs_deviation(data, center=None, scale=0.67449):
 
 
 def median_abs_deviation_threshold(data, center=None, cutoff=3.):
-    """calculate rms_threshold based on the standardised residual
+    """calculate rms_threshold based on the standardized residual
 
     Outlier detection with median absolute deviation.
     """

--- a/src/mintpy/utils/utils1.py
+++ b/src/mintpy/utils/utils1.py
@@ -200,7 +200,7 @@ def spatial_average(File, datasetName='coherence', maskFile=None, box=None,
         dateList = [i for i in txtContent[:, 0]]
         return meanList, dateList
 
-    # Baic File Info
+    # Basic File Info
     atr = readfile.read_attribute(File)
     k = atr['FILE_TYPE']
     if not box:
@@ -324,7 +324,7 @@ def spatial_average(File, datasetName='coherence', maskFile=None, box=None,
 
 def temporal_average(File, datasetName='coherence', updateMode=False, outFile=None):
     """Calculate temporal average of multi-temporal dataset, equivalent to stacking
-    For ifgramStakc/unwrapPhase, return average phase velocity
+    For ifgramStack/unwrapPhase, return average phase velocity
 
     Parameters: File : string, file to be averaged in time
                 datasetName : string, dataset to be read from input file, for multiple
@@ -502,7 +502,7 @@ def get_geometry_file(dset_list, work_dir=None, coord='geo', abspath=True, print
         return None
 
     # check dset in the existing h5 files
-    for fname in list(fname_list):   #use list() as temp copy to handle varing list during the loop
+    for fname in list(fname_list):   #use list() as temp copy to handle modifying list during the loop
         if any(dset not in readfile.get_dataset_list(fname) for dset in dset_list):
             fname_list.remove(fname)
     if len(fname_list) == 0:
@@ -557,7 +557,7 @@ def update_template_file(template_file, extra_dict, delimiter='='):
         f_tmp.write(line)
     f_tmp.close()
 
-    # Overwrite exsting original template file
+    # Overwrite existing original template file
     shutil.move(tmp_file, template_file)
     return template_file
 
@@ -576,14 +576,14 @@ def add_attribute(fname, atr_new=dict(), print_msg=False):
     atr = readfile.read_attribute(fname)
     key_list = list(atr.keys())
 
-    # compare new attributes with exsiting ones
+    # compare new attributes with existing ones
     update = update_attribute_or_not(atr_new, atr)
     if not update:
         vprint('All updated (removed) attributes already exists (do not exists)'
                ' and have the same value, skip update.')
         return fname
 
-    # update attributes in the inpupt data file
+    # update attributes in the input data file
     fext = os.path.splitext(fname)[1]
     if fext in ['.h5', '.he5']:
         with h5py.File(fname, 'r+') as f:
@@ -767,7 +767,7 @@ def check_template_auto_value(templateDict, auto_file='defaults/smallbaselineApp
 def run_deramp(fname, ramp_type, mask_file=None, out_file=None, datasetName=None,
                save_ramp_coeff=False, extra_meta=None):
     """ Remove ramp from each 2D matrix of input file
-    Parameters: fname           - str, data file to be derampped
+    Parameters: fname           - str, data file to be deramped
                 ramp_type       - str, name of ramp to be estimated.
                 mask_file       - str, file of mask of pixels used for ramp estimation
                 out_file        - str, output file name

--- a/tests/smallbaselineApp.py
+++ b/tests/smallbaselineApp.py
@@ -79,7 +79,7 @@ def create_parser():
                         help='test directory (default: %(default)s).')
 
     parser.add_argument('--nofresh', dest='fresh_start', action='store_false',
-                        help='Use exsiting files WITHOUT starting from the scratch (default: %(default)s).')
+                        help='Use existing files WITHOUT starting from the scratch (default: %(default)s).')
     return parser
 
 


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

general quality-of-life fixes that came up while adding more GPS comparisons for UTM products (these are before those additions, it just because a big enough PR to submit)

- Typos/unused import fixes that were highlighted by my spellchecker
- Starting the use again of the subsetting capability of `ReadAsArray` instead of reading everything (https://github.com/insarlab/MintPy/pull/661), since the errors in the comment were from this: https://github.com/OSGeo/gdal/issues/8026 (but can be avoided by casting to a python numeric type)
- simplify logic in `update_attribute_or_not` to exit early
- backwards compatible changes to `readfile` functions to allow more functions to accept `pathlib.Paths`

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.