### PR TITLE
`view --dem-blend`: support data/DEM in diff resolutions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,4 +31,5 @@ PASTE ERROR MESSAGE HERE
 * Operating system: <!-- macOS, Linux, Windows, etc. -->
 * Python environment: <!-- conda, macports, pip, path setup, etc. -->
 * MintPy version: <!-- output of `smallbaselineApp.py -v` -->
+* InSAR processor/product: <!-- isce2, aria, fringe, miaplpy, hyp3, gamma, snap, roipac, etc. -->
 * Your custom / default template file (if the bug is related to a specific dataset): <!-- It helps the diagnose a lot if you could post the configurations you used. You can drag-and-drop them here directly. -->

--- a/src/mintpy/cli/view.py
+++ b/src/mintpy/cli/view.py
@@ -148,6 +148,9 @@ def cmd_line_parse(iargs=None):
         # --dem-blend option requires --dem option
         if inps.dem_file is None:
             parser.error("--dem-blend requires -d/-dem.")
+        # --cbar-ext option is ignored
+        if '--cbar-ext' in inps.argv:
+            print('WARNING: --cbar-ext is NOT compatiable with --dem-blend, ignore --cbar-ext and continue.')
 
     # check: conflicted options (geo-only options if inpput file is in radar-coordinates)
     geo_opt_names = ['--coord', '--show-gps', '--coastline', '--lalo-label', '--lalo-step', '--scalebar', '--faultline']

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -134,7 +134,7 @@ def add_dem_argument(parser):
     # DEM-blended image
     dem.add_argument('--shade-frac', dest='shade_frac', type=float, default=0.5, metavar='NUM',
                      help='[Blend] Increases/decreases the contrast of the hillshade (default: %(default)s).')
-    dem.add_argument('--base-color', dest='base_color', type=float, default=0.9, metavar='NUM',
+    dem.add_argument('--base-color', dest='base_color', type=float, default=0.7, metavar='NUM',
                      help='[Blend] Topograhpy basemap greyish color ranges in [0,1] (default: %(default)s).')
     dem.add_argument('--blend-mode', dest='blend_mode', type=str, default='overlay',
                      choices={'hsv','overlay','soft'}, metavar='STR',


### PR DESCRIPTION
**Description of proposed changes**

This PR supports input data and DEM files in different resolution for `view --dem-blend` (#1089), by resampling the lower resolution one into higher resolution on the fly using `skimage.transform.resize()`

+ `utils.plot.prep_blend_image()`: add resampling on the fly using skimage.transform.resize() to support different resolutions between data and DEM while using the view.py --dem-blend option

+ `utils.plot.prep_blend_image()`: change the default base_color from 0.9 to 0.7, for a slightly darker DEM background

+ `cli.view.cmd_line_parse()`: ignore --cbar-ext option if --dem-blend is specified as well.

+ `.github/ISSUE_TEMPLATE/bug_report.md`: add insar processor/product info

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2374) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.