### PR TITLE
view: allow unit change when viewing seasonal time functions

### DIFF
--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -1149,7 +1149,9 @@ def read_data4figure(i_start, i_end, inps, metadata):
             or inps.key in ['timeseries', 'inversion']
             or all(d in inps.dsetFamilyList for d in ['horizontal', 'vertical'])
             or inps.dsetFamilyList == ['data','model','residual']
-            or inps.dsetFamilyList == [f'band{i+1}' for i in range(len(inps.dsetFamilyList))]):
+            or inps.dsetFamilyList == [f'band{i+1}' for i in range(len(inps.dsetFamilyList))]
+            or all(d in inps.dsetFamilyList for d in ['annualAmplitude', 'semiAnnualAmplitude'])
+            or all(d in inps.dsetFamilyList for d in ['annualPhase', 'semiAnnualPhase'])):
         same_unit4all_subplots = True
     else:
         same_unit4all_subplots = False

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -1150,8 +1150,8 @@ def read_data4figure(i_start, i_end, inps, metadata):
             or all(d in inps.dsetFamilyList for d in ['horizontal', 'vertical'])
             or inps.dsetFamilyList == ['data','model','residual']
             or inps.dsetFamilyList == [f'band{i+1}' for i in range(len(inps.dsetFamilyList))]
-            or all(d in inps.dsetFamilyList for d in ['annualAmplitude', 'semiAnnualAmplitude'])
-            or all(d in inps.dsetFamilyList for d in ['annualPhase', 'semiAnnualPhase'])):
+            or all(d.endswith('Amplitude') for d in inps.dsetFamilyList)
+            or all(d.endswith('Phase') for d in inps.dsetFamilyList)):
         same_unit4all_subplots = True
     else:
         same_unit4all_subplots = False


### PR DESCRIPTION
small change to allow a user to change the units when viewing both annualAmplitude[Phase] and semiAnnualAmplitude[Phase]

e.g., `view.py geo_velocity.h5 annualAmplitude semiAnnualAmplitude -u mm`