### PR TITLE
`conncomp.plot_bridge()`: improve memory usage

### DIFF
--- a/src/mintpy/objects/conncomp.py
+++ b/src/mintpy/objects/conncomp.py
@@ -357,19 +357,20 @@ class connectComponent:
     def plot_bridge(self, ax, cmap='jet', radius=50):
         # label background
         ax.imshow(self.labelImg, cmap=cmap, interpolation='nearest')
-        # bridges
+
+        # plot bridges
         for bridge in self.bridges:
             ax.plot([bridge['x0'], bridge['x1']],
                     [bridge['y0'], bridge['y1']], 'w-', lw=1)
+
             # endpoint window
             if radius > 0:
                 aoi_mask0, aoi_mask1 = self.get_bridge_endpoint_aoi_mask(bridge, radius=radius)
-                label_mask0 = self.labelImg == bridge['label0']
-                label_mask1 = self.labelImg == bridge['label1']
-                mask0 = np.ma.masked_where(~(aoi_mask0*label_mask0), np.zeros(self.labelImg.shape))
-                mask1 = np.ma.masked_where(~(aoi_mask1*label_mask1), np.zeros(self.labelImg.shape))
-                ax.imshow(mask0, cmap='gray', alpha=0.3, vmin=0, vmax=1)
-                ax.imshow(mask1, cmap='gray', alpha=0.3, vmin=0, vmax=1)
+
+                # Overlay bridge regions directly using plot function
+                ax.plot(np.nonzero(aoi_mask0)[1], np.nonzero(aoi_mask0)[0], 'gray', alpha=0.3)
+                ax.plot(np.nonzero(aoi_mask1)[1], np.nonzero(aoi_mask1)[0], 'gray', alpha=0.3)
+
         # reference pixel
         ax.plot(self.refX, self.refY, 'ks', ms=2)
         return ax

--- a/src/mintpy/objects/conncomp.py
+++ b/src/mintpy/objects/conncomp.py
@@ -369,8 +369,8 @@ class connectComponent:
                 label_mask0 = self.labelImg == bridge['label0']
                 label_mask1 = self.labelImg == bridge['label1']
                 # Note by Emre, Mar 2024: overlay bridge regions directly using plot() function,
-                # instead of using np.ma.masked_where() with imshow(),
-                # to save memory while calling this func in a loop (https://github.com/insarlab/MintPy/pull/1155)
+                # to save memory while calling this func in a loop by avoiding creating separate
+                # mask arrays (https://github.com/insarlab/MintPy/pull/1155)
                 ax.plot(np.nonzero(aoi_mask0*label_mask0)[1], np.nonzero(aoi_mask0*label_mask0)[0], 'gray', alpha=0.3)
                 ax.plot(np.nonzero(aoi_mask1*label_mask1)[1], np.nonzero(aoi_mask1*label_mask1)[0], 'gray', alpha=0.3)
 

--- a/src/mintpy/objects/conncomp.py
+++ b/src/mintpy/objects/conncomp.py
@@ -355,11 +355,11 @@ class connectComponent:
 
 
     def plot_bridge(self, ax, cmap='jet', radius=50):
-        # label background
+        # background label
         ax.imshow(self.labelImg, cmap=cmap, interpolation='nearest')
 
-        # plot bridges
         for bridge in self.bridges:
+            # bridges
             ax.plot([bridge['x0'], bridge['x1']],
                     [bridge['y0'], bridge['y1']], 'w-', lw=1)
 
@@ -368,7 +368,9 @@ class connectComponent:
                 aoi_mask0, aoi_mask1 = self.get_bridge_endpoint_aoi_mask(bridge, radius=radius)
                 label_mask0 = self.labelImg == bridge['label0']
                 label_mask1 = self.labelImg == bridge['label1']
-                # Overlay bridge regions directly using plot function
+                # Note by Emre Mar 2024: overlay bridge regions directly using plot() function,
+                # instead of using np.ma.masked_where() with imshow(),
+                # to save memory while calling this func in a loop (https://github.com/insarlab/MintPy/pull/1155)
                 ax.plot(np.nonzero(aoi_mask0*label_mask0)[1], np.nonzero(aoi_mask0*label_mask0)[0], 'gray', alpha=0.3)
                 ax.plot(np.nonzero(aoi_mask1*label_mask1)[1], np.nonzero(aoi_mask1*label_mask1)[0], 'gray', alpha=0.3)
 

--- a/src/mintpy/objects/conncomp.py
+++ b/src/mintpy/objects/conncomp.py
@@ -366,10 +366,11 @@ class connectComponent:
             # endpoint window
             if radius > 0:
                 aoi_mask0, aoi_mask1 = self.get_bridge_endpoint_aoi_mask(bridge, radius=radius)
-
+                label_mask0 = self.labelImg == bridge['label0']
+                label_mask1 = self.labelImg == bridge['label1']
                 # Overlay bridge regions directly using plot function
-                ax.plot(np.nonzero(aoi_mask0)[1], np.nonzero(aoi_mask0)[0], 'gray', alpha=0.3)
-                ax.plot(np.nonzero(aoi_mask1)[1], np.nonzero(aoi_mask1)[0], 'gray', alpha=0.3)
+                ax.plot(np.nonzero(aoi_mask0*label_mask0)[1], np.nonzero(aoi_mask0*label_mask0)[0], 'gray', alpha=0.3)
+                ax.plot(np.nonzero(aoi_mask1*label_mask1)[1], np.nonzero(aoi_mask1*label_mask1)[0], 'gray', alpha=0.3)
 
         # reference pixel
         ax.plot(self.refX, self.refY, 'ks', ms=2)

--- a/src/mintpy/objects/conncomp.py
+++ b/src/mintpy/objects/conncomp.py
@@ -368,7 +368,7 @@ class connectComponent:
                 aoi_mask0, aoi_mask1 = self.get_bridge_endpoint_aoi_mask(bridge, radius=radius)
                 label_mask0 = self.labelImg == bridge['label0']
                 label_mask1 = self.labelImg == bridge['label1']
-                # Note by Emre Mar 2024: overlay bridge regions directly using plot() function,
+                # Note by Emre, Mar 2024: overlay bridge regions directly using plot() function,
                 # instead of using np.ma.masked_where() with imshow(),
                 # to save memory while calling this func in a loop (https://github.com/insarlab/MintPy/pull/1155)
                 ax.plot(np.nonzero(aoi_mask0*label_mask0)[1], np.nonzero(aoi_mask0*label_mask0)[0], 'gray', alpha=0.3)


### PR DESCRIPTION
This commit improves memory usage when plotting bridges. Current method creates separate mask arrays while plotting the bridges and the memory usage grows to hundreds of GBs when running tens of interferograms (`54 interferograms -> ~200GB`). This change brings memory usage down to `~8GB`.
