### PR TITLE
Update URL for HyP3 sample notebook

### DIFF
--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -479,7 +479,7 @@ $DATA_DIR/StHelensEnvDT156
     └── StHelensEnvDT156.txt
 ```
 
-The corresponding template opptions for `load_data`:
+The corresponding template options for `load_data`:
 
 ```cfg
 ## manually specify the following attributes since they are missing from gmtsar products

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -386,7 +386,7 @@ mintpy.load.waterMaskFile    = $DATA_DIR/SanFranSenDT42/mask/watermask.msk
 
 2. Clip DEM and all interferograms to the same area using hyp3lib/[cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.
 
-Here is an example workflow: [smallbaselineApp_hyp3](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/smallbaselineApp_hyp3.ipynb).
+Here is an example workflow: [smallbaselineApp_hyp3](https://nbviewer.org/github/insarlab/MintPy-tutorial/blob/main/workflows/smallbaselineApp_hyp3.ipynb).
 
 HyP3 produces two types of InSAR products: 1) scene-wide products using Gamma and 2) burst-wide products using ISCE2.
 


### PR DESCRIPTION
**Description of proposed changes**

The link to the smallbaselineApp_hyp3.ipynb tutorial was broken in https://github.com/insarlab/MintPy/blob/main/docs/dir_structure.md. It looks like that notebook was moved into a `workflows` subdirectory. This PR updates the URL to the current notebook location.

**Reminders**

- [ ] ~~Fix #xxxx~~
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] ~~If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration~~.
- [ ] ~~If adding new functionality, add a detailed description to the documentation and/or an example.~~
