### PR TITLE
`readfile`: support `Gamma` SLC in complex32 format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,30 +53,35 @@ jobs:
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
+            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 2/4 - SanFranSenDT42 (ARIA)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
+            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 3/5 - RidgecrestSenDT71 (HyP3)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset RidgecrestSenDT71
+            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 4/5 - WellsEnvD2T399 (Gamma)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
+            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 5/5 - WCapeSenAT29 (SNAP)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29
+            rm -r ${HOME}/data
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,35 +53,30 @@ jobs:
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
-            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 2/4 - SanFranSenDT42 (ARIA)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
-            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 3/5 - RidgecrestSenDT71 (HyP3)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset RidgecrestSenDT71
-            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 4/5 - WellsEnvD2T399 (Gamma)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
-            rm -r ${HOME}/data
 
       - run:
           name: Integration Test 5/5 - WCapeSenAT29 (SNAP)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29
-            rm -r ${HOME}/data
 
 workflows:
   version: 2

--- a/src/mintpy/cli/prep_isce.py
+++ b/src/mintpy/cli/prep_isce.py
@@ -50,7 +50,7 @@ def create_parser(subparsers=None):
         name, synopsis=synopsis, description=synopsis, epilog=epilog, subparsers=subparsers)
 
     # observations
-    parser.add_argument('-f', dest='obs_files', type=str, nargs='+', default='./merged/interferograms/*/filt_*.unw',
+    parser.add_argument('-f', dest='obs_files', type=str, nargs='+', default=['./merged/interferograms/*/filt_*.unw'],
                         help='Wildcard path pattern for the primary observation files.\n'
                              'E.g.: topsStack          : {dset_dir}/merged/interferograms/*/filt_*.unw\n'
                              '      topsStack / iono   : {dset_dir}/ion/*/ion_cal/filt.ion\n'

--- a/src/mintpy/load_data.py
+++ b/src/mintpy/load_data.py
@@ -756,10 +756,7 @@ def prepare_metadata(iDict):
 
         ## run
         ut.print_command_line(script_name, iargs)
-        try:
-            prep_module.main(iargs)
-        except:
-            warnings.warn('prep_aria.py failed. Assuming its result exists and continue...')
+        prep_module.main(iargs)
 
     elif processor == 'gmtsar':
         # use the custom template file if exists & input

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -1652,10 +1652,10 @@ class viewer():
             no_data_val = readfile.get_no_data_value(self.file)
             if self.no_data_value is not None:
                 vprint(f'masking pixels with NO_DATA_VALUE of {self.no_data_value}')
-                data = np.ma.masked_where(data == self.no_data_value, data)
+                data[data == self.no_data_value] = np.nan
             elif no_data_val is not None and not np.isnan(no_data_val):
                 vprint(f'masking pixels with NO_DATA_VALUE of {no_data_val}')
-                data = np.ma.masked_where(data == no_data_val, data)
+                data[data == no_data_val] = np.nan
 
             # update/save mask info
             if np.ma.is_masked(data):


### PR DESCRIPTION
**Description of proposed changes**

+ utils.readfile: support Gamma slc in complex32 format
   - add scomplex to complex32 data type conversion
   - read_binary_file(): support .rslc/rmli file extension
   - read_complex_int16(): refactor to use cpx_band in str for a more flexible output data; revise the output from 2 matrices into 1 matrix
   - read_binary(): support complex32 while calling read_complex_int16(), since it's not supported in numpy.

+ utils.readfile.auto_no_data_value(): add geometrical offset files from alos2App with num of band = 1

+ view.viewer.plot(): set pixels with no data value to np.nan, instead of call np.ma.masked_where(), which seems over-complicated (compared with setting to nan) and I could not recall the reason anymore.

+ cli/prep_isce.py: set -f default from str to list, to be consistent with the non-default var type.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [ ] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2649) test (green)
- [x] Pass local test
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.