### PR TITLE
UTM support for `view --show-gps` + dual-coord input for `lalo2yx/yx2lalo()`

### DIFF
--- a/src/mintpy/asc_desc2horz_vert.py
+++ b/src/mintpy/asc_desc2horz_vert.py
@@ -186,8 +186,7 @@ def run_asc_desc2horz_vert(inps):
     for i, (atr, fname) in enumerate(zip(atr_list, inps.file)):
         # overlap SNWE --> box to read for each specific file
         coord = ut.coordinate(atr)
-        x0 = coord.lalo2yx(W, coord_type='lon')
-        y0 = coord.lalo2yx(N, coord_type='lat')
+        y0, x0 = coord.lalo2yx(N, W)
         box = (x0, y0, x0 + width, y0 + length)
 
         # read data

--- a/src/mintpy/cli/plot_transection.py
+++ b/src/mintpy/cli/plot_transection.py
@@ -126,8 +126,7 @@ def cmd_line_parse(iargs=None):
 
     # check: --start/end-lalo (start/end_lalo --> start/end_yx)
     if inps.start_lalo and inps.end_lalo:
-        [y0, y1] = inps.coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]], coord_type='lat')
-        [x0, x1] = inps.coord.lalo2yx([inps.start_lalo[1], inps.end_lalo[1]], coord_type='lon')
+        [y0, y1], [x0, x1] = inps.coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]], [inps.start_lalo[1], inps.end_lalo[1]])
         inps.start_yx = [y0, x0]
         inps.end_yx = [y1, x1]
 

--- a/src/mintpy/cli/plot_transection.py
+++ b/src/mintpy/cli/plot_transection.py
@@ -126,7 +126,8 @@ def cmd_line_parse(iargs=None):
 
     # check: --start/end-lalo (start/end_lalo --> start/end_yx)
     if inps.start_lalo and inps.end_lalo:
-        [y0, y1], [x0, x1] = inps.coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]], [inps.start_lalo[1], inps.end_lalo[1]])
+        [y0, y1], [x0, x1] = inps.coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]],
+                                                [inps.start_lalo[1], inps.end_lalo[1]])
         inps.start_yx = [y0, x0]
         inps.end_yx = [y1, x1]
 

--- a/src/mintpy/legacy/transect_legacy2.py
+++ b/src/mintpy/legacy/transect_legacy2.py
@@ -314,8 +314,7 @@ def plot_transect_location(ax, inps):
         if 0 <= col < data0.shape[1] and 0 <= row < data0.shape[0]:
             z = data0[row, col]
             if 'X_FIRST' in atr0.keys():
-                lat = coord.yx2lalo(row, coord_type='row')
-                lon = coord.yx2lalo(col, coord_type='col')
+                lat, lon = coord.yx2lalo(row, col)
                 return f'lon={lon:.4f}, lat={lat:.4f}, x={x:.0f},  y={y:.0f},  value={z:.4f}'
             else:
                 return f'x={x:.0f},  y={y:.0f},  value={z:.4f}'

--- a/src/mintpy/legacy/transect_legacy2.py
+++ b/src/mintpy/legacy/transect_legacy2.py
@@ -297,7 +297,8 @@ def plot_transect_location(ax, inps):
 
     coord = ut.coordinate(atr0)
     if inps.start_lalo and inps.end_lalo:
-        [y0, y1], [x0, x1] = coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]], [inps.start_lalo[1], inps.end_lalo[1]])
+        [y0, y1], [x0, x1] = coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]],
+                                           [inps.start_lalo[1], inps.end_lalo[1]])
         inps.start_yx = [y0, x0]
         inps.end_yx = [y1, x1]
 

--- a/src/mintpy/legacy/transect_legacy2.py
+++ b/src/mintpy/legacy/transect_legacy2.py
@@ -233,8 +233,7 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
 def transect_lalo(z, atr, start_lalo, end_lalo, interpolation='nearest'):
     """Extract 2D matrix (z) value along the line [start_lalo, end_lalo]"""
     coord = ut.coordinate(atr)
-    [y0, y1] = coord.lalo2yx([start_lalo[0], end_lalo[0]], coord_type='lat')
-    [x0, x1] = coord.lalo2yx([start_lalo[1], end_lalo[1]], coord_type='lon')
+    [y0, y1], [x0, x1] = coord.lalo2yx([start_lalo[0], end_lalo[0]], [start_lalo[1], end_lalo[1]])
     transect = transect_yx(z, atr, [y0, x0], [y1, x1], interpolation)
     return transect
 
@@ -298,8 +297,7 @@ def plot_transect_location(ax, inps):
 
     coord = ut.coordinate(atr0)
     if inps.start_lalo and inps.end_lalo:
-        [y0, y1] = coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]], coord_type='lat')
-        [x0, x1] = coord.lalo2yx([inps.start_lalo[1], inps.end_lalo[1]], coord_type='lon')
+        [y0, y1], [x0, x1] = coord.lalo2yx([inps.start_lalo[0], inps.end_lalo[0]], [inps.start_lalo[1], inps.end_lalo[1]])
         inps.start_yx = [y0, x0]
         inps.end_yx = [y1, x1]
 

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -334,8 +334,7 @@ class coordinate:
         """
         self.open()
         if self.geocoded:
-            lat = self.yx2lalo(az, coord_type='az')
-            lon = self.yx2lalo(rg, coord_type='rg')
+            lat, lon = self.yx2lalo(az, rg)
             return lat, lon, 0, 0
 
         if not isinstance(az, np.ndarray):
@@ -402,8 +401,7 @@ class coordinate:
         Returns:    geo_box   - tuple      of 4 float in (W, N, E, S)
         """
         try:
-            lat = self.yx2lalo([pixel_box[1], pixel_box[3]], coord_type='y')
-            lon = self.yx2lalo([pixel_box[0], pixel_box[2]], coord_type='x')
+            lat, lon = self.yx2lalo([pixel_box[1], pixel_box[3]], [pixel_box[0], pixel_box[2]])
             # shift lat from pixel center to the UL corner
             lat = [i - self.lat_step / 2.0 for i in lat]
             lon = [i - self.lon_step / 2.0 for i in lon]

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -133,7 +133,7 @@ class coordinate:
         lon_coord_out = []
         for y_i, x_i in zip(y_in, x_in):
             lat_coord_out.append((y_i + 0.5) * self.lat_step + self.lat0)
-            lon_coord_out.append(x_i + 0.5) * self.lon_step + self.lon0
+            lon_coord_out.append((x_i + 0.5) * self.lon_step + self.lon0)
 
         if len(lat_coord_out) == 1 and len(lon_coord_out) == 1:
             coord_out = tuple([lat_coord_out[0], lon_coord_out[0]])

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -89,7 +89,7 @@ class coordinate:
         self.open()
         if not self.geocoded:
             raise ValueError('Input file is not geocoded.')
-        
+
         lat_coord_in = self._clean_coord(lat_coord_in)
         lon_coord_in = self._clean_coord(lon_coord_in)
     

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -92,7 +92,7 @@ class coordinate:
 
         lat_coord_in = self._clean_coord(lat_coord_in)
         lon_coord_in = self._clean_coord(lon_coord_in)
-    
+
         if 'UTM_ZONE' in self.src_metadata and np.max(lat_coord_in) <= 90 and np.max(lon_coord_in) <= 360:
             lat_coord_in, lon_coord_in = ut0.latlon2utm(np.array(lat_coord_in), np.array(lon_coord_in))
 

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -92,7 +92,7 @@ class coordinate:
         lat_coord_in = self._clean_coord(lat_coord_in)
         lon_coord_in = self._clean_coord(lon_coord_in)
     
-        if 'UTM_ZONE' in self.src_metadata:
+        if 'UTM_ZONE' in self.src_metadata and np.max(lat_coord_in) <= 90 and np.max(lon_coord_in) <= 360:
             lat_coord_in, lon_coord_in = ut0.latlon2utm(np.array(lat_coord_in), np.array(lon_coord_in))
 
         # convert coordinates
@@ -224,6 +224,9 @@ class coordinate:
                     az/rg_res - float, residul/uncertainty of coordinate conversion
         """
         # ensure longitude convention to be consistent with src_metadata
+        if 'UTM_ZONE' in self.src_metadata and (np.max(lat) > 90 or np.max(lon) > 360):
+            lat, lon = ut0.utm2latlon(self.src_metadata, lon, lat)
+
         if 'X_FIRST' in self.src_metadata.keys():
             width = int(self.src_metadata['WIDTH'])
             lon_step = float(self.src_metadata['X_STEP'])

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -93,7 +93,7 @@ class coordinate:
         lat_coord_in = self._clean_coord(lat_coord_in)
         lon_coord_in = self._clean_coord(lon_coord_in)
 
-        if 'UTM_ZONE' in self.src_metadata and np.max(lat_coord_in) <= 90 and np.max(lon_coord_in) <= 360:
+        if 'UTM_ZONE' in self.src_metadata and np.max(np.abs(lat_coord_in)) <= 90 and np.max(np.abs(lon_coord_in)) <= 360:
             lat_coord_in, lon_coord_in = ut0.latlon2utm(np.array(lat_coord_in), np.array(lon_coord_in))
 
         # convert coordinates
@@ -226,7 +226,7 @@ class coordinate:
                     az/rg_res - float, residul/uncertainty of coordinate conversion
         """
         # ensure longitude convention to be consistent with src_metadata
-        if 'UTM_ZONE' in self.src_metadata and (np.max(lat) > 90 or np.max(lon) > 360):
+        if 'UTM_ZONE' in self.src_metadata and (np.max(np.abs(lat)) > 90 or np.max(np.abs(lon)) > 360):
             lat, lon = ut0.utm2latlon(self.src_metadata, lon, lat)
 
         if 'X_FIRST' in self.src_metadata.keys():

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -79,7 +79,8 @@ class coordinate:
         return coord_in
 
     def lalo2yx(self, lat_coord_in, lon_coord_in):
-        """convert geo coordinates into radar coordinates for Geocoded file only
+        """convert geo coordinates into radar coordinates for Geocoded file only.
+        Attempts to convert lat/lon to utm coordinates if needed.
         Parameters: lat_coord_in  - list / tuple / 1D np.ndarray / float, coordinate(s) in latitude
                     lon_coord_in  - list / tuple / 1D np.ndarray / float, coordinate(s) in longitude
         Example:    300, 1000 = coordinate.lalo2yx(32.1, 130.5)
@@ -219,6 +220,7 @@ class coordinate:
 
     def geo2radar(self, lat, lon, print_msg=True, debug_mode=False):
         """Convert geo coordinates into radar coordinates.
+        Attempts to convert utm coordinates to lat/lon if needed.
         Parameters: lat/lon   - np.array / float, latitude/longitude
         Returns:    az/rg     - np.array / int, range/azimuth pixel number
                     az/rg_res - float, residul/uncertainty of coordinate conversion

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -211,8 +211,7 @@ class coherenceMatrixViewer():
     def update_coherence_matrix(self, event):
         if event.inaxes == self.ax_img:
             if self.fig_coord == 'geo':
-                yx = [self.coord.lalo2yx(event.ydata, coord_type='lat'),
-                      self.coord.lalo2yx(event.xdata, coord_type='lon')]
+                yx = self.coord.lalo2yx(event.ydata, event.xdata)
             else:
                 yx = [int(event.ydata+0.5),
                       int(event.xdata+0.5)]

--- a/src/mintpy/plot_transection.py
+++ b/src/mintpy/plot_transection.py
@@ -168,8 +168,7 @@ class transectionViewer():
 
         # convert coordinates accordingly
         if 'Y_FIRST' in self.atr.keys():
-            ys = self.coord.yx2lalo([start_yx[0], end_yx[0]], coord_type='y')
-            xs = self.coord.yx2lalo([start_yx[1], end_yx[1]], coord_type='x')
+            ys, xs = self.coord.yx2lalo([start_yx[0], end_yx[0]], [start_yx[1], end_yx[1]])
         else:
             ys = [start_yx[0], end_yx[0]]
             xs = [start_yx[1], end_yx[1]]

--- a/src/mintpy/reference_point.py
+++ b/src/mintpy/reference_point.py
@@ -171,8 +171,7 @@ def reference_point_attribute(atr, y, x):
     atrNew['REF_X'] = str(x)
     coord = ut.coordinate(atr)
     if 'X_FIRST' in atr.keys():
-        atrNew['REF_LAT'] = str(coord.yx2lalo(y, coord_type='y'))
-        atrNew['REF_LON'] = str(coord.yx2lalo(x, coord_type='x'))
+        atrNew['REF_LAT'], atrNew['REF_LON'] = [str(val) for val in coord.yx2lalo(y, x)]
     return atrNew
 
 

--- a/src/mintpy/reference_point.py
+++ b/src/mintpy/reference_point.py
@@ -171,7 +171,7 @@ def reference_point_attribute(atr, y, x):
     atrNew['REF_X'] = str(x)
     coord = ut.coordinate(atr)
     if 'X_FIRST' in atr.keys():
-        atrNew['REF_LAT'], atrNew['REF_LON'] = [str(val) for val in coord.yx2lalo(y, x)]
+        atrNew['REF_LAT'], atrNew['REF_LON'] = (str(val) for val in coord.yx2lalo(y, x))
     return atrNew
 
 

--- a/src/mintpy/subset.py
+++ b/src/mintpy/subset.py
@@ -183,18 +183,13 @@ def subset_input_dict2box(subset_dict, meta_dict):
 
     # Use subset_lat/lon input if existed,  priority: lat/lon > y/x > len/wid
     coord = ut.coordinate(meta_dict)
-    if subset_dict.get('subset_lat', None):
-        sub_y = coord.lalo2yx(subset_dict['subset_lat'], coord_type='latitude')
-    elif subset_dict['subset_y']:
+    if subset_dict.get('subset_lat', None) and subset_dict.get('subset_lon', None):
+        sub_y, sub_x = coord.lalo2yx(subset_dict['subset_lat'], subset_dict['subset_lon'])
+    elif subset_dict['subset_y'] and subset_dict['subset_x']:
         sub_y = subset_dict['subset_y']
-    else:
-        sub_y = [0, length]
-
-    if subset_dict.get('subset_lon', None):
-        sub_x = coord.lalo2yx(subset_dict['subset_lon'], coord_type='longitude')
-    elif subset_dict['subset_x']:
         sub_x = subset_dict['subset_x']
     else:
+        sub_y = [0, length]
         sub_x = [0, width]
 
     # Get subset box in y/x

--- a/src/mintpy/subset.py
+++ b/src/mintpy/subset.py
@@ -183,13 +183,18 @@ def subset_input_dict2box(subset_dict, meta_dict):
 
     # Use subset_lat/lon input if existed,  priority: lat/lon > y/x > len/wid
     coord = ut.coordinate(meta_dict)
-    if subset_dict.get('subset_lat', None) and subset_dict.get('subset_lon', None):
-        sub_y, sub_x = coord.lalo2yx(subset_dict['subset_lat'], subset_dict['subset_lon'])
-    elif subset_dict['subset_y'] and subset_dict['subset_x']:
+    if subset_dict.get('subset_lat', None):
+        sub_y = coord.lalo2yx(subset_dict['subset_lat'], 0)[0]
+    elif subset_dict['subset_y']:
         sub_y = subset_dict['subset_y']
-        sub_x = subset_dict['subset_x']
     else:
         sub_y = [0, length]
+
+    if subset_dict.get('subset_lon', None):
+        sub_x = coord.lalo2yx(0, subset_dict['subset_lon'])[1]
+    elif subset_dict['subset_x']:
+        sub_x = subset_dict['subset_x']
+    else:
         sub_x = [0, width]
 
     # Get subset box in y/x

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -46,6 +46,7 @@ MPL_COLORS = [
     '#bcbd22',
     '#17becf',
 ]
+plt.rcParams["axes.formatter.limits"] = (-1e10, 1e10)
 
 
 ########################################### Parser utilities ##############################################

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -46,6 +46,7 @@ MPL_COLORS = [
     '#bcbd22',
     '#17becf',
 ]
+# ensur UTM coordinate plot axes do not use scientific notation
 plt.rcParams["axes.formatter.limits"] = (-1e10, 1e10)
 
 
@@ -1128,7 +1129,8 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
     start_date = inps.gps_start_date if inps.gps_start_date else metadata.get('START_DATE', None)
     end_date = inps.gps_end_date if inps.gps_end_date else metadata.get('END_DATE', None)
 
-    if 'UTM_ZONE' in metadata:
+    # pre-query: convert UTM to lat/lon for query
+    if 'UTM_ZONE' in metadata.keys():
         south, west = ut0.utm2latlon(atr, SNWE[2], SNWE[0])
         north, east = ut0.utm2latlon(atr, SNWE[3], SNWE[1])
         SNWE = (south, north, west, east)
@@ -1140,7 +1142,8 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         print('  continue without GNSS plots.')
         return ax
 
-    if 'UTM_ZONE' in metadata:
+    # post-query: convert lat/lon to UTM for plotting
+    if 'UTM_ZONE' in metadata.keys():
         site_lats, site_lons = ut0.latlon2utm(site_lats, site_lons)
 
     # mask out stations not coincident with InSAR data

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1140,6 +1140,9 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         print('  continue without GNSS plots.')
         return ax
 
+    if 'UTM_ZONE' in metadata:
+        site_lats, site_lons = ut0.latlon2utm(site_lats, site_lons)
+
     # mask out stations not coincident with InSAR data
     if inps.mask_gps and inps.msk is not None:
         msk = inps.msk if inps.msk.ndim == 2 else np.prod(inps.msk, axis=-1)
@@ -1219,9 +1222,6 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         if np.sum(nan_flag) > 0:
             vprint(f'ignore the following {np.sum(nan_flag)} stations due to limited overlap/observations in time')
             vprint(f'  {site_names[nan_flag]}')
-
-        if 'UTM_ZONE' in metadata:
-            site_lats, site_lons = ut0.latlon2utm(site_lats, site_lons)
 
         # plot
         for lat, lon, obs in zip(site_lats, site_lons, site_obs):

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1128,6 +1128,11 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
     start_date = inps.gps_start_date if inps.gps_start_date else metadata.get('START_DATE', None)
     end_date = inps.gps_end_date if inps.gps_end_date else metadata.get('END_DATE', None)
 
+    if 'UTM_ZONE' in metadata:
+        south, west = ut0.utm2latlon(atr, SNWE[2], SNWE[0])
+        north, east = ut0.utm2latlon(atr, SNWE[3], SNWE[1])
+        SNWE = (south, north, west, east)
+
     # query for GNSS stations
     site_names, site_lats, site_lons = gps.search_gps(SNWE, start_date, end_date)
     if site_names.size == 0:
@@ -1214,6 +1219,9 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
         if np.sum(nan_flag) > 0:
             vprint(f'ignore the following {np.sum(nan_flag)} stations due to limited overlap/observations in time')
             vprint(f'  {site_names[nan_flag]}')
+
+        if 'UTM_ZONE' in metadata:
+            site_lats, site_lons = ut0.latlon2utm(site_lats, site_lons)
 
         # plot
         for lat, lon, obs in zip(site_lats, site_lons, site_obs):

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -358,8 +358,7 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
 def transect_lalo(z, atr, start_lalo, end_lalo, interpolation='nearest'):
     """Extract 2D matrix (z) value along the line [start_lalo, end_lalo]"""
     coord = coordinate(atr)
-    [y0, y1] = coord.lalo2yx([start_lalo[0], end_lalo[0]], coord_type='lat')
-    [x0, x1] = coord.lalo2yx([start_lalo[1], end_lalo[1]], coord_type='lon')
+    [[y0, y1], [x0, x1]] = coord.lalo2yx([start_lalo[0], end_lalo[0]], [start_lalo[1], end_lalo[1]])
     transect = transect_yx(z, atr, [y0, x0], [y1, x1], interpolation)
     return transect
 

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -327,7 +327,7 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
     if 'Y_FIRST' in atr.keys():
         y_step = float(atr['Y_STEP'])
         x_step = float(atr['X_STEP'])
-        if 'UTM_ZONE' not in atr:
+        if not atr.get('UTM_ZONE', None):   # WGS84 lat/lon
             [lat0, lat1], _ = coordinate(atr).yx2lalo([y0, y1], [x0, x1])
             lat_c = (lat0 + lat1) / 2.
             y_step *= np.pi/180.0 * earth_radius
@@ -361,7 +361,8 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
 def transect_lalo(z, atr, start_lalo, end_lalo, interpolation='nearest'):
     """Extract 2D matrix (z) value along the line [start_lalo, end_lalo]"""
     coord = coordinate(atr)
-    [[y0, y1], [x0, x1]] = coord.lalo2yx([start_lalo[0], end_lalo[0]], [start_lalo[1], end_lalo[1]])
+    [y0, y1], [x0, x1] = coord.lalo2yx([start_lalo[0], end_lalo[0]],
+                                       [start_lalo[1], end_lalo[1]])
     transect = transect_yx(z, atr, [y0, x0], [y1, x1], interpolation)
     return transect
 

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -328,7 +328,7 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
         y_step = float(atr['Y_STEP'])
         x_step = float(atr['X_STEP'])
         if 'UTM_ZONE' not in atr:
-            [lat0, lat1], [lon0, lon1] = coordinate(atr).yx2lalo([y0, y1], [x0, x1])
+            [lat0, lat1], _ = coordinate(atr).yx2lalo([y0, y1], [x0, x1])
             lat_c = (lat0 + lat1) / 2.
             y_step *= np.pi/180.0 * earth_radius
             x_step *= np.pi/180.0 * earth_radius * np.cos(lat_c * np.pi/180)

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -328,7 +328,7 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
         y_step = float(atr['Y_STEP'])
         x_step = float(atr['X_STEP'])
         if not atr.get('UTM_ZONE', None):   # WGS84 lat/lon
-            [lat0, lat1], _ = coordinate(atr).yx2lalo([y0, y1], [x0, x1])
+            [lat0, lat1] = coordinate(atr).yx2lalo([y0, y1], [x0, x1])[0]
             lat_c = (lat0 + lat1) / 2.
             y_step *= np.pi/180.0 * earth_radius
             x_step *= np.pi/180.0 * earth_radius * np.cos(lat_c * np.pi/180)

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -325,10 +325,13 @@ def transect_yx(z, atr, start_yx, end_yx, interpolation='nearest'):
     earth_radius = 6.3781e6    # in meter
     dist_unit = 'm'
     if 'Y_FIRST' in atr.keys():
-        [lat0, lat1] = coordinate(atr).yx2lalo([y0, y1], coord_type='y')
-        lat_c = (lat0 + lat1) / 2.
-        x_step = float(atr['X_STEP']) * np.pi/180.0 * earth_radius * np.cos(lat_c * np.pi/180)
-        y_step = float(atr['Y_STEP']) * np.pi/180.0 * earth_radius
+        y_step = float(atr['Y_STEP'])
+        x_step = float(atr['X_STEP'])
+        if 'UTM_ZONE' not in atr:
+            [lat0, lat1], [lon0, lon1] = coordinate(atr).yx2lalo([y0, y1], [x0, x1])
+            lat_c = (lat0 + lat1) / 2.
+            y_step *= np.pi/180.0 * earth_radius
+            x_step *= np.pi/180.0 * earth_radius * np.cos(lat_c * np.pi/180)
     else:
         try:
             x_step = range_ground_resolution(atr)

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -335,7 +335,8 @@ def latlon2utm(lat, lon):
                 northing - scalar or 1/2D np.ndarray, UTM    coordinates in y direction
     """
     import utm
-    return utm.from_latlon(lat, lon)[:2]
+    easting, northing = utm.from_latlon(lat, lon)[:2]
+    return northing, easting
 
 
 def snwe_to_wkt_polygon(snwe):

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -615,15 +615,17 @@ def plot_slice(ax, data, metadata, inps):
             # lat/lon
             msg = f'E={x:.{lalo_digit}f}, N={y:.{lalo_digit}f}'
             # value
-            col = coord.lalo2yx(x, coord_type='lon') - inps.pix_box[0]
-            row = coord.lalo2yx(y, coord_type='lat') - inps.pix_box[1]
+            row, col = coord.lalo2yx(y, x)
+            row -= inps.pix_box[1]
+            col -= inps.pix_box[0]
             if 0 <= col < num_col and 0 <= row < num_row:
                 v = data[row, col]
                 msg += ', v=[]' if np.isnan(v) or np.ma.is_masked(v) else f', v={v:.3f}'
                 # DEM
                 if inps.dem_file:
-                    dem_col = coord_dem.lalo2yx(x, coord_type='lon') - dem_pix_box[0]
-                    dem_row = coord_dem.lalo2yx(y, coord_type='lat') - dem_pix_box[1]
+                    dem_row, dem_col = coord_dem.lalo2yx(y, x)
+                    dem_row -= dem_pix_box[1]
+                    dem_col -= dem_pix_box[0]
                     if 0 <= dem_col < dem_wid and 0 <= dem_row < dem_len:
                         h = dem[dem_row, dem_col]
                         msg += ', h=[]' if np.isnan(h) else f', h={h:.1f}'


### PR DESCRIPTION
**Description of proposed changes**

HyP3 (and I believe NISAR as well) both output their InSAR products in UTM coordinates. While MintPy was originally designed to use lat/lon coordinates, has limited support for UTM datasets as well. Users have noted (i.e., issue #1145) that it would be nice to better support UTM datasets.

This PR adds some additional support for UTM datasets, in plotting and GPS comparison contexts by:
1. Ensuring UTM coordinate plot axes do not use scientific notation (see issue #1145)
2. Ensuring `coords.coordinate.latlon2yx` works with UTM coordinates
3. Ensuring `coords.coordinate.geo2rdr` works with UTM coordinates
4. Adding compatibility for UTM coordinates to GPS plotting functionality

To accomplish this, checks for the use of UTM coordinates were added to `latlon2yx` and `geo2rdr`. Also, the inputs for `latlon2yx` was changed from a coordinate and a coordinate type (lat or lon) to a pair of lat/lon or northing/easting coordinates. All uses of `latlon2yx` were changed to use this new input format.

**Reminders**

- [x] Fixes #1145
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
