### PR TITLE
extend `--style scatter` to `tsview`

### DIFF
--- a/src/mintpy/cli/view.py
+++ b/src/mintpy/cli/view.py
@@ -80,12 +80,6 @@ def create_parser(subparsers=None):
                              '  reverse = x * -1\n'
                              '  inverse = 1 / x')
 
-    # plot data in different styles: image, scatter, contour etc.
-    parser.add_argument('--style', dest='style', choices={'image', 'scatter'}, default='image',
-                        help='Plot data as image or scatter (default: %(default)s).')
-    parser.add_argument('--scatter-size', dest='scatter_marker_size', type=float, metavar='SIZE', default=10,
-                        help='Scatter marker size in points**2 (default: %(default)s).')
-
     parser = arg_utils.add_data_disp_argument(parser)
     parser = arg_utils.add_dem_argument(parser)
     parser = arg_utils.add_figure_argument(parser)

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -60,17 +60,22 @@ def add_data_disp_argument(parser):
     data.add_argument('--nd','--no-data-val','--no-data-value', dest='no_data_value', type=float,
                       help='Specify the no-data-value to be ignored and masked.')
 
-    data.add_argument('--interp','--interpolation', dest='interpolation', default='nearest',
-                      help='matplotlib interpolation method for imshow, e.g.:\n'
-                           'none, antialiased, nearest, bilinear, bicubic, spline16, sinc, etc. Check more at:\n'
-                           'https://matplotlib.org/stable/gallery/images_contours_and_fields/'
-                           'interpolation_methods.html')
     data.add_argument('--wrap', action='store_true',
                       help='re-wrap data to display data in fringes.')
     data.add_argument('--wrap-range', dest='wrap_range', type=float, nargs=2,
                       default=[-1.*math.pi, math.pi], metavar=('MIN', 'MAX'),
                       help='range of one cycle after wrapping (default: %(default)s).')
 
+    data.add_argument('--interp','--interpolation', dest='interpolation', default='nearest',
+                      help='matplotlib interpolation method for imshow, e.g.:\n'
+                           'none, antialiased, nearest, bilinear, bicubic, spline16, sinc, etc. Check more at:\n'
+                           'https://matplotlib.org/stable/gallery/images_contours_and_fields/'
+                           'interpolation_methods.html')
+    data.add_argument('--alpha', dest='transparency', type=float,
+                      help='Data transparency. \n'
+                           '0.0 - fully transparent, 1.0 - no transparency.')
+
+    # flip X/Y-axis
     data.add_argument('--flip-lr', dest='flip_lr',
                       action='store_true', help='flip left-right')
     data.add_argument('--flip-ud', dest='flip_ud',
@@ -78,6 +83,7 @@ def add_data_disp_argument(parser):
     data.add_argument('--noflip', dest='auto_flip', action='store_false',
                       help='turn off auto flip for radar coordinate file')
 
+    # multilook / average for data reduction
     data.add_argument('--nmli','--num-multilook','--multilook-num', dest='multilook_num',
                       type=int, default=1, metavar='NUM',
                       help='multilook data in X and Y direction with a factor for display '
@@ -87,9 +93,13 @@ def add_data_disp_argument(parser):
                            'If multilook is True and multilook_num=1, '
                            'multilook_num will be estimated automatically.\n'
                            'Useful when displaying big datasets.')
-    data.add_argument('--alpha', dest='transparency', type=float,
-                      help='Data transparency. \n'
-                           '0.0 - fully transparent, 1.0 - no transparency.')
+
+    # plot data in different styles: image, scatter, contour etc.
+    parser.add_argument('--style', dest='style', choices={'image', 'scatter'}, default='image',
+                        help='Plot data as image or scatter (default: %(default)s).')
+    parser.add_argument('--scatter-size', dest='scatter_marker_size', type=float, metavar='SIZE', default=10,
+                        help='Scatter marker size in points**2 (default: %(default)s).')
+
     return parser
 
 

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -466,7 +466,7 @@ def plot_slice(ax, data, metadata, inps):
     Parameters: ax       : matplot.pyplot axes object
                 data     : 2D np.ndarray,
                 metadata : dictionary, attributes of data
-                inps     : Namespace, optional, input options for display
+                inps     : Namespace, input options for display
     Returns:    ax       : matplot.pyplot axes object
                 inps     : Namespace for input options
                 im       : matplotlib.image.AxesImage object


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes the following errors (as found out by @falkamelung) introduced in #1146, and extends the `--style scatter` capability to `tsview` as well.

```bash
tsview.py S1_IW12_087_0529_0530_20180902_20240104_N19421_N19519_W154945_W154827.he5
open HDFEOS file: S1_IW12_087_0529_0530_20180902_20240104_N19421_N19519_W154945_W154827.he5
data   coverage in y/x: (0, 0, 474, 390)
subset coverage in y/x: (0, 0, 474, 390)
data   coverage in lat/lon: (-154.94537646484375, 19.518744537353516, -154.82687646484374, 19.421244537353516)
subset coverage in lat/lon: (-154.94537646484375, 19.518744537353516, -154.82687646484374, 19.421244537353516)
------------------------------------------------------------------------
reference point in y/x: (115, 314)
reference point in lat/lon: (19.489869537353517, -154.86675146484376)
estimate deformation model with the following assumed time functions:
    polynomial : 1
    periodic   : []
    stepDate   : []
    polyline   : []
    exp        : {}
    log        : {}
reading timeseries from file S1_IW12_087_0529_0530_20180902_20240104_N19421_N19519_W154945_W154827.he5
reference to pixel: (115, 314)
reference to date: 20210206
read HDFEOS contained mask dataset.
data    range: [-15.96868, 17.101936] cm
display range: [-14.569724, 14.711732] cm
create figure for map in size of [6.0, 6.7]
display data in transparency: 1.0
plot in geo-coordinate
Traceback (most recent call last):
  File "/Users/famelung/code/rsmas_insar/tools/miniconda3/bin/tsview.py", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/famelung/code/rsmas_insar/tools/MintPy/src/mintpy/cli/tsview.py", line 176, in main
    obj.plot()
  File "/Users/famelung/code/rsmas_insar/tools/MintPy/src/mintpy/tsview.py", line 715, in plot
    self.plot_init_image(img_data)
  File "/Users/famelung/code/rsmas_insar/tools/MintPy/src/mintpy/tsview.py", line 846, in plot_init_image
    self.img, self.cbar_img = view.plot_slice(self.ax_img, img_data, self.atr, self)[2:4]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/famelung/code/rsmas_insar/tools/MintPy/src/mintpy/view.py", line 558, in plot_slice
    elif inps.style == 'image':
         ^^^^^^^^^^
AttributeError: 'timeseriesViewer' object has no attribute ‘style'
```

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2515/workflows/40a06ca2-4755-4f63-8402-e9a5f359fd0f/jobs/2522) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.