### PR TITLE
`readfile`: support GDAL `int8` dtype

### DIFF
--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -211,8 +211,8 @@ SPECIAL_STR2NUM = {
 def numpy_to_gdal_dtype(np_dtype: DTypeLike) -> int:
     """Convert NumPy dtype to GDAL dtype.
 
-    Parameters: np_dtype  : DTypeLike, NumPy dtype to convert.
-    Returns:    gdal_code : int, GDAL type code corresponding to `np_dtype`.
+    Parameters: np_dtype  - DTypeLike, NumPy dtype to convert.
+    Returns:    gdal_code - int, GDAL type code corresponding to `np_dtype`.
     """
     from osgeo import gdal_array, gdalconst
     np_dtype = np.dtype(np_dtype)
@@ -233,8 +233,8 @@ def numpy_to_gdal_dtype(np_dtype: DTypeLike) -> int:
 def gdal_to_numpy_dtype(gdal_dtype: Union[str, int]) -> np.dtype:
     """Convert GDAL dtype to NumPy dtype.
 
-    Parameters: gdal_dtype : str/int, GDAL dtype to convert.
-    Returns:    np_dtype   : DTypeLike, NumPy dtype
+    Parameters: gdal_dtype - str/int, GDAL dtype to convert.
+    Returns:    np_dtype   - np.dtype, NumPy dtype
     """
     from osgeo import gdal, gdal_array
     if isinstance(gdal_dtype, str):

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -211,6 +211,8 @@ SPECIAL_STR2NUM = {
 def numpy_to_gdal_dtype(np_dtype: DTypeLike) -> int:
     """Convert NumPy dtype to GDAL dtype.
 
+    Modified from dolphin.utils.numpy_to_gdal_type().
+
     Parameters: np_dtype  - DTypeLike, NumPy dtype to convert.
     Returns:    gdal_code - int, GDAL type code corresponding to `np_dtype`.
     """
@@ -232,6 +234,8 @@ def numpy_to_gdal_dtype(np_dtype: DTypeLike) -> int:
 
 def gdal_to_numpy_dtype(gdal_dtype: Union[str, int]) -> np.dtype:
     """Convert GDAL dtype to NumPy dtype.
+
+    Modified from dolphin.utils.gdal_to_numpy_type().
 
     Parameters: gdal_dtype - str/int, GDAL dtype to convert.
     Returns:    np_dtype   - np.dtype, NumPy dtype

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -15,6 +15,7 @@ import re
 import sys
 import warnings
 import xml.etree.ElementTree as ET
+from typing import Union
 
 import h5py
 import numpy as np


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the support of reading `int8` type for files in GDAL format, as suggested by @scottstanie in #1081.

+ add the correction `int8` conversion between GDAL and NumPy in `DATA_TYPE_GDAL2NUMPY/NUMPY2GDAL`

+ add `numpy_to_gdal_dtype()` from `dolphin`

+ add `gdal_to_numpy_dtype()` from `dolphin`

I did not replace the usage of dict conversion with the two functions above yet, because [`cint16/32` is supported by GDAL but not in numpy yet](https://github.com/insarlab/MintPy/blob/7ff149b7a99ece61f0fee33482f969a6540ba279/src/mintpy/utils/readfile.py#L132-L133), thus, the dict conversion may be more generic at the moment for translation purposes.

**Reminders**

- [x] Fix #1081 
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2336/workflows/c8c9c9d7-fc2e-4ae3-8e9e-b1d0270bd4bb/jobs/2343) (green)
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.