### PR TITLE
`ionex`: migrate from `interp2d` to `RegularGridInterpolator`

### DIFF
--- a/src/mintpy/objects/ionex.py
+++ b/src/mintpy/objects/ionex.py
@@ -16,7 +16,7 @@ import os
 import re
 
 import numpy as np
-from scipy import interpolate
+from scipy.interpolate import RegularGridInterpolator, interpn
 
 from mintpy.utils import ptime
 
@@ -139,8 +139,8 @@ def interp_3d_maps(tec_maps, mins, lats, lons, utc_min, lat, lon, interp_method=
         ind1 = ind0 + 1
         lon0 = lon + (utc_min - mins[ind0]) * 360. / (24. * 60.)
         lon1 = lon + (utc_min - mins[ind1]) * 360. / (24. * 60.)
-        tec_val0 = interpfs[ind0](lon0, lat)
-        tec_val1 = interpfs[ind1](lon1, lat)
+        tec_val0 = interpfs[ind0]((lon0, lat))
+        tec_val1 = interpfs[ind1]((lon1, lat))
         tec_val = (  (mins[ind1] - utc_min) / (mins[ind1] - mins[ind0]) * tec_val0
                    + (utc_min - mins[ind0]) / (mins[ind1] - mins[ind0]) * tec_val1 )
         return tec_val
@@ -160,28 +160,26 @@ def interp_3d_maps(tec_maps, mins, lats, lons, utc_min, lat, lon, interp_method=
             tec_val = np.zeros(num_pts, dtype=np.float32)
             prog_bar = ptime.progressBar(maxValue=num_pts, print_msg=print_msg)
             for i in range(num_pts):
-                tec_val[i] = interpolate.interp2d(
-                    x=lons,
-                    y=lats,
-                    z=tec_maps[time_ind[i], :, :],
-                    kind='linear',
-                )(lon[i], lat[i])
+                tec_val[i] = RegularGridInterpolator(
+                    points=(lons, lats),
+                    values=tec_maps[time_ind[i], :, :].T,
+                    method='linear',
+                )((lon[i], lat[i]))
 
                 prog_bar.update(i+1, every=200)
             prog_bar.close()
 
         else:
-            tec_val = interpolate.interp2d(
-                x=lons,
-                y=lats,
-                z=tec_maps[time_ind[0], :, :],
-                kind='linear',
-            )(lon, lat)
+            tec_val = RegularGridInterpolator(
+                points=(lons, lats),
+                values=tec_maps[time_ind[0], :, :].T,
+                method='linear',
+            )((lon, lat))
 
     elif interp_method in ['linear3d', 'trilinear']:
         if not rotate_tec_map:
             # option 1: interpolate between consecutive TEC maps
-            tec_val = interpolate.interpn(
+            tec_val = interpn(
                 points=(mins, np.flip(lats), lons),
                 values=np.flip(tec_maps, axis=1),
                 xi=(utc_min, lat, lon),
@@ -196,14 +194,14 @@ def interp_3d_maps(tec_maps, mins, lats, lons, utc_min, lat, lon, interp_method=
             interpfs = []
             for i in range(len(mins)):
                 interpfs.append(
-                    interpolate.interp2d(
-                        x=lons,
-                        y=lats,
-                        z=tec_maps[i, :, :],
-                        kind='linear',
+                    RegularGridInterpolator(
+                        points=(lons, lats),
+                        values=tec_maps[i, :, :].T,
+                        method='linear',
                     ),
                 )
 
+            # interpolate
             if isinstance(utc_min, np.ndarray):
                 num_pts = len(utc_min)
                 tec_val = np.zeros(num_pts, dtype=np.float32)
@@ -222,7 +220,7 @@ def interp_3d_maps(tec_maps, mins, lats, lons, utc_min, lat, lon, interp_method=
                     interpfs,
                     mins, lats, lons,
                     utc_min, lat, lon,
-                )[0]
+                )
 
     else:
         msg = f'Un-recognized interp_method input: {interp_method}!'

--- a/tests/objects/ionex.py
+++ b/tests/objects/ionex.py
@@ -47,6 +47,7 @@ def prep_test_data(prep_mode=True):
 def test_read_ionex():
     """Test mintpy.objects.ionex.read_ionex()"""
 
+    print('Test 1: read GIM files via ionex.read_ionex()')
     time_ind = 1
     x0, x1, y0, y1 = 3, 9, 28, 33
     tec_aoi = np.array(
@@ -69,11 +70,13 @@ def test_read_ionex():
 
     # compare
     assert np.allclose(tec_maps[time_ind, y0:y1, x0:x1], tec_aoi)
+    print('Pass.')
 
 
 def test_get_ionex_value():
     """Test mintpy.objects.ionex.get_ionex_value()"""
 
+    print('Test 2: Get the ionex for a given location/time via ionex.get_ionex_value()')
     lat, lon = -21.3, -67.4         # northern Chile
     utc_sec = 23 * 3600 + 7 * 60    # 23:07 UTC
 
@@ -96,6 +99,7 @@ def test_get_ionex_value():
             rotate_tec_map=rotate,
         )
         assert np.allclose(tec_val, value, atol=1e-05, rtol=1e-05)
+        print(f'Interpolation method ({method:8s}) with rotation ({str(rotate):5s}): Pass.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of proposed changes**

+ objects.ionex.get_ionex_value(): migrate from scipy.interpolate.interp2d() to scipy.interpolate.RegularGridInterpolator(), as the former has been removed since scipy-1.14

+ tests.objects.ionex.py: more print out msg

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2664/workflows/1d826fba-541e-4470-9697-e36095011a73/jobs/2671) unit test (the circleci integration test is failing due to the known gdal issue https://github.com/insarlab/MintPy/issues/1220)
- [x] Pass local integration test
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.