### PR TITLE
GMT-like shaded relief illumination via `view.py --dem-blend`

### DIFF
--- a/src/mintpy/cli/view.py
+++ b/src/mintpy/cli/view.py
@@ -143,6 +143,12 @@ def cmd_line_parse(iargs=None):
     if inps.flip_lr or inps.flip_ud:
         inps.auto_flip = False
 
+    if inps.disp_dem_blend:
+        inps.disp_dem_shade = False
+        # --dem-blend option requires --dem option
+        if inps.dem_file is None:
+            parser.error("--dem-blend requires -d/-dem.")
+
     # check: conflicted options (geo-only options if inpput file is in radar-coordinates)
     geo_opt_names = ['--coord', '--show-gps', '--coastline', '--lalo-label', '--lalo-step', '--scalebar', '--faultline']
     geo_opt_names = list(set(geo_opt_names) & set(inps.argv))

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -98,44 +98,49 @@ def add_dem_argument(parser):
     dem = parser.add_argument_group('DEM', 'display topography in the background')
     dem.add_argument('-d', '--dem', dest='dem_file', metavar='DEM_FILE',
                      help='DEM file to show topography as background')
-    dem.add_argument('--dem-blend', dest='disp_dem_blend', action='store_true',
-                     help='blend the DEM shade with input image to have a GMT-like impression.')
     dem.add_argument('--mask-dem', dest='mask_dem', action='store_true',
                      help='Mask out DEM pixels not coincident with valid data pixels')
     dem.add_argument('--dem-noshade', dest='disp_dem_shade', action='store_false',
                      help='do not show DEM shaded relief')
     dem.add_argument('--dem-nocontour', dest='disp_dem_contour', action='store_false',
                      help='do not show DEM contour lines')
+    dem.add_argument('--dem-blend', dest='disp_dem_blend', action='store_true',
+                     help='blend the DEM shade with input image to have a GMT-like impression.')
 
     # DEM contours
-    dem.add_argument('--contour-smooth', dest='dem_contour_smooth', type=float, default=3.0,
-                     help='Background topography contour smooth factor - sigma of Gaussian filter. \n'
+    dem.add_argument('--contour-smooth', dest='dem_contour_smooth', type=float, default=3.0, metavar='NUM',
+                     help='[Contour] Topography contour smooth factor - sigma of Gaussian filter. \n'
                           'Set to 0.0 for no smoothing; (default: %(default)s).')
     dem.add_argument('--contour-step', dest='dem_contour_step', metavar='NUM', type=float, default=200.0,
-                     help='Background topography contour step in meters (default: %(default)s).')
+                     help='[Contour] Topography contour step in meters (default: %(default)s).')
     dem.add_argument('--contour-lw','--contour-linewidth', dest='dem_contour_linewidth',
                      metavar='NUM', type=float, default=0.5,
-                     help='Background topography contour linewidth (default: %(default)s).')
+                     help='[Contour] Topography contour linewidth (default: %(default)s).')
 
     # DEM shade
     dem.add_argument('--shade-az', dest='shade_azdeg', type=float, default=315., metavar='DEG',
-                     help='The azimuth (0-360, degrees clockwise from North) of the light source '
+                     help='[Shade] Azimuth angle (0-360, degrees clockwise from North) of the light source '
                           '(default: %(default)s).')
     dem.add_argument('--shade-alt', dest='shade_altdeg', type=float, default=45., metavar='DEG',
-                     help='The altitude (0-90, degrees up from horizontal) of the light source '
+                     help='[Shade] Altitude (0-90, degrees up from horizontal) of the light source '
                           '(default: %(default)s).')
     dem.add_argument('--shade-min', dest='shade_min', type=float, default=-4000., metavar='MIN',
-                     help='The min height in m of colormap of shaded relief topography (default: %(default)s).')
+                     help='[Shade] Minimum height of shaded relief topography (default: %(default)s m).')
     dem.add_argument('--shade-max', dest='shade_max', type=float, default=999., metavar='MAX',
-                     help='The max height of colormap of shaded relief topography (default: max(DEM)+2000).')
-    dem.add_argument('--shade-exag', dest='shade_exag', type=float, default=0.5,
-                     help='Vertical exaggeration ratio (default: %(default)s).')
+                     help='[Shade] Maximum height of shaded relief topography (default: max(DEM)+2000 m).')
+    dem.add_argument('--shade-exag', dest='shade_exag', type=float, default=0.5,  metavar='NUM',
+                     help='[Shade] Vertical exaggeration ratio (default: %(default)s).')
 
     # DEM-blended image
-    dem.add_argument('--shade-frac', dest='shade_frac', type=float, default=0.5,
-                     help='Only for --dem-blend. Increases/decreases the contrast of the hillshade (default: %(default)s).')
-    dem.add_argument('--base-color', dest='base_color', type=float, default=0.9,
-                     help='Only for --dem-blend. DEM basemap greyish color ranges in [0,1] (default: %(default)s).')
+    dem.add_argument('--shade-frac', dest='shade_frac', type=float, default=0.5, metavar='NUM',
+                     help='[Blend] Increases/decreases the contrast of the hillshade (default: %(default)s).')
+    dem.add_argument('--base-color', dest='base_color', type=float, default=0.9, metavar='NUM',
+                     help='[Blend] Topograhpy basemap greyish color ranges in [0,1] (default: %(default)s).')
+    dem.add_argument('--blend-mode', dest='blend_mode', type=str, default='overlay',
+                     choices={'hsv','overlay','soft'}, metavar='STR',
+                     help='[Blend] Type of blending used to combine the colormapped data with illumated '
+                          'topography.\n(choices: %(choices)s; default: %(default)s).\n'
+                          'https://matplotlib.org/stable/gallery/specialty_plots/topographic_hillshading.html')
     return parser
 
 
@@ -286,8 +291,8 @@ def add_map_argument(parser):
     mapg.add_argument('--coastline', dest='coastline', type=str, choices={'10m', '50m', '110m'},
                       help="Draw coastline with specified resolution (default: %(default)s).\n"
                            "This will enable --lalo-label option.\n"
-                           "Link: https://scitools.org.uk/cartopy/docs/latest/matplotlib/geoaxes.html"
-                           "#cartopy.mpl.geoaxes.GeoAxes.coastlines")
+                           "https://scitools.org.uk/cartopy/docs/latest/reference/generated/"
+                           "cartopy.mpl.geoaxes.GeoAxes.html")
     mapg.add_argument('--coastline-lw', '--coastline-linewidth', dest='coastline_linewidth',
                       metavar='NUM', type=float, default=1,
                       help='Coastline linewidth (default: %(default)s).')

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -102,6 +102,8 @@ def add_dem_argument(parser):
                      help='Mask out DEM pixels not coincident with valid data pixels')
     dem.add_argument('--dem-noshade', dest='disp_dem_shade', action='store_false',
                      help='do not show DEM shaded relief')
+    dem.add_argument('--dem-blend', dest='disp_dem_blend', action='store_true',
+                     help='blend the DEM shade with input image to have a GMT-like impression.')
     dem.add_argument('--dem-nocontour', dest='disp_dem_contour', action='store_false',
                      help='do not show DEM contour lines')
 
@@ -127,6 +129,10 @@ def add_dem_argument(parser):
                      help='The max height of colormap of shaded relief topography (default: max(DEM)+2000).')
     dem.add_argument('--shade-exag', dest='shade_exag', type=float, default=0.5,
                      help='Vertical exaggeration ratio (default: %(default)s).')
+    dem.add_argument('--shade-frac', dest='shade_frac', type=float, default=0.5,
+                     help='Only for --dem-blend. Increases/decreases the contrast of the hillshade (default: %(default)s).')
+    dem.add_argument('--base-color', dest='base_color', type=float, default=0.9,
+                     help='Only for --dem-blend. DEM basemap greyish color ranges in [0,1] (default: %(default)s).')
     return parser
 
 

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -98,15 +98,16 @@ def add_dem_argument(parser):
     dem = parser.add_argument_group('DEM', 'display topography in the background')
     dem.add_argument('-d', '--dem', dest='dem_file', metavar='DEM_FILE',
                      help='DEM file to show topography as background')
+    dem.add_argument('--dem-blend', dest='disp_dem_blend', action='store_true',
+                     help='blend the DEM shade with input image to have a GMT-like impression.')
     dem.add_argument('--mask-dem', dest='mask_dem', action='store_true',
                      help='Mask out DEM pixels not coincident with valid data pixels')
     dem.add_argument('--dem-noshade', dest='disp_dem_shade', action='store_false',
                      help='do not show DEM shaded relief')
-    dem.add_argument('--dem-blend', dest='disp_dem_blend', action='store_true',
-                     help='blend the DEM shade with input image to have a GMT-like impression.')
     dem.add_argument('--dem-nocontour', dest='disp_dem_contour', action='store_false',
                      help='do not show DEM contour lines')
 
+    # DEM contours
     dem.add_argument('--contour-smooth', dest='dem_contour_smooth', type=float, default=3.0,
                      help='Background topography contour smooth factor - sigma of Gaussian filter. \n'
                           'Set to 0.0 for no smoothing; (default: %(default)s).')
@@ -116,19 +117,21 @@ def add_dem_argument(parser):
                      metavar='NUM', type=float, default=0.5,
                      help='Background topography contour linewidth (default: %(default)s).')
 
+    # DEM shade
     dem.add_argument('--shade-az', dest='shade_azdeg', type=float, default=315., metavar='DEG',
                      help='The azimuth (0-360, degrees clockwise from North) of the light source '
                           '(default: %(default)s).')
     dem.add_argument('--shade-alt', dest='shade_altdeg', type=float, default=45., metavar='DEG',
                      help='The altitude (0-90, degrees up from horizontal) of the light source '
                           '(default: %(default)s).')
-
     dem.add_argument('--shade-min', dest='shade_min', type=float, default=-4000., metavar='MIN',
                      help='The min height in m of colormap of shaded relief topography (default: %(default)s).')
     dem.add_argument('--shade-max', dest='shade_max', type=float, default=999., metavar='MAX',
                      help='The max height of colormap of shaded relief topography (default: max(DEM)+2000).')
     dem.add_argument('--shade-exag', dest='shade_exag', type=float, default=0.5,
                      help='Vertical exaggeration ratio (default: %(default)s).')
+
+    # DEM-blended image
     dem.add_argument('--shade-frac', dest='shade_frac', type=float, default=0.5,
                      help='Only for --dem-blend. Increases/decreases the contrast of the hillshade (default: %(default)s).')
     dem.add_argument('--base-color', dest='base_color', type=float, default=0.9,

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -2214,13 +2214,13 @@ def prep_blend_image(data, dem, vmin=None, vmax=None, cmap='viridis',
     return illum_rgb
 
 
-def plot_blend_image(ax, data, dem, inps):
+def plot_blend_image(ax, data, dem, inps, print_msg=True):
     """Plot DEM-blended image.
 
     Parameters: ax - matplotlib.pyplot.Axes or BasemapExt object
                 data - 2D np.ndarray, image to be blended
                 dem  - 2D np.ndarray, topography used for blending
-                inps - Namespace object with the following 7 items:
+                inps - Namespace object with the following items:
                        'base_color'   : float
                        'blend_mode'   : str
                        'colormap'     : str or matplotlib.colors.colormap class
@@ -2231,8 +2231,16 @@ def plot_blend_image(ax, data, dem, inps):
                        'shade_frac'   : float
                        'mask_dem'     : bool
                        'vlim'         : list of 2 float
+                print_msg - bool, print verbose message or not
     Returns:    im   - matplotlob.pyplot.AxesImage
     """
+    if print_msg:
+        msg = 'plotting data '
+        msg += f'blended by DEM shaded relief (contrast={inps.shade_frac:.1f}, '
+        msg += f'base_color={inps.base_color:.1f}, exag={inps.shade_exag}, '
+        msg += f'az/alt={inps.shade_azdeg}/{inps.shade_altdeg} deg) ...'
+        print(msg)
+
     # prepare
     blend_img = prep_blend_image(
         data, dem,

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1446,7 +1446,7 @@ def plot_colorbar(inps, im, cax):
             cax.set_xticks(inps.cbar_ticks)
 
     # update tick labels for special symbol: pi
-    if ticks == [-np.pi, 0, np.pi]:
+    if ticks is not None and ticks[:] == [-np.pi, 0, np.pi]:
         if orientation == 'vertical':
             cax.set_yticklabels([r'-$\pi$', '0', r'$\pi$'])
         else:

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -2225,9 +2225,6 @@ def plot_image4view(ax, data, dem=None, extent=None, geo_box=None, inps=None):
     Examples :      ax, im = pp.plot_image4view(ax, data, dem, inps=inps)
     """
     imshow_data = True
-
-    # print messages
-    global vprint
     vprint = print if inps.print_msg else lambda *args, **kwargs: None
 
     # get plotting extent from geo_box if not given

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1402,7 +1402,7 @@ def plot_colorbar(inps, im, cax):
     # ticks for special cases
     if abs(vmin + np.pi) / np.pi < 0.001 and abs(vmax - np.pi) / np.pi < 0.001:
         ticks = [-np.pi, 0, np.pi]   # special case 1: -pi/pi
-    elif hasattr(inps, 'unique_values') and inps.unique_values and len(inps.unique_values) <= 5:
+    elif hasattr(inps, 'unique_values') and inps.unique_values is not None and len(inps.unique_values) <= 5:
         ticks = inps.unique_values   # special case 2: show finite exact tick values
     else:
         ticks = None
@@ -2091,7 +2091,8 @@ def blend_colorbar(cax, inps, vlim, orientation='vertical', ticks=None,
                 ticks       - list of float or None, colorbar ticks
                 fraction    - float, increases or decreases the contrast of the hillshade
                 blend_mode  - {'hsv', 'overlay', 'soft'} or callable
-                vert_exag   - float; The amount to exaggerate the elevation values by when calculating illumination
+                vert_exag   - float, the amount to exaggerate the elevation values by
+                              when calculating illumination
     Examples:   blend_colorbar(cax, inps, vlim=[-3, 6], orientation='vertical')
     """
     from matplotlib.colors import LightSource
@@ -2151,18 +2152,19 @@ def prep_blend_image(data, dem, vmin=None, vmax=None, cmap='viridis',
                      base_color=0.9, shade_frac=0.5, blend_mode='overlay',
                      azdeg=315, altdeg=45, vert_exag=0.5, mask_nan_dem=True,
                      mask_nan_data=False, fill_value=0):
-    """Prepare the illuminated RGB array given the data and DEM, using shaded relief from a light source,
+    """Prepare the illuminated RGB array for the data, using shaded relief DEM from a light source,
     like the `gmt grdimage -I` feature, i.e. hillshade + DEM-blended data.
 
     Parameters: data          - 2D np.ndarray in size of (m, n), data to be blended
                 dem           - 2D np.ndarray in size of (m, n), dem data
-                vmin          - float, lower display limit of the data
-                vmax          - float, upper display limit of the data
+                vmin/max      - float, lower/upper display limit of the data
                 cmap          - str or matplotlib.colors.colormap class
                 base_color    - float or color hex codes
                 shade_frac    - float, increases or decreases the contrast of the hillshade
                 blend_mode    - {'hsv', 'overlay', 'soft'} or callable
-                vert_exag     - float, the amount to exaggerate the elevation values by when calculating illumination
+                az/altdeg     - float, azimuth/altitude angle of the light source
+                vert_exag     - float, the amount to exaggerate the elevation values by
+                                when calculating illumination
                 mask_nan_dem  - bool, whether to mask blended image based on nan dem pixels
                 mask_nan_data - bool, whether to mask blended image based on nan data pixels
                 fill_value    - float, set the masked pixels as alpha = fill_value (transparent)

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1934,8 +1934,11 @@ def prepare_dem_background(dem, inps, data=None, print_msg=True):
             blend_img = shaded_image(
                 data, dem, ls,
                 vmin=vlim[0], vmax=vlim[1],
-                cmap=inps.colormap, base_color=inps.base_color,
-                shade_frac=inps.shade_frac, vert_exag=inps.shade_exag,
+                cmap=inps.colormap,
+                base_color=inps.base_color,
+                shade_frac=inps.shade_frac,
+                blend_mode=inps.blend_mode,
+                vert_exag=inps.shade_exag,
                 mask_dem_dataNan=inps.mask_dem)
 
         if print_msg:
@@ -2139,7 +2142,7 @@ def shaded_colorbar(inps, cax, fraction=0.75, blend_mode='soft', vert_exag=6000)
 
 
 def shaded_image(data, dem, ls, vmin=None, vmax=None, cmap='viridis',
-                 base_color=0.9, shade_frac=0.5, blend_mode='hsv', vert_exag=0.5,
+                 base_color=0.9, shade_frac=0.5, blend_mode='overlay', vert_exag=0.5,
                  mask_dem_demNan=True, mask_dem_dataNan=False, mask_value=0):
     """Add illumination to the rgb data array based on a DEM file.
        Use shaded relief from a light source to adjust the colors of the data rgb array to have a cool impression.

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1401,9 +1401,9 @@ def plot_colorbar(inps, im, cax):
 
     # ticks for special cases
     if abs(vmin + np.pi) / np.pi < 0.001 and abs(vmax - np.pi) / np.pi < 0.001:
-        ticks = [-np.pi, 0, np.pi]   # special case 1: -pi/pi
+        ticks = [-np.pi, 0, np.pi]         # special case 1: -pi/pi
     elif hasattr(inps, 'unique_values') and inps.unique_values is not None and len(inps.unique_values) <= 5:
-        ticks = inps.unique_values   # special case 2: show finite exact tick values
+        ticks = list(inps.unique_values)   # special case 2: show finite exact tick values
     else:
         ticks = None
 
@@ -1411,9 +1411,11 @@ def plot_colorbar(inps, im, cax):
     if not inps.disp_dem_blend:
         # regular colorbar
         cbar = plt.colorbar(im, cax=cax, orientation=orientation, extend=inps.cbar_ext, ticks=ticks)
+        cbar_type = 'mpl'
     else:
         # illuminated colorbar for DEM-blended images
         blend_colorbar(cax, inps, vlim=[vmin, vmax], orientation=orientation, ticks=ticks)
+        cbar_type = 'img'
         cbar = None
 
     # ticks for generic cases
@@ -1421,32 +1423,32 @@ def plot_colorbar(inps, im, cax):
         if inps.cbar_nbins <= 2:
             # manually set tick for better positions when the color step is not a common number
             # e.g. for numInvIfgram.h5
-            if cbar is not None:
+            if cbar_type == 'mpl':
                 cbar.set_ticks(inps.dlim)
             elif orientation == 'vertical':
                 cax.set_yticks(inps.dlim)
-            else:
+            elif orientation == 'horizontal':
                 cax.set_xticks(inps.dlim)
 
         else:
-            if cbar is not None:
+            if cbar_type == 'mpl':
                 cbar.locator = ticker.MaxNLocator(nbins=inps.cbar_nbins)
                 cbar.update_ticks()
             elif orientation == 'vertical':
                 cax.yaxis.set_major_locator(ticker.MaxNLocator(nbins=inps.cbar_nbins))
-            else:
+            elif orientation == 'horizontal':
                 cax.xaxis.set_major_locator(ticker.MaxNLocator(nbins=inps.cbar_nbins))
 
     elif inps.cbar_ticks:
-        if cbar is not None:
+        if cbar_type == 'mpl':
             cbar.set_ticks(inps.cbar_ticks)
         elif orientation == 'vertical':
             cax.set_yticks(inps.cbar_ticks)
-        else:
+        elif orientation == 'horizontal':
             cax.set_xticks(inps.cbar_ticks)
 
     # update tick labels for special symbol: pi
-    if ticks is not None and ticks[:] == [-np.pi, 0, np.pi]:
+    if ticks and len(ticks) == 3 and ticks == [-np.pi, 0, np.pi]:
         if orientation == 'vertical':
             cax.set_yticklabels([r'-$\pi$', '0', r'$\pi$'])
         else:
@@ -1464,11 +1466,11 @@ def plot_colorbar(inps, im, cax):
 
     if cbar_label is not None:
         kwargs = dict(fontsize=inps.font_size, color=inps.font_color)
-        if cbar is not None:
+        if cbar_type == 'mpl':
             cbar.set_label(cbar_label, **kwargs)
         elif orientation == 'vertical':
             cax.set_ylabel(cbar_label, **kwargs)
-        else:
+        elif orientation == 'horizontal':
             cax.set_xlabel(cbar_label, **kwargs)
 
     return inps, cbar

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -14,10 +14,8 @@ import warnings
 
 import h5py
 import matplotlib as mpl
-import matplotlib.colors as colors
 import numpy as np
 from matplotlib import dates as mdates, pyplot as plt, ticker
-from matplotlib.colors import LightSource
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy import stats
 
@@ -1915,6 +1913,7 @@ def prepare_dem_background(dem, inps, data=None, print_msg=True):
 
     # prepare shade relief
     if inps.disp_dem_shade:
+        from matplotlib.colors import LightSource
         ls = LightSource(azdeg=inps.shade_azdeg, altdeg=inps.shade_altdeg)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -2053,7 +2052,7 @@ def plot_dem_background(ax, geo_box=None, dem_shade=None, dem_contour=None, dem_
             # radar coordinates
             elif isinstance(ax, plt.Axes):
                 ax.imshow(blend_img, extent=rdr_extent, **kwargs)
-            im = plt.cm.ScalarMappable(norm=colors.Normalize(vlim[0], vlim[1]), cmap=inps.colormap)
+            im = plt.cm.ScalarMappable(norm=mpl.colors.Normalize(vlim[0], vlim[1]), cmap=inps.colormap)
 
     # plot topo contour
     if dem_contour is not None and dem_contour_seq is not None:
@@ -2097,6 +2096,8 @@ def shaded_colorbar(inps, cax, fraction=0.75, blend_mode='soft', vert_exag=6000)
 
     Examples :      cax = pp.shaded_colorbar(inps, cax)
     """
+    from matplotlib.colors import LightSource
+
     # expand vlim by 0.01% to account for potential numerical precision leak
     # e.g. wrapped phase
     epsilon = (inps.vlim[1] - inps.vlim[0]) * 0.0001
@@ -2115,7 +2116,7 @@ def shaded_colorbar(inps, cax, fraction=0.75, blend_mode='soft', vert_exag=6000)
     ele = np.ones_like(arr) * np.cos(0.6*x)    # altitude as a cosine along teh illum. profile
 
     dnorm = (arr - vmin) / (vmax - vmin)
-    cMap = plt.cm.ScalarMappable(norm=colors.Normalize(0,1), cmap=inps.colormap)
+    cMap = plt.cm.ScalarMappable(norm=mpl.colors.Normalize(0,1), cmap=inps.colormap)
     image = cMap.to_rgba(dnorm)[:, :, :3]
     rgb = ls.shade_rgb(image, ele, fraction=fraction, blend_mode=blend_mode, vert_exag=vert_exag)
 
@@ -2171,7 +2172,7 @@ def shaded_image(data, dem, ls, vmin=None, vmax=None, cmap='viridis',
     data_norm = (data-vmin) / (vmax-vmin)
 
     # cmap norm and ScalarMappable
-    mappable = plt.cm.ScalarMappable(norm=colors.Normalize(0,1), cmap=cmap)
+    mappable = plt.cm.ScalarMappable(norm=mpl.colors.Normalize(0,1), cmap=cmap)
 
     # convert data norm to image and remove alpha channel (the fourth dimension)
     img_rgb = mappable.to_rgba(data_norm)[:, :, :3]

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -2164,7 +2164,8 @@ def prep_blend_image(data, dem, ls, vmin=None, vmax=None, cmap='viridis',
     return illum_rgb
 
 
-def plot_blend_image(ax, data, dem, geo_box=None, inps=None, print_msg=True):
+def plot_blend_image(ax, data, dem, geo_box=None, inps=None, print_msg=True,
+                     blend_img=None, dem_contour=None, dem_contour_seq=None):
     """Plot image with DEM if provided
     Parameters :    ax      matplotlib.pyplot.Axes or BasemapExt object
                     data    2D np.array

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -527,7 +527,7 @@ def plot_slice(ax, data, metadata, inps):
             inps.disp_ref_pixel = False
 
         ## Plot the image
-        ax, im = pp.plot_image4view(ax, data, dem=dem, extent=extent, geo_box=inps.geo_box, inps=inps)
+        ax, im = pp.plot_image4view(ax, data, dem=dem, extent=extent, inps=inps)
 
         # Draw faultline using GMT lonlat file
         if inps.faultline_file:

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -540,7 +540,7 @@ def plot_slice(ax, data, metadata, inps):
         if inps.disp_dem_blend:
             im = pp.plot_blend_image(ax, data, dem, inps, print_msg=inps.print_msg)
         else:
-            print('plotting data ...')
+            vprint('plotting data ...')
             im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
                            extent=inps.extent, origin='upper', interpolation=inps.interpolation,
                            alpha=inps.transparency, animated=inps.animation, zorder=1)
@@ -657,7 +657,7 @@ def plot_slice(ax, data, metadata, inps):
         if inps.disp_dem_blend:
             im = pp.plot_blend_image(ax, data, dem, inps, print_msg=inps.print_msg)
         else:
-            print('plotting data ...')
+            vprint('plotting data ...')
             im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
                            extent=inps.extent, interpolation=inps.interpolation,
                            alpha=inps.transparency, zorder=1)

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -538,8 +538,9 @@ def plot_slice(ax, data, metadata, inps):
 
         # Plot data
         if inps.disp_dem_blend:
-            im = pp.plot_blend_image(ax, data, dem, inps)
+            im = pp.plot_blend_image(ax, data, dem, inps, print_msg=inps.print_msg)
         else:
+            print('plotting data ...')
             im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
                            extent=inps.extent, origin='upper', interpolation=inps.interpolation,
                            alpha=inps.transparency, animated=inps.animation, zorder=1)
@@ -648,21 +649,15 @@ def plot_slice(ax, data, metadata, inps):
                 print_msg=inps.print_msg,
             )
 
-        # Plot Data
-        msg = 'plotting data '
-        if inps.disp_dem_blend:
-            msg += f'blended by DEM shaded relief (contrast={inps.shade_frac:.1f}, '
-            msg += f'base_color={inps.base_color:.1f}, exag={inps.shade_exag}, '
-            msg += f'az/alt={inps.shade_azdeg}/{inps.shade_altdeg} deg)'
-        vprint(msg+' ...')
-
-        # (left, right, bottom, top) in data coordinates
+        # extent = (left, right, bottom, top) in data coordinates
         inps.extent = (inps.pix_box[0]-0.5, inps.pix_box[2]-0.5,
                        inps.pix_box[3]-0.5, inps.pix_box[1]-0.5)
 
+        # Plot Data
         if inps.disp_dem_blend:
-            im = pp.plot_blend_image(ax, data, dem, inps)
+            im = pp.plot_blend_image(ax, data, dem, inps, print_msg=inps.print_msg)
         else:
+            print('plotting data ...')
             im = ax.imshow(data, cmap=inps.colormap, vmin=inps.vlim[0], vmax=inps.vlim[1],
                            extent=inps.extent, interpolation=inps.interpolation,
                            alpha=inps.transparency, zorder=1)

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -715,7 +715,7 @@ def plot_slice(ax, data, metadata, inps):
         if not inps.disp_dem_blend:
             inps, cbar = pp.plot_colorbar(inps, im, cax)
         else:
-            cax = pp.shaded_colorbar(inps, cax)
+            cax = pp.plot_blend_colorbar(inps, cax)
 
     # 3.2 Title
     if inps.disp_title:
@@ -1169,29 +1169,16 @@ def plot_subplot4figure(i, inps, ax, data, metadata):
     1) Plot DEM, data and reference pixel
     2) axes setting: tick, ticklabel, title, axis etc.
     """
-    imshow_data = ~inps.disp_dem_blend # if disp_dem_blend, no need to imshow the data as a layer again
+    # prepare inps.vlim for each data in subplot
+    inps.vlim = [np.nanmin(data), np.nanmax(data)]
 
-    # Plot DEM
-    if inps.dem_file:
-        ax, im = pp.plot_dem_background(ax,
-                                        dem_shade=inps.dem_shade,
-                                        dem_contour=inps.dem_contour,
-                                        dem_contour_seq=inps.dem_contour_seq,
-                                        dem=inps.dem,
-                                        data=data,
-                                        blend_img=inps.blend_img,
-                                        inps=inps,
-                                        print_msg=False)
+    # set plot extent
+    extent = (inps.pix_box[0]-0.5, inps.pix_box[2]-0.5,
+              inps.pix_box[3]-0.5, inps.pix_box[1]-0.5)
 
-    if imshow_data:
-        vlim = inps.vlim
-        vlim = vlim if vlim is not None else [np.nanmin(data), np.nanmax(data)]
-        extent = (inps.pix_box[0]-0.5, inps.pix_box[2]-0.5,
-                inps.pix_box[3]-0.5, inps.pix_box[1]-0.5)
-        # Plot Data
-        im = ax.imshow(data, cmap=inps.colormap, vmin=vlim[0], vmax=vlim[1],
-                        extent=extent, origin='upper', interpolation=inps.interpolation,
-                        alpha=inps.transparency, zorder=1)
+    # plot image
+    inps.print_msg = False
+    ax, im = pp.plot_image4view(ax, data, dem=inps.dem, extent=extent, inps=inps)
 
     # Plot Seed Point
     if inps.disp_ref_pixel:
@@ -1391,7 +1378,7 @@ def plot_figure(j, inps, metadata):
             if not inps.disp_dem_blend:
                 inps, cbar = pp.plot_colorbar(inps, im, cax)
             else:
-                cax = pp.shaded_colorbar(inps, cax)
+                cax = pp.plot_blend_colorbar(inps, cax)
 
     else:
         adjust_subplots_layout(fig, inps)
@@ -1479,7 +1466,7 @@ def prepare4multi_subplots(inps, metadata):
                 print_msg=False,
             )[0]
 
-            inps.dem_shade, inps.dem_contour, inps.dem_contour_seq, inps.blend_img = pp.prepare_dem_background(
+            inps.dem_shade, inps.dem_contour, inps.dem_contour_seq = pp.prepare_dem_background(
                 dem=dem,
                 inps=inps,
                 print_msg=inps.print_msg,
@@ -1492,7 +1479,7 @@ def prepare4multi_subplots(inps, metadata):
             msg += 'This feature is only supported for single subplot, and not for multi-subplots.'
             msg += '\n    --> Ignore it and continue.'
             print(msg)
-        inps.dem = dem   # store it for later call pp.plot_dem_background()
+        inps.dem = dem   # store it for later calling pp.plot_image4view()
     return inps
 
 

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -587,8 +587,6 @@ def plot_slice(ax, data, metadata, inps):
 
         # Show UNR GPS stations
         if inps.disp_gps:
-            SNWE = (inps.geo_box[3], inps.geo_box[1],
-                    inps.geo_box[0], inps.geo_box[2])
             ax = pp.plot_gps(ax, SNWE, inps, metadata, print_msg=inps.print_msg)
 
         # Status bar

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -749,11 +749,7 @@ def plot_slice(ax, data, metadata, inps):
     if inps.disp_cbar:
         divider = make_axes_locatable(ax)
         cax = divider.append_axes(inps.cbar_loc, inps.cbar_size, pad=inps.cbar_size, axes_class=plt.Axes)
-
-        if not inps.disp_dem_blend:
-            inps, cbar = pp.plot_colorbar(inps, im, cax)
-        else:
-            cax = pp.plot_blend_colorbar(inps, cax)
+        inps, cbar = pp.plot_colorbar(inps, im, cax)
 
     # 3.2 Title
     if inps.disp_title:
@@ -777,7 +773,7 @@ def plot_slice(ax, data, metadata, inps):
     if inps.disp_tick:
         # move x-axis tick label to the top if colorbar is at the bottom
         if inps.cbar_loc == 'bottom':
-            ax.tick_params(labelbottom=False, labeltop=True)
+            ax.tick_params(bottom=False, top=True, labelbottom=False, labeltop=True)
 
         # manually turn ON to enable tick labels for UTM with cartopy
         # link: https://github.com/SciTools/cartopy/issues/491


### PR DESCRIPTION
**Description of proposed changes**


Hi @yunjunz,

Here is what MintPy has long been awaiting for :star2:!!! To be like GMT :satisfied:

Rather than plotting DEM in the background and overlaying the data with transparency, I attempt to view data with color adjusted by the shaded relief DEM when provided. Just like `gmt grdimage -I` feature. Hereafter, I call this way of showing data as "DEM-blended data".

This can be done via [`matplotlib.colors.LightSource.shade_rgb()` module](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.LightSource.html#matplotlib.colors.LightSource.shade_rgb) (as opposed to what has been used in MintPy, i.e., the `LightSource.shade()` module, which only produces the shaded relief of the DEM itself).

Thus, I added two major functions in `plot.py` to handle this functionality of displaying DEM-blended data.

Changes in MintPy code are as follows.

+ `arg_utils.py`: allow the user to specify `--dem-blend`, `--shade-frac`, and `--base-color` arguments to activate and tune the DEM-blended data plotting.
  - `--dem-blend` : to activate the way of plotting the DEM-blended data
  - `--shade-frac` : tune the fraction or the contrast in shade_rgb()
  - `--base-color` : set the grayish color of the DEM background

+ `plot.py`:
   - `shaded_image()`: add illumination to the RGB data array based on a DEM file.
   - `shaded_colorbar()`: to plot a shaded illuminated colorbar. The shading is just schematic, not reflecting the real shades in the data (see future To-dos at the end of this PR).
   - `plot_image4view()`: handle the top layer plotting, this will call several other functions in plot.py, including the above two new functions.

+ `view.py`: adjust the current code to call new functions in plot.py. For a single plot, the DEM-blended data is shown well. We need to have some further tweaks for multiple subplots.

## Calling view.py examples:
```
# use a DEM from `inputs/srtm.dem` (you can also use your inputs/geometryGeo.h5) as shaded relief to adjust/blend the color of your velocity data, mask out pixels when data is NaN
view.py velocity.h5 velocity -c RdBu_r --dem inputs/srtm.dem --mask maskTempCoh.h5 --unit mm --ref-lalo 29.5463 36.0810 --vlim -4 4 --dem-nocontour --shade-exag 0.2 --dem-blend --base-color=0.9 --figtitle fancy-gmt-style
```
Results:
<img width="475" alt="image" src="https://github.com/insarlab/MintPy/assets/55262505/6f89c87d-c516-4980-8193-254b60eb862a">


## Compare between the original view.py figure (left) and this PR (right). 

Shading parameters (shown in both figure titles) are intentionally adjusted so that the two plots have a similar color tone. The only difference is the style in which the DEM is displayed.

```
# left (original MintPy way of plotting data overlaying on top of the DEM)
view.py velocity.h5 velocity -c RdBu_r --dem inputs/srtm.dem --mask maskTempCoh.h5 --unit mm --ref-lalo 29.5463 36.0810 --vlim -4 4 --dem-nocontour --shade-exag 0.5 --shade-min -6000 --shade-max 3000 --alpha 0.8

# right (this PR; I set the default blend_mode in LightSource.shade_rgb() as 'hsv' for better visualization of the map)
view.py velocity.h5 velocity -c RdBu_r --dem inputs/srtm.dem --mask maskTempCoh.h5 --unit mm --ref-lalo 29.5463 36.0810 --vlim -4 4 --dem-nocontour --dem-blend --shade-exag 0.5 --shade-frac 0.3 --base-color=0.9

# They are using the same light source, with MintPy default --shade-az (315.) and --shade-alt (45.)
```

![image](https://github.com/insarlab/MintPy/assets/55262505/6ca0e499-acd5-4ada-9b74-197ddfd46faf)


## Compare different `blend_mode`

There are three blend modes in `matplotlib.colors.LightSource.shade_rgb()`, {`hsv`,`overlay`,`soft`}. The default is `hsv`. Although matplotlib documentation says `overlay` or `soft` may be more realistic in showing elevation, `hsv` somehow looks better from my not-thoroughly tests (upper right panel in the below plot). 

![image](https://github.com/insarlab/MintPy/assets/55262505/cf32ba28-1542-4fef-a708-74cbe72db99c)


However, `hsv` seems to have some artificial color jumps (upper right panel in the below plot) when plotting these Solid Earth tides apparent velocity with a tiny data range. 

![image](https://github.com/insarlab/MintPy/assets/55262505/6fbf6220-7843-44fd-b643-620f3ce1e0d1)


## Future To-do

1. Know what was going on for `hsv` showing that color jump.

2. Implement this in the multiple subplots function, such as plotting all the geometries (height, longitude, latitude, incidencAngle, etc. with DEM shaded effects):
  ```
  view.py inputs/geometry.geo -d inputs/geometry.geo
  ```
  I try to adapt the code and implement this in plotting multiple subplots. But it still looks like it is plotting as the original MintPy way. The DEM-blended data does not seem to show up. 

3. The current fancy version of the colorbar with the illumination effects is not indicating the real shading in the data image. It is now serve only as a schematic. Although maybe it is hard to tell from our eyes. I did this by creating a fake color data from vmin & vmax in the colorbar axis, and adding yet another fake cosine-function elevation profile (hardcoded values) with shaded relief across the colorbar axis to micmic the illumination effects. Here, I have to use `soft` blend_mode for better performance. I know now it sounds pretty hacky, but it works. Check ([plot.py shaded_colorbar() function](https://github.com/insarlab/MintPy/compare/main...yuankailiu:MintPy:dev.view?expand=1#diff-d7ed74e02eb4fdfcb929a064ed7789be1de3838e47e8da6937bb42c8427abe64R2083)).

4. Perhaps some refactoring is needed.  

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
