### PR TITLE
`utils0.utm2latlon()`: allow coordinates outside of the normal range of a UTM zone

### DIFF
--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -318,7 +318,11 @@ def utm2latlon(meta, easting, northing):
     import utm
     zone_num = int(meta['UTM_ZONE'][:-1])
     northern = meta['UTM_ZONE'][-1].upper() == 'N'
-    lat, lon = utm.to_latlon(easting, northing, zone_num, northern=northern)
+    # set 'strict=False' to allow coordinates outside the range of a typical single UTM zone,
+    # which can be common for large area analysis, e.g. the Norwegian mapping authority
+    # publishes a height data in UTM zone 33 coordinates for the whole country, even though
+    # most of it is technically outside zone 33.
+    lat, lon = utm.to_latlon(easting, northing, zone_num, northern=northern, strict=False)
     return lat, lon
 
 


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.utils0.utm2latlon()`: set `strict=False` while calling `utm.to_latlon()` to allow coordinates outside the range of a typical single UTM zone, which can be common for large area analysis, as suggested by @swdmike in https://github.com/insarlab/MintPy/issues/1098

**Reminders**

- [x] Fix #1098
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2378/workflows/6beab83d-5124-43d0-a126-b7cac0ca01c1/jobs/2385) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.