### PR TITLE
bugfix for numpy 2.0

### DIFF
--- a/src/mintpy/closure_phase_bias.py
+++ b/src/mintpy/closure_phase_bias.py
@@ -216,7 +216,7 @@ def cum_seq_unw_closure_phase_timeseries(conn, conn_dir, date_list, meta):
     # write bias time series to HDF5 file
     ds_dict = {
         'timeseries' : [np.float32,     (num_date, length, width), bias_ts],
-        'date'       : [np.dtype('S8'), (num_date,), np.array(date_list, np.string_)],
+        'date'       : [np.dtype('S8'), (num_date,), np.array(date_list, np.bytes_)],
     }
     meta['FILE_TYPE'] = 'timeseries'
     writefile.layout_hdf5(cum_cp_file, ds_dict, metadata=meta)
@@ -634,7 +634,7 @@ def estimate_bias_timeseries_approx(stack_file, bias_free_conn, bw, water_mask_f
     meta['UNIT'] = 'm'
     ds_name_dict = {
         'timeseries' : [np.float32,     (num_date, length, width), None],
-        'date'       : [np.dtype('S8'), (num_date,),  np.array(date_list, np.string_)],
+        'date'       : [np.dtype('S8'), (num_date,),  np.array(date_list, np.bytes_)],
     }
     writefile.layout_hdf5(bias_ts_file, ds_name_dict, meta)
 
@@ -949,7 +949,7 @@ def estimate_bias_timeseries(stack_file, bias_free_conn, bw, cluster_kwargs, wat
     bias_ts_file = os.path.join(outdir, 'timeseriesBias.h5')
     ds_name_dict = {
         'timeseries' : [np.float32,     (num_date, length, width), None],
-        'date'       : [np.dtype('S8'), (num_date,),  np.array(date_list, np.string_)],
+        'date'       : [np.dtype('S8'), (num_date,),  np.array(date_list, np.bytes_)],
     }
     meta['FILE_TYPE'] = 'timeseries'
     meta['DATA_TYPE'] = 'float32'

--- a/src/mintpy/ifgram_inversion.py
+++ b/src/mintpy/ifgram_inversion.py
@@ -1027,7 +1027,7 @@ def run_ifgram_inversion(inps):
     meta['REF_DATE'] = date_list[0]
 
     # 2.2 instantiate time-series
-    dates = np.array(date_list, dtype=np.string_)
+    dates = np.array(date_list, dtype=np.bytes_)
     pbase = stack_obj.get_perp_baseline_timeseries(dropIfgram=True)
     ds_name_dict = {
         "date"       : [dates.dtype, (num_date,), dates],

--- a/src/mintpy/iono_tec.py
+++ b/src/mintpy/iono_tec.py
@@ -262,7 +262,7 @@ def vtec2iono_ramp_timeseries(date_list, vtec_list, geom_file, iono_file, sub_te
 
     # prepare data matrix
     ds_dict = {}
-    ds_dict['date'] = np.array(date_list, dtype=np.string_)
+    ds_dict['date'] = np.array(date_list, dtype=np.bytes_)
     ds_dict['vtec'] = np.array(vtec_list, dtype=np.float32)
     ds_dict['timeseries'] = ts_ramp
 

--- a/src/mintpy/legacy/2to3_timeseries.py
+++ b/src/mintpy/legacy/2to3_timeseries.py
@@ -55,7 +55,7 @@ def run_2to3_timeseries(py2_file, py3_file):
         prog_bar.close()
 
     # prepare metadata
-    dates = np.array(date_list, np.string_)
+    dates = np.array(date_list, np.bytes_)
     atr['REF_DATE'] = date_list[0]
     if 'P_BASELINE_TIMESERIES' in atr.keys():
         bperp = np.array([float(i) for i in atr['P_BASELINE_TIMESERIES'].split()], dtype=np.float32)

--- a/src/mintpy/legacy/load2hdf5.py
+++ b/src/mintpy/legacy/load2hdf5.py
@@ -110,7 +110,7 @@ def main(iargs=None):
         # add "date" dataset for timeseries
         if inps.dset_name and inps.dset_name == 'timeseries':
             date_list = [os.path.basename(os.path.dirname(x)) for x in inps.file]
-            dsDict['date'] = np.array(date_list, dtype=np.string_)
+            dsDict['date'] = np.array(date_list, dtype=np.bytes_)
 
     # metadata
     if inps.metadata:

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -331,7 +331,7 @@ class timeseries:
                     compression = rf[TIMESERIES_DSET_NAMES[0]].compression
             refobj.close(print_msg=False)
         data = np.array(data, dtype=np.float32)
-        dates = np.array(dates, dtype=np.string_)
+        dates = np.array(dates, dtype=np.bytes_)
         bperp = np.array(bperp, dtype=np.float32)
         metadata = dict(metadata)
         metadata['FILE_TYPE'] = self.name

--- a/src/mintpy/objects/stackDict.py
+++ b/src/mintpy/objects/stackDict.py
@@ -220,7 +220,7 @@ class ifgramStackDict:
             ###############################
             # 2D dataset containing reference and secondary dates of all pairs
             dsName = 'date'
-            dsDataType = np.string_
+            dsDataType = np.bytes_
             dsShape = (numIfgram, 2)
             print('create dataset /{d:<{w}} of {t:<25} in size of {s}'.format(d=dsName,
                                                                               w=maxDigit,
@@ -672,7 +672,7 @@ class geometryDict:
                     # Write 1D dataset date accompnay the 3D bperp
                     dsName = 'date'
                     dsShape = (self.numDate,)
-                    dsDataType = np.string_
+                    dsDataType = np.bytes_
                     print(('create dataset /{d:<{w}} of {t:<25}'
                            ' in size of {s}').format(d=dsName,
                                                      w=maxDigit,

--- a/src/mintpy/prep_fringe.py
+++ b/src/mintpy/prep_fringe.py
@@ -148,7 +148,7 @@ def prepare_timeseries(outfile, unw_file, metadata, processor, baseline_dir=None
     )
 
     # define dataset structure
-    dates = np.array(date_list, dtype=np.string_)
+    dates = np.array(date_list, dtype=np.bytes_)
     ds_name_dict = {
         "date"       : [dates.dtype, (num_date,), dates],
         "bperp"      : [np.float32,  (num_date,), pbase],
@@ -316,7 +316,7 @@ def prepare_stack(outfile, unw_file, metadata, processor, baseline_dir=None, box
     )
 
     # define (and fill out some) dataset structure
-    date12_arr = np.array([x.split('_') for x in date12_list], dtype=np.string_)
+    date12_arr = np.array([x.split('_') for x in date12_list], dtype=np.bytes_)
     drop_ifgram = np.ones(num_pair, dtype=np.bool_)
     ds_name_dict = {
         "date"             : [date12_arr.dtype, (num_pair, 2), date12_arr],

--- a/src/mintpy/prep_nisar.py
+++ b/src/mintpy/prep_nisar.py
@@ -409,7 +409,7 @@ def prepare_stack(
     cols, rows = meta['WIDTH'], meta['LENGTH']
 
     # define (and fill out some) dataset structure
-    date12_arr = np.array([x.split("_") for x in date12_list], dtype=np.string_)
+    date12_arr = np.array([x.split("_") for x in date12_list], dtype=np.bytes_)
     drop_ifgram = np.ones(num_pair, dtype=np.bool_)
     ds_name_dict = {
         "date": [date12_arr.dtype, (num_pair, 2), date12_arr],

--- a/src/mintpy/save_hdfeos5.py
+++ b/src/mintpy/save_hdfeos5.py
@@ -339,7 +339,7 @@ def write_hdf5_file(metadata, out_file, ts_file, tcoh_file, scoh_file, mask_file
 
         ## O2 - date
         dsName = 'date'
-        data = np.array(dateList, dtype=np.string_)
+        data = np.array(dateList, dtype=np.bytes_)
         dset = create_hdf5_dataset(group, dsName, data)
 
         ## O3 - perp baseline

--- a/src/mintpy/solid_earth_tides.py
+++ b/src/mintpy/solid_earth_tides.py
@@ -210,9 +210,9 @@ def calc_solid_earth_tides_timeseries(ts_file, geom_file, set_comp='enu2los',
         # dataset
         ds_dict = {
             'timeseries' : ts_set,
-            'date'       : np.array(date_list, dtype=np.string_),
+            'date'       : np.array(date_list, dtype=np.bytes_),
             'sensingMid' : np.array([i.strftime('%Y%m%dT%H%M%S') for i in dt_objs],
-                                    dtype=np.string_),
+                                    dtype=np.bytes_),
         }
 
         # write

--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -194,7 +194,7 @@ def run_timeseries2time_func(inps):
         # prepare ds_name_dict manually, instead of using ref_file, to support --ex option
         date_digit = len(inps.date_list[0])
         ds_name_dict = {
-            "date" : [np.dtype(f'S{date_digit}'), (num_date,), np.array(inps.date_list, np.string_)],
+            "date" : [np.dtype(f'S{date_digit}'), (num_date,), np.array(inps.date_list, np.bytes_)],
             "timeseries" : [np.float32, (num_date, length, width), None]
         }
         writefile.layout_hdf5(inps.res_file, ds_name_dict=ds_name_dict, metadata=atrR)

--- a/src/mintpy/tropo_gacos.py
+++ b/src/mintpy/tropo_gacos.py
@@ -189,7 +189,7 @@ def calculate_delay_timeseries(tropo_file, dis_file, geom_file, gacos_dir):
     # instantiate time-series
     length, width = int(atr['LENGTH']), int(atr['WIDTH'])
     num_date = len(date_list)
-    dates = np.array(date_list, dtype=np.string_)
+    dates = np.array(date_list, dtype=np.bytes_)
     ds_name_dict = {
         "date"       : [dates.dtype, (num_date,), dates],
         "timeseries" : [np.float32,  (num_date, length, width), None],

--- a/src/mintpy/tropo_pyaps3.py
+++ b/src/mintpy/tropo_pyaps3.py
@@ -655,7 +655,7 @@ def calc_delay_timeseries(inps):
     length, width = int(atr['LENGTH']), int(atr['WIDTH'])
     num_date = len(inps.grib_files)
     date_list = [str(re.findall(r'\d{8}', os.path.basename(i))[0]) for i in inps.grib_files]
-    dates = np.array(date_list, dtype=np.string_)
+    dates = np.array(date_list, dtype=np.bytes_)
     ds_name_dict = {
         "date"       : [dates.dtype, (num_date,), dates],
         "timeseries" : [np.float32,  (num_date, length, width), None],

--- a/src/mintpy/utils/time_func.py
+++ b/src/mintpy/utils/time_func.py
@@ -8,6 +8,7 @@
 #   from mintpy.utils import time_func
 
 
+import math
 import numpy as np
 from scipy import linalg
 
@@ -305,7 +306,7 @@ def get_design_matrix4polynomial_func(yr_diff, degree):
     """
     A = np.zeros([len(yr_diff), degree + 1], dtype=np.float32)
     for i in range(degree+1):
-        A[:,i] = (yr_diff**i) / np.math.factorial(i)
+        A[:,i] = (yr_diff**i) / math.factorial(i)
 
     return A
 

--- a/src/mintpy/utils/time_func.py
+++ b/src/mintpy/utils/time_func.py
@@ -9,6 +9,7 @@
 
 
 import math
+
 import numpy as np
 from scipy import linalg
 

--- a/src/mintpy/utils/writefile.py
+++ b/src/mintpy/utils/writefile.py
@@ -268,7 +268,7 @@ def layout_hdf5(fname, ds_name_dict=None, metadata=None, ds_unit_dict=None, ref_
     }
 
     # structure for timeseries
-    dates = np.array(date_list, np.string_)
+    dates = np.array(date_list, np.bytes_)
     ds_name_dict = {
         "date"       : [np.dtype("S8"), (num_date,), dates],
         "bperp"      : [np.float32,     (num_date,), pbase],


### PR DESCRIPTION
**Description of proposed changes**

+ remove all occurrences of `np.string_` with `np.bytes_`, as the former has been removed in [numpy 2.0](https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals)

+ `utils.time_func.get_design_matrix4polynomial_func()`: swtich from `np.math.factorial()` to math.factorial(), as the former is removed from numpy 2.0

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Pass local test
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
