### PR TITLE
bugfix for `coord.lalo2yx()` when lat/lon have diff sizes

### DIFF
--- a/docs/api/attributes.md
+++ b/docs/api/attributes.md
@@ -52,7 +52,7 @@ The following attributes vary for each interferogram:
 +  MODIFICATION_TIME = dataset modification time, exists in ifgramStack.h5 file for 3D dataset, used for "--update" option of unwrap error corrections.
 +  NCORRLOOKS = number of independent looks, as explained in [SNAPHU](https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/snaphu.conf.full)
 +  UTM_ZONE = [UTM zone](https://docs.up42.com/data/reference/utm#utm-wgs84), comprises a zone number and a hemisphere, e.g. 11N, 60S, for geocoded file with UTM projection only.
-+  EPSG = EPSG code for coordinate systems, for geocoded files only. Check [here] for its relationship with UTM zone.
++  EPSG = EPSG code for coordinate systems, for geocoded files only. Check [here](https://docs.up42.com/data/reference/utm#utm-wgs84) for its relationship with UTM zone.
 +  CENTER_INCIDENCE_ANGLE = incidence angle in degrees at the scene center, read from the 2D incidence angle matrix, for isce2 files only.
 
 ### Reference ###

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -80,14 +80,15 @@ class coordinate:
         """Ensure input coordinate as list type and same size."""
 
         def _to_list(x):
-            # note: np.float128 is not supported on Windows OS,
-            # use np.longdouble as a platform neutral syntax
-            float_types = (float, np.float16, np.float32, np.float64, np.longdouble)
-            int_types = (int, np.int16, np.int32, np.int64)
-            # convert known types: numpy array, numbers and None
+            # convert numpy array to list or scalar
             if isinstance(x, np.ndarray):
                 x = x.tolist()
-            elif isinstance(x, int_types + float_types):
+            # convert scalar / None to list
+            # Note: np.float128 is not supported on Windows OS,
+            #   use np.longdouble as a platform neutral syntax
+            float_types = (float, np.float16, np.float32, np.float64, np.longdouble)
+            int_types = (int, np.int16, np.int32, np.int64)
+            if isinstance(x, int_types + float_types):
                 x = [x]
             elif x is None:
                 x = [None]

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -91,8 +91,7 @@ class coordinate:
                 x = [x]
             elif x is None:
                 x = [None]
-            else:
-                x = list(x)
+            x = list(x)
             return x
 
         # convert to list type

--- a/src/mintpy/subset.py
+++ b/src/mintpy/subset.py
@@ -184,14 +184,14 @@ def subset_input_dict2box(subset_dict, meta_dict):
     # Use subset_lat/lon input if existed,  priority: lat/lon > y/x > len/wid
     coord = ut.coordinate(meta_dict)
     if subset_dict.get('subset_lat', None):
-        sub_y = coord.lalo2yx(subset_dict['subset_lat'], 0)[0]
+        sub_y = coord.lalo2yx(subset_dict['subset_lat'], None)[0]
     elif subset_dict['subset_y']:
         sub_y = subset_dict['subset_y']
     else:
         sub_y = [0, length]
 
     if subset_dict.get('subset_lon', None):
-        sub_x = coord.lalo2yx(0, subset_dict['subset_lon'])[1]
+        sub_x = coord.lalo2yx(None, subset_dict['subset_lon'])[1]
     elif subset_dict['subset_x']:
         sub_x = subset_dict['subset_x']
     else:

--- a/src/mintpy/utils/arg_utils.py
+++ b/src/mintpy/utils/arg_utils.py
@@ -447,14 +447,14 @@ def add_save_argument(parser):
 def add_subset_argument(parser, geo=True):
     """Argument group parser for subset options"""
     sub = parser.add_argument_group('Subset', 'Display dataset in subset range')
-    sub.add_argument('--sub-x','--subx','--subset-x', dest='subset_x', type=int, nargs=2,
+    sub.add_argument('--sub-x','--subset-x', dest='subset_x', type=int, nargs=2,
                      metavar=('XMIN', 'XMAX'), help='subset display in x/cross-track/range direction')
-    sub.add_argument('--sub-y','--suby','--subset-y', dest='subset_y', type=int, nargs=2,
+    sub.add_argument('--sub-y','--subset-y', dest='subset_y', type=int, nargs=2,
                      metavar=('YMIN', 'YMAX'), help='subset display in y/along-track/azimuth direction')
     if geo:
-        sub.add_argument('--sub-lat','--sublat','--subset-lat', dest='subset_lat', type=float, nargs=2,
+        sub.add_argument('--sub-lat','--subset-lat', dest='subset_lat', type=float, nargs=2,
                          metavar=('LATMIN', 'LATMAX'), help='subset display in latitude')
-        sub.add_argument('--sub-lon','--sublon','--subset-lon', dest='subset_lon', type=float, nargs=2,
+        sub.add_argument('--sub-lon','--subset-lon', dest='subset_lon', type=float, nargs=2,
                          metavar=('LONMIN', 'LONMAX'), help='subset display in longitude')
     return parser
 

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -270,7 +270,9 @@ def touch(fname_list, times=None):
 def utm_zone2epsg_code(utm_zone):
     """Convert UTM Zone string to EPSG code.
 
-    Reference: https://docs.up42.com/data/reference/utm#utm-wgs84
+    Reference:
+        https://docs.up42.com/data/reference/utm#utm-wgs84
+        https://pyproj4.github.io/pyproj/stable/examples.html#initializing-crs
 
     Parameters: utm_zone  - str, atr['UTM_ZONE'], comprises a zone number
                             and a hemisphere, e.g. 11N, 36S, etc.
@@ -290,7 +292,9 @@ def utm_zone2epsg_code(utm_zone):
 def epsg_code2utm_zone(epsg_code):
     """Convert EPSG code to UTM Zone string.
 
-    Reference: https://docs.up42.com/data/reference/utm#utm-wgs84
+    Reference:
+        https://docs.up42.com/data/reference/utm#utm-wgs84
+        https://pyproj4.github.io/pyproj/stable/examples.html#initializing-crs
 
     Parameters: epsg_code - str / int, EPSG code
     Returns:    utm_zone  - str, atr['UTM_ZONE'], comprises a zone number
@@ -299,9 +303,6 @@ def epsg_code2utm_zone(epsg_code):
     Examples:   utm_zone = epsg_code2utm_zone('32736')
     """
     from pyproj import CRS
-
-    # link: https://pyproj4.github.io/pyproj/stable/examples.html#initializing-crs
-    # alternatively, use CRS.from_user_input(epsg_code) or CRS.from_string(f'EPSG:{epsg_code}')
     crs = CRS.from_epsg(epsg_code)
     utm_zone = crs.utm_zone
     if not utm_zone:


### PR DESCRIPTION
**Description of proposed changes**

+ `objects.coord.coordinate`:
   - `_clean_coord()`: 1) take two arg instead of one, and ensure the two coords have the same size, following the changes in https://github.com/insarlab/MintPy/pull/1153; 2) support `None` as input
   - `lalo2yx/yx2lalo()`: support `None` as inputs

+ `subset.subset_input_dict2box()`: use `None` as input to convert one type of coord only.

+ `utils.arg_utils.add_subset_argument()`: remove the unused option name alias (`--suby/x/lat/lon`), as they are not very readable and not frequently used.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2541/workflows/36cd45a2-5464-45f6-ae14-46aa78a2d4bb/jobs/2548) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.