### PR TITLE
bugfix for `mintpy.network.aoiYX/LALO` options

### DIFF
--- a/src/mintpy/modify_network.py
+++ b/src/mintpy/modify_network.py
@@ -231,7 +231,7 @@ def get_date12_to_drop(inps):
         print('use coherence-based network modification')
 
         # get area of interest for coherence calculation
-        pix_box = get_aoi_pix_box(obj.metadata, inps.lookupFile, inps.aoi_pix_box, inps.aoi_geo_box)
+        pix_box = get_aoi_pix_box(obj.metadata, inps.lookupFile, inps.aoiYX, inps.aoiLALO)
 
         # calculate spatial average coherence
         cohList = ut.spatial_average(inps.file,
@@ -263,7 +263,7 @@ def get_date12_to_drop(inps):
         print('use area-ratio-based network modification')
 
         # get area of interest for coherence calculation
-        pix_box = get_aoi_pix_box(obj.metadata, inps.lookupFile, inps.aoi_pix_box, inps.aoi_geo_box)
+        pix_box = get_aoi_pix_box(obj.metadata, inps.lookupFile, inps.aoiYX, inps.aoiLALO)
 
         # calculate average coherence in masked out areas as threshold
         meanMaskCoh = np.nanmean(ut.spatial_average(inps.file,


### PR DESCRIPTION
**Description of proposed changes**

+ Fix the bug of `mintpy.network.aoiYX` and `mintpy.network.aoiLALO` getting ignored, which was introduced in https://github.com/insarlab/MintPy/pull/554.

+ Fix the `--aoi-lalo` option checking for radar-coded files without lookup files.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2371/workflows/5783fa05-dd64-46b5-adb8-603c7f4cb6a8/jobs/2378) (green)