### PR TITLE
bugfix for `view.py numInvIfgram.py` for `hyp3` products

### DIFF
--- a/src/mintpy/ifgram_inversion.py
+++ b/src/mintpy/ifgram_inversion.py
@@ -1060,6 +1060,11 @@ def run_ifgram_inversion(inps):
     # 2.4 instantiate number of inverted observations
     meta['FILE_TYPE'] = 'mask'
     meta['UNIT'] = '1'
+    # ignore NO_DATA_VALUE from ifgram stack file here as 1) it makes sense
+    # and 2) to avoid the weird error at https://github.com/insarlab/MintPy/issues/1185
+    if 'NO_DATA_VALUE' in meta.keys():
+        meta.pop('NO_DATA_VALUE')
+
     ds_name_dict = {"mask" : [np.float32, (length, width)]}
     writefile.layout_hdf5(inps.numInvFile, ds_name_dict, metadata=meta)
 

--- a/tests/configs/RidgecrestSenDT71.txt
+++ b/tests/configs/RidgecrestSenDT71.txt
@@ -21,5 +21,4 @@ mintpy.topographicResidual.stepDate             = 20190706T0320
 mintpy.topographicResidual.pixelwiseGeometry    = no
 mintpy.save.hdfEos5                             = yes
 mintpy.save.hdfEos5.subset                      = yes
-mintpy.plot                                     = no
 mintpy.plot.maxMemory                           = 2


### PR DESCRIPTION
**Description of proposed changes**

+ `ifgram_inversion`: ignore the `NO_DATA_VALUE` metadata from the `hyp3` ifgram stack file, while creating the # of inverted ifgram file, because 1) the zero value is valid (not no-data-value), and 2) to avoid the strange plotting error from `matplotlib`. The detailed reason seems to be within `matplotlib`, not within `mintpy` code itself.

+ `tests/configs/RidgecrestSenDT71`: turn back ON the plotting during testing.

**Reminders**

- [x] Fix #1185
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2614)  and local tests (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.