### PR TITLE
`modify_network`: add `--ex-date12` option

### DIFF
--- a/src/mintpy/defaults/smallbaselineApp.cfg
+++ b/src/mintpy/defaults/smallbaselineApp.cfg
@@ -82,6 +82,7 @@ mintpy.network.connNumMax      = auto  #[1-inf, no], auto for no, max number of 
 mintpy.network.startDate       = auto  #[20090101 / no], auto for no
 mintpy.network.endDate         = auto  #[20110101 / no], auto for no
 mintpy.network.excludeDate     = auto  #[20080520,20090817 / no], auto for no
+mintpy.network.excludeDate12   = auto  #[20080520_20090817 / no], auto for no
 mintpy.network.excludeIfgIndex = auto  #[1:5,25 / no], auto for no, list of ifg index (start from 0)
 mintpy.network.referenceFile   = auto  #[date12_list.txt / ifgramStack.h5 / no], auto for no
 

--- a/src/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/src/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -28,6 +28,7 @@ mintpy.network.connNumMax        = no
 mintpy.network.startDate         = no
 mintpy.network.endDate           = no
 mintpy.network.excludeDate       = no
+mintpy.network.excludeDate12     = no
 mintpy.network.excludeIfgIndex   = no
 mintpy.network.referenceFile     = no
 

--- a/src/mintpy/modify_network.py
+++ b/src/mintpy/modify_network.py
@@ -199,6 +199,15 @@ def get_date12_to_drop(inps):
         for ifg_idx, date12 in zip(inps.excludeIfgIndex, tempList):
             print(f'{ifg_idx} : {date12}')
 
+    # excludeDate12
+    if inps.excludeDate12:
+        tempList = [i for i in inps.excludeDate12 if i in date12ListAll]
+        date12_to_drop += tempList
+        print('--------------------------------------------------')
+        print(f'Drop ifgrams with the following date12: {len(tempList)}')
+        for date12 in tempList:
+            print(date12)
+
     # excludeDate
     if inps.excludeDate:
         tempList = [i for i in date12ListAll if any(j in inps.excludeDate for j in i.split('_'))]


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the capability to exclude interferometric pairs given the list of date12, besides given the ifgram index. The benefit is that it won't change after updating interferogram stack.

+ `(cli.)modify_network.py`: add `--exclude-date12` option to exclude pairs given date1_date2

+ `defaults.smallbaselineApp(_auto).cfg`: add `mintpy.network.excludeDate12` option with auto value of no

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2501/workflows/fc595d66-ade3-46c1-91bf-e8d760b25066/jobs/2508) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
