### PR TITLE
read/load support for `isce2/alos2App` dense offset

### DIFF
--- a/src/mintpy/load_data.py
+++ b/src/mintpy/load_data.py
@@ -668,6 +668,7 @@ def prepare_metadata(iDict):
         # --baseline-dir / --geometry-dir
         baseline_dir = iDict['mintpy.load.baselineDir']
         geom_dir = os.path.dirname(iDict['mintpy.load.demFile'])
+        geom_dir = os.path.abspath(geom_dir)
 
         # --dset-dir / --file-pattern
         obs_keys = [

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -838,10 +838,17 @@ def get_slice_list(fname, no_complex=False):
         elif 'offset' in fbase and num_band == 2:
             # ampcor offset file, e.g. offset.bip, dense_offsets.bil
             slice_list = ['azimuthOffset', 'rangeOffset']
+            if fname.endswith('_denseoffset.off'):
+                # for alos2App dense offset, the file has the opposite band order
+                # e.g. 231206-240103_denseoffset.off
+                slice_list = ['rangeOffset', 'azimuthOffset']
 
-        elif 'offset' in fbase and '_cov' in fbase and num_band == 3:
+        elif 'offset' in fbase and 'cov' in fname and num_band == 3:
             # ampcor offset covariance file, e.g. offset_cov.bip, dense_offsets_cov.bil
             slice_list = ['azimuthOffsetVar', 'rangeOffsetVar', 'offsetCovar']
+            if fname.endswith('_denseoffset.cov'):
+                # for alos2App dense offset, e.g. 231206-240103_denseoffset.cov
+                slice_list = ['rangeOffsetVar', 'azimuthOffsetVar', 'offsetCovar']
 
         elif fext in ['.lkv']:
             slice_list = ['east', 'north', 'up']
@@ -1364,8 +1371,16 @@ def auto_no_data_value(meta):
 
         # known file types
         # isce2: dense offsets from topsApp.py
-        if processor == 'isce' and fname.endswith('dense_offsets.bil') and num_band == 2:
-            no_data_value = -10000.
+        if processor == 'isce' and num_band == 2:
+            # isce2 dense offset
+            if fname.endswith('dense_offsets.bil'):
+                # from topsApp.py
+                no_data_value = -10000.
+            elif fname.endswith('_denseoffset.off'):
+                # from alos2App.py
+                no_data_value = 0.
+            else:
+                no_data_value = None
 
         else:
             # default value for unknown file types


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.readfile.auto_no_data_value()`: support `alos2App` dense offset

+ `utils.readfile.get_slice_list()`: `alos2App` use rg/az order, instead of az/rg order in other isce2 applications.

+ `utils.isce_utils.extract_alosStack_metadata/extract_image_size_alosStack()`: support geometry files from alos2App/dense_offset, which have different naming conventions as the ones from InSAR.

+ `load_data`: use absolute path for better robustness

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2474/workflows/25006442-ad6a-4fde-81b3-e74035bc0bce/jobs/2481) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.