### PR TITLE
pyproject.toml: fix path of the readme file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ include-package-data = true
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
-readme = { file = ["README.md"], content-type = "text/markdown" }
+readme = { file = ["docs/README.md"], content-type = "text/markdown" }
 
 # extra requirements: `pip install pysolid[test]` or `pip install .[test]`
 [tool.setuptools.dynamic.optional-dependencies.test]


### PR DESCRIPTION
**Description of proposed changes**

+ pyproject.toml: fix path of the readme file, as the 2nd attempt to fix the "Not finding README.md specified in pyprojet.toml" error on PyPI website, as suggested by @scottstanie in https://github.com/insarlab/MintPy/pull/1197.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2636/workflows/74b1d404-309b-4540-9598-57481daeb6c4/jobs/2642) test (green)