### PR TITLE
`utils0.latlon2utm()`: ensure a single output UTM zone

### DIFF
--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -132,7 +132,7 @@ class coordinate:
                 and 'UTM_ZONE' in self.src_metadata
                 and np.max(np.abs(lat_in)) <= 90
                 and np.max(np.abs(lon_in)) <= 360):
-            lat_in, lon_in = ut0.latlon2utm(np.array(lat_in), np.array(lon_in))
+            lat_in, lon_in = ut0.latlon2utm(self.src_metadata, np.array(lat_in), np.array(lon_in))
 
         # convert coordinates
         y_out = []
@@ -292,7 +292,7 @@ class coordinate:
         if ('UTM_ZONE' in self.src_metadata
                 and np.max(np.abs(lat)) <= 90
                 and np.max(np.abs(lon)) <= 360):
-            lat, lon = ut0.latlon2utm(np.array(lat), np.array(lon))
+            lat, lon = ut0.latlon2utm(self.src_metadata, np.array(lat), np.array(lon))
 
         self.open()
         if self.geocoded:

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1144,7 +1144,7 @@ def plot_gps(ax, SNWE, inps, metadata=dict(), print_msg=True):
 
     # post-query: convert lat/lon to UTM for plotting
     if 'UTM_ZONE' in metadata.keys():
-        site_lats, site_lons = ut0.latlon2utm(site_lats, site_lons)
+        site_lats, site_lons = ut0.latlon2utm(metadata, site_lats, site_lons)
 
     # mask out stations not coincident with InSAR data
     if inps.mask_gps and inps.msk is not None:

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -368,16 +368,22 @@ def utm2latlon(meta, easting, northing):
     return lat, lon
 
 
-def latlon2utm(lat, lon):
+def latlon2utm(meta, lat, lon):
     """Convert latitude/longitude in degrees to UTM easting/northing in meters.
 
-    Parameters: lat      - scalar/list/tuple/1-2D np.ndarray, WGS 84 coordinates in y direction
+    Parameters: meta     - dict, mintpy attributes that includes:
+                           UTM_ZONE
+                lat      - scalar/list/tuple/1-2D np.ndarray, WGS 84 coordinates in y direction
                 lon      - scalar/list/tuple/1-2D np.ndarray, WGS 84 coordinates in x direction
     Returns:    easting  - scalar/list/tuple/1-2D np.ndarray, UTM    coordinates in x direction
                 northing - scalar/list/tuple/1-2D np.ndarray, UTM    coordinates in y direction
     """
     import utm
-    easting, northing = utm.from_latlon(np.array(lat), np.array(lon))[:2]
+
+    # invoke zone_num to ensure all coordinates are converted into the same single UTM zone,
+    # even if they cross a UTM boundary.
+    zone_num = int(meta['UTM_ZONE'][:-1])
+    easting, northing = utm.from_latlon(np.array(lat), np.array(lon), force_zone_number=zone_num)[:2]
 
     # output format
     if any(isinstance(x, (list, tuple)) for x in [lat, lon]):


### PR DESCRIPTION
**Description of proposed changes**

+ utils.utils0.latlon2utm(): add `meta` in as required argument to invoke `force_zone_number` while calling `utm.from_latlon()`, to ensure all coordiantes are converted into the same single UTM zone, as designated in the UTM_ZONE metadata, even if they cross a UTM boundary.

+ adjust the `latlon2utm()` usage in all scripts:
   - objects.coord.py
   - utils.plot.py

**Reminders**

- [x] Fix #1176 
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2593) test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.