### PR TITLE
tsview: print ref_yx/lalo info & use miniforge for dev installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,7 +47,7 @@ The same procedure, in principle, can be used in <a href="https://ubuntu.com">Ub
 
 Note: The installation note below is tested on Linux and macOS, and is still experimental on Windows (may have bugs).
 
-MintPy is written in Python 3 and relies on several Python modules, check the <a href="https://github.com/insarlab/MintPy/blob/main/requirements.txt">requirements.txt</a> file for details. We recommend using <a href="https://docs.conda.io/en/latest/miniconda.html">conda</a> or <a href="https://www.macports.org/install.php">macports</a> to install the python environment and the prerequisite packages, because of the convenient management and default performance setting with <a href="http://markus-beuckelmann.de/blog/boosting-numpy-blas.html">numpy/scipy</a> and <a href="https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree">pyresample</a>.
+MintPy is written in Python 3 and relies on several Python modules, check the <a href="https://github.com/insarlab/MintPy/blob/main/requirements.txt">requirements.txt</a> file for details. We recommend using <a href="https://docs.conda.io/projects/conda/en/stable/">conda</a> to install the python environment and the prerequisite packages, because of the convenient management and default performance setting with <a href="http://markus-beuckelmann.de/blog/boosting-numpy-blas.html">numpy/scipy</a> and <a href="https://pyresample.readthedocs.io/en/latest/installation.html#using-pykdtree">pyresample</a>.
 
 ### 2.1 Install on Linux ###
 
@@ -64,40 +64,33 @@ cd ~/tools
 git clone https://github.com/insarlab/MintPy.git
 ```
 
-<h4>b. Install dependencies via conda</h4>
+<h4>b. Install dependencies via conda / mamba</h4>
 
-Install <a href="https://docs.conda.io/en/latest/miniconda.html">miniconda</a> if you have not already done so. You may need to close and restart the shell for changes to take effect.
+Install <a href="https://github.com/conda-forge/miniforge">miniforge</a> if you have not already done so. You may need to close and restart the shell for changes to take effect.
 
 ```bash
 # use wget or curl to download in the command line or click from the web browser
-# for macOS, use Miniconda3-latest-MacOSX-x86_64.sh instead.
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/tools/miniconda3
-~/tools/miniconda3/bin/conda init bash
+# for macOS, use Miniforge3-MacOSX-x86_64.sh instead.
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+bash Miniforge3-Linux-x86_64.sh -b -p ~/tools/miniforge
+~/tools/miniforge/bin/mamba init bash
 ```
 
-Install the dependencies into a custom existing environment [recommended] by running:
-
-```bash
-# To speedup, try "conda install mamba", then use "mamba install" to replace "conda install" below
-
-# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
-# Add "isce2"     below to install extra dependencies if you use ISCE-2
-conda install -c conda-forge --file ~/tools/MintPy/requirements.txt
-```
-
-<p>
-<details>
-<p><summary>Or install the dependencies to a new environment, e.g. named "insar", by running:</summary></p>
+Install dependencies into a new environment, e.g. named "insar":
 
 ```bash
 # Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
 # Add "isce2"     below to install extra dependencies if you use ISCE-2
-conda create --name insar --file ~/tools/MintPy/requirements.txt
-conda activate insar
+mamba create --name insar --file ~/tools/MintPy/requirements.txt
 ```
-</details>
-</p>
+
+or install dependencies into an existing environment:
+
+```bash
+# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
+# Add "isce2"     below to install extra dependencies if you use ISCE-2
+mamba update --name my-existing-env --file ~/tools/MintPy/requirements.txt
+```
 
 <h4>c. Install MintPy</h4>
 
@@ -145,11 +138,11 @@ sudo xcodebuild -license</code></pre>
 <li>Install <a href="https://www.xquartz.org">XQuartz</a>, then restart the terminal.</li>
 </ul>
 
-<p>Install MintPy via conda, which is the same as the <a href="#21-install-on-linux">instruction for Linux</a>.</p>
+<p>Install MintPy via conda [recommended], which is the same as the <a href="#21-install-on-linux">instruction for Linux</a>.</p>
 
 <p>
 <details>
-<p><summary>Or install MintPy via MacPorts</summary></p>
+<p><summary>Or install MintPy via MacPorts [obsolete] </summary></p>
 
 Same as the instruction for Linux, except for the "b. Install dependencies" section, which is as below. Note that the installation procedure via MacPorts has not been maintained since Sep 2022, and will likely be phased out at some point, since conda/mamba works seamlessly on both MacOS and Linux.
 

--- a/src/mintpy/simulation/iono.py
+++ b/src/mintpy/simulation/iono.py
@@ -198,7 +198,7 @@ def incidence_angle_ground2iono(inc_angle, iono_height=450e3):
 def lalo_ground2iono(lat, lon, inc_angle, az_angle=None, head_angle=None, iono_height=450e3, method='spherical_distance'):
     """Calculate lat/lon of IPP with the given lat/lon on the ground and LOS geometry
 
-    Equation (12) in Yunjun et al. (2021, TGRS).
+    Equation (12) in Yunjun et al. (2022, TGRS).
 
     Parameters: lat/lon      - float, latitude/longitude of the point on the ground in degrees
                 inc_angle    - float/np.ndarray, incidence angle of the line-of-sight vector on the ground in degrees

--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -160,10 +160,13 @@ def read_init_info(inps):
     if not inps.ref_yx and 'REF_Y' in atr.keys():
         inps.ref_yx = (int(atr['REF_Y']), int(atr['REF_X']))
 
-    # ref_yx --> ref_lalo if in geo-coord
-    # for plotting purpose only
-    if inps.ref_yx and 'Y_FIRST' in atr.keys():
-        inps.ref_lalo = inps.coord.radar2geo(inps.ref_yx[0], inps.ref_yx[1], print_msg=False)[0:2]
+    # print/plot ref_yx/lalo info
+    if inps.ref_yx:
+        vprint(f'reference point in y/x: {inps.ref_yx}')
+        # ref_yx --> ref_lalo if in geo-coord [for plotting purpose only]
+        if 'Y_FIRST' in atr.keys():
+            inps.ref_lalo = inps.coord.radar2geo(inps.ref_yx[0], inps.ref_yx[1], print_msg=False)[0:2]
+            vprint(f'reference point in lat/lon: {inps.ref_lalo}')
 
     # do not plot native reference point if it's out of the coverage due to subset
     if (inps.ref_yx and 'Y_FIRST' in atr.keys()
@@ -171,7 +174,7 @@ def read_init_info(inps):
         and not (    inps.pix_box[0] <= inps.ref_yx[1] < inps.pix_box[2]
                  and inps.pix_box[1] <= inps.ref_yx[0] < inps.pix_box[3])):
         inps.disp_ref_pixel = False
-        print('the native REF_Y/X is out of subset box, thus do not display')
+        vprint('the native REF_Y/X is out of subset box, thus do not display')
 
     ## initial pixel coord
     if inps.lalo:

--- a/src/mintpy/utils/map.py
+++ b/src/mintpy/utils/map.py
@@ -77,6 +77,11 @@ def auto_lalo_sequence(geo_box, lalo_step=None, lalo_max_num=4, step_candidate=[
     Example:    geo_box = (128.0, 37.0, 138.0, 30.0)
                 lats, lons, step = m.auto_lalo_sequence(geo_box)
     """
+    # check input arguments
+    if geo_box[1] <= geo_box[3] or geo_box[2] < geo_box[0]:
+        raise ValueError(f'Input geo_box {geo_box} has N <= S or E <= W! Check the order of (W, N, E, S).')
+    if lalo_step and lalo_step <= 0:
+        raise ValueError(f'Input lalo_step ({lalo_step}) must be positive!')
 
     max_lalo_dist = max([geo_box[1] - geo_box[3], geo_box[2] - geo_box[0]])
 


### PR DESCRIPTION
**Description of proposed changes**

+ docs/installation: replace miniconda with miniforge
   - use miniforge3 as the recommended conda/mamba installer, instead of miniconda3. This brings two benefits: 1) mamba is installed by default; 2) the conda-forge channel is set as the default and only channel.
   - use mamba as the package installer, instead of conda, for a faster speed and a slightly simpler note as well.
+ tsview: print out ref_yx/lalo info if available
+ simulatiton/iono: fix typo
+ utils.map.auto_lalo_seq*(): check input args for a more meaningful diagnose

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2462) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.