### PR TITLE
`mintpy.geocode.laloStep`: support single value input

### DIFF
--- a/src/mintpy/cli/geocode.py
+++ b/src/mintpy/cli/geocode.py
@@ -35,6 +35,7 @@ degrees     --> meters on equator
 0.000833334 --> 90
 0.000555556 --> 60
 0.000462963 --> 50
+0.000370370 --> 40
 0.000277778 --> 30
 0.000185185 --> 20
 0.000092593 --> 10
@@ -206,6 +207,16 @@ def read_template2inps(template_file, inps):
                     iDict[key] = math.nan
                 else:
                     iDict[key] = float(value)
+
+    # ensure laloStep is a list of two items
+    key = 'laloStep'
+    if key in iDict.keys() and iDict[key]:
+        if len(iDict[key]) == 1:
+            lalo_step = iDict[key]
+            iDict[key] = [-1 * abs(lalo_step[0]), abs(lalo_step[0])]
+            print(f'single laloStep input {lalo_step} detected, convert into two as {iDict[key]}')
+        elif len(iDict[key]) > 2:
+            raise ValueError(f'laloStep input {iDict[key]} could NOT have >2 items!')
 
     # computing configurations
     key = 'mintpy.compute.maxMemory'

--- a/src/mintpy/cli/timeseries_rms.py
+++ b/src/mintpy/cli/timeseries_rms.py
@@ -60,6 +60,12 @@ def cmd_line_parse(iargs=None):
     """Command line parser."""
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
+
+    # save argv (to check the manually specified arguments)
+    # use iargs        for python call
+    # use sys.argv[1:] for command line call
+    inps.argv = iargs if iargs else sys.argv[1:]
+
     return inps
 
 

--- a/src/mintpy/defaults/smallbaselineApp.cfg
+++ b/src/mintpy/defaults/smallbaselineApp.cfg
@@ -314,8 +314,8 @@ mintpy.timeFunc.bootstrapCount            = auto   #[int>1], auto for 400, numbe
 ########## 11.1 geocode (post-processing)
 # for input dataset in radar coordinates only
 # commonly used resolution in meters and in degrees (on equator)
-# 100,         90,          60,          50,          30,          20,          10
-# 0.000925926, 0.000833334, 0.000555556, 0.000462963, 0.000277778, 0.000185185, 0.000092593
+# 100,         90,          60,          50,          40,          30,          20,          10
+# 0.000925926, 0.000833334, 0.000555556, 0.000462963, 0.000370370, 0.000277778, 0.000185185, 0.000092593
 mintpy.geocode              = auto  #[yes / no], auto for yes
 mintpy.geocode.SNWE         = auto  #[-1.2,0.5,-92,-91 / none ], auto for none, output extent in degree
 mintpy.geocode.laloStep     = auto  #[-0.000555556,0.000555556 / None], auto for None, output resolution in degree

--- a/src/mintpy/smallbaselineApp.py
+++ b/src/mintpy/smallbaselineApp.py
@@ -186,7 +186,7 @@ class TimeSeriesAnalysis:
             # use ut.add_attribute() instead of add_attribute.py because of
             # better control of special metadata, such as SUBSET_X/YMIN
             msg = f'updating metadata based on custom template file {os.path.basename(self.customTemplateFile)}'
-            for fname in [stack_file, ion_file, geom_file]:
+            for fname in [stack_file, ion_file]:  #, geom_file]:
                 if fname:
                     print(f'{msg} for file: {os.path.basename(fname)}')
                     ut.add_attribute(fname, self.customTemplate)
@@ -217,8 +217,8 @@ class TimeSeriesAnalysis:
         # 1) output waterMask.h5 to simplify the detection/use of waterMask
         water_mask_file = os.path.join(self.workDir, 'waterMask.h5')
         if 'waterMask' in readfile.get_dataset_list(geom_file):
-            print(f'generate {water_mask_file} from {geom_file} for conveniency')
             if ut.run_or_skip(out_file=water_mask_file, in_file=geom_file) == 'run':
+                print(f'generate {water_mask_file} from {geom_file} for conveniency')
                 water_mask, atr = readfile.read(geom_file, datasetName='waterMask')
 
                 # ignore no-data pixels in geometry files

--- a/src/mintpy/timeseries_rms.py
+++ b/src/mintpy/timeseries_rms.py
@@ -89,6 +89,10 @@ def run_timeseries_rms(inps):
     analyze_rms(inps.date_list, inps.rms_list, inps)
 
     # plot RMS
+    if '--figsize' not in inps.argv and len(inps.date_list) > 120:
+        fig_wid = min(15, inps.fig_size[0] * len(inps.date_list) / 120)
+        inps.fig_size[0] = float(f'{fig_wid:.1f}')
+
     pp.plot_timeseries_rms(
         rms_file=inps.rms_file,
         cutoff=inps.cutoff,


### PR DESCRIPTION
**Description of proposed changes**

+ `geocode`: support single input for the `mintpy.geocode.laloStep` option, as it is commonly used; and convert it into a list of two internally in the code.

+ `smallbaselineApp.run_load_data()`: tune the auto-skipping, by not adding the metadata from the custom template to the geometry HDF5 file, to avoid updating its file modification time.

+ `timeseries_rms`: auto adjust figure width for long TS

+ `utils.utils1.spatial_average()`:
   - always read the output from the text file, which is in 1e-4 precision, to ensure consistency.
   - use the dataset MODIFICATION_TIME for ifgramStack file, for a more representative run/skip checking.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2331) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.