### PR TITLE
`autoPath` for `alosStack`: supp custom multilook # + ion phase/coherence

### DIFF
--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -544,16 +544,17 @@ def plot_coherence_history(ax, date12List, cohList, p_dict={}):
     ax.bar(x_list, np.nanmax(coh_mat, axis=0), bar_width.days, label='Max {}'.format(p_dict['ds_name']))
     ax.bar(x_list, np.nanmin(coh_mat, axis=0), bar_width.days, label='Min {}'.format(p_dict['ds_name']))
 
+    # axis format
     if p_dict['disp_title']:
         ax.set_title('{} History: Min/Max of All Related Pairs'.format(p_dict['ds_name']))
-
     ax = auto_adjust_xaxis_date(ax, datevector, fontsize=p_dict['fontsize'],
                                 every_year=p_dict['every_year'])[0]
     ax.set_ylim([p_dict['vlim'][0], p_dict['vlim'][1]])
-
     #ax.set_xlabel('Time [years]', fontsize=p_dict['fontsize'])
-    ax.set_ylabel(p_dict['ds_name'], fontsize=p_dict['fontsize'])
+    ax.set_ylabel(p_dict['cbar_label'], fontsize=p_dict['fontsize'])
     ax.legend(loc='best')
+    ax.tick_params(which='both', direction='in', labelsize=p_dict['fontsize'],
+                   bottom=True, top=True, left=True, right=True)
 
     return ax
 


### PR DESCRIPTION
**Description of proposed changes**

This PR further support the auto path setting for alosStack products, after https://github.com/insarlab/MintPy/pull/1119.

+ `defaults.auto_path`: add `get_multilook_suffix()` to grab the custom multilook suffix in the interferogram file name

+ `defaults.auto_path.get_reference_date()`: minor bug fix in the print out msg

+ `defaults.auto_path.AUTO_PATH_ISCE_ALOS`: add `mintpy.load.ion*File` default file patterns

+ `utils.plot.plot_coherence_history()`: plot ticks on all four boundaries, and set tick `in`

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2506) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
