### PR TITLE
demo/test: add SanFranBaySenD42 for `GMTSAR`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,31 +49,37 @@ jobs:
             ${MINTPY_HOME}/tests/dem_error.py
 
       - run:
-          name: Integration Test 1/4 - FernandinaSenDT128 (ISCE/topsStack)
+          name: Integration Test 1 - FernandinaSenDT128 (ISCE2/topsStack)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
 
       - run:
-          name: Integration Test 2/4 - SanFranSenDT42 (ARIA)
+          name: Integration Test 2 - SanFranSenDT42 (ARIA)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
 
       - run:
-          name: Integration Test 3/5 - RidgecrestSenDT71 (HyP3)
+          name: Integration Test 3 - RidgecrestSenDT71 (ASF HyP3)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset RidgecrestSenDT71
 
       - run:
-          name: Integration Test 4/5 - WellsEnvD2T399 (Gamma)
+          name: Integration Test 4 - SanFranBaySenD42 (GMTSAR)
+          command: |
+            mkdir -p ${HOME}/data
+            ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranBaySenD42
+
+      - run:
+          name: Integration Test 5 - WellsEnvD2T399 (Gamma)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
 
       - run:
-          name: Integration Test 5/5 - WCapeSenAT29 (SNAP)
+          name: Integration Test 6 - WCapeSenAT29 (SNAP)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
           command: |
             export PYTHONUNBUFFERED=1
             # install dependencies and source code
-            mamba install --verbose --yes gdal">=3" --file ${MINTPY_HOME}/requirements.txt
+            # pin gdal version because gdal-3.9 could not read the GMT-6 *.grd file properly
+            mamba install --verbose --yes --file ${MINTPY_HOME}/requirements.txt gdal"<3.9"
             python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -h

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/FernandinaSenDT128.txt
 ```
 
 <p align="left">
-  <img width="600" src="https://yunjunzhang.files.wordpress.com/2019/06/fernandinasendt128_poi.jpg">
+  <img width="600" src="https://github.com/insarlab/design-docs/blob/main/docs/FernandinaSenDT128-ISCE2.jpg">
 </p>
 
 Results are plotted in **./pic** folder. To explore more data information and visualization, try the following scripts:

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -74,7 +74,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranBaySenD42.txt
 
 Relevant literature:
 
-+ Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San
++ Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct connection between the Hayward and Calaveras Faults, _Geophysical Research Letters,_ 42(8), 2734-2741, doi:10.1002/2015GL063575.
 
 ### Envisat of the 2008 Wells, Nevada earthquake with Gamma ###
 
@@ -95,7 +95,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/WellsEnvD2T399.txt
 
 Relevant literature:
 
-+ Nealy, J. L., H. M. Benz, G. P. Hayes, E. A. Bergman, and W. D. Barnhart (2017), The 2008 Wells, Nevada, Earthquake Sequence: Source Constraints Using C
++ Nealy, J. L., H. M. Benz, G. P. Hayes, E. A. Bergman, and W. D. Barnhart (2017), The 2008 Wells, Nevada, Earthquake Sequence: Source Constraints Using Calibrated Multiple‐Event Relocation and InSAR, _Bulletin of the Seismological Society of America_, 107(3), 1107-1117, doi:10.1785/0120160298.
 
 ### Sentinel-1 on Western Cape, South Africa with SNAP ###
 

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -1,6 +1,6 @@
 Here are example interferogram stacks pre-processed using different InSAR processors.
 
-### Sentinel-1 on Fernandina with ISCE ###
+### Sentinel-1 on Fernandina with ISCE2/topsStack ###
 
 + Area: Fernandina volcano at Galápagos Islands, Ecuador
 + Data: Sentinel-1 A/B descending track 128 during Dec 2014 - June 2018 (98 acquisitions; [Zenodo](https://zenodo.org/record/3952953))
@@ -14,7 +14,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/FernandinaSenDT128.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://yunjunzhang.files.wordpress.com/2019/06/fernandinasendt128_poi.jpg">
+  <img width="650" src="https://github.com/insarlab/design-docs/blob/main/docs/FernandinaSenDT128-ISCE2.jpg">
 </p>
 
 Relevant literature:
@@ -35,12 +35,46 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranSenDT42.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://yunjunzhang.files.wordpress.com/2020/11/sanfransendt42_transect.jpg">
+  <img width="650" src="https://github.com/insarlab/design-docs/blob/main/docs/SanFranSenDT42-ARIA.jpg">
 </p>
 
 Relevant literature:
 
 + Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct connection between the Hayward and Calaveras Faults, _Geophysical Research Letters,_ 42(8), 2734-2741, doi:10.1002/2015GL063575.
+
+### Sentinel-1 of the 2019 Ridgecrest, California earthquake sequence with ASF HyP3 ###
+
++ Area: Owens Valley, California, USA ([USGS event page](https://earthquake.usgs.gov/earthquakes/eventpage/ci38457511/executive))
++ Data: Sentinel-1 descending track 71 during June - August 2019 (7 acquisitions; [Zenodo](https://zenodo.org/record/11049257))
++ Size: ~240 MB
+
+```bash
+wget https://zenodo.org/record/11049257/files/RidgecrestSenDT71.tar.xz
+tar -xvJf RidgecrestSenDT71.tar.xz
+cd RidgecrestSenDT71
+smallbaselineApp.py ${MINTPY_HOME}/docs/templates/RidgecrestSenDT71.txt
+```
+
+### Sentinel-1 on San Francisco Bay with GMTSAR ###
+
++ Area: San Francisco Bay, California, USA
++ Data: Sentinel-1 A/B descending track 42 during December 2014 - June 2024 (333 acquisitoins; [Zenodo](https://zenodo.org/records/12773014))
++ Size: ~2.3 GB
+
+```bash
+wget https://zenodo.org/records/12773014/files/SanFranBaySenD42.tar.xz
+tar -xvJf SanFranBaySenD42.tar.xz
+cd SanFranBaySenD42
+smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranBaySenD42.txt
+```
+
+<p align="left">
+  <img width="600" src="https://github.com/insarlab/design-docs/blob/main/docs/SanFranBaySenD42-GMTSAR.jpg">
+</p>
+
+Relevant literature:
+
++ Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San
 
 ### Envisat of the 2008 Wells, Nevada earthquake with Gamma ###
 
@@ -56,25 +90,12 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/WellsEnvD2T399.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://yunjunzhang.files.wordpress.com/2019/06/wellsenvd2t399_co_poi.jpg">
+  <img width="650" src="https://github.com/insarlab/design-docs/blob/main/docs/WellsEnvD2T399-Gamma.jpg">
 </p>
 
 Relevant literature:
 
-+ Nealy, J. L., H. M. Benz, G. P. Hayes, E. A. Bergman, and W. D. Barnhart (2017), The 2008 Wells, Nevada, Earthquake Sequence: Source Constraints Using Calibrated Multiple‐Event Relocation and InSAR, _Bulletin of the Seismological Society of America_, 107(3), 1107-1117, doi:10.1785/0120160298.
-
-### Sentinel-1 of the 2019 Ridgecrest, California earthquake sequence with HyP3 ###
-
-+ Area: Owens Valley, California, USA ([USGS event page](https://earthquake.usgs.gov/earthquakes/eventpage/ci38457511/executive))
-+ Data: Sentinel-1 descending track 71 during June - August 2019 (7 acquisitions; [Zenodo](https://zenodo.org/record/11049257))
-+ Size: ~240 MB
-
-```bash
-wget https://zenodo.org/record/11049257/files/RidgecrestSenDT71.tar.xz
-tar -xvJf RidgecrestSenDT71.tar.xz
-cd RidgecrestSenDT71
-smallbaselineApp.py ${MINTPY_HOME}/docs/templates/RidgecrestSenDT71.txt
-```
++ Nealy, J. L., H. M. Benz, G. P. Hayes, E. A. Bergman, and W. D. Barnhart (2017), The 2008 Wells, Nevada, Earthquake Sequence: Source Constraints Using C
 
 ### Sentinel-1 on Western Cape, South Africa with SNAP ###
 
@@ -103,7 +124,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/KujuAlosAT422F650.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://yunjunzhang.files.wordpress.com/2019/06/kujualosat422f650_vel.jpg">
+  <img width="650" src="https://github.com/insarlab/design-docs/blob/main/docs/KujuAlosAT422F650-ROIPAC.jpg">
 </p>
 
 Relevant literature:

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -463,9 +463,10 @@ $DATA_DIR/SanFranBaySenD42
 ├── baseline_table.dat
 ├── supermaster.PRM
 ├── geometry
-|   ├── azimuth_angle.grd
 |   ├── dem.grd
-│   └── incidence_angle.grd
+|   ├── azimuth_angle.grd
+│   ├── incidence_angle.grd
+│   └── water_mask.grd
 ├── interferograms
 │   ├── 2004114_2004324
 │   │   ├── corr_ll.grd
@@ -485,16 +486,17 @@ RLOOKS          = 32         #[int], number of looks in the range direction
 HEADING         = -168.0     #[float], satellite heading angle, measured from the north in clockwise as positive
                              # One could open the *.kml file in Google Earth and measure it manually
 
-mintpy.load.processor    = gmtsar
-mintpy.load.metaFile     = $DATA_DIR/SanFranBaySenD42/supermaster.PRM
-mintpy.load.baselineDir  = $DATA_DIR/SanFranBaySenD42/baseline_table.dat
+mintpy.load.processor     = gmtsar
+mintpy.load.metaFile      = $DATA_DIR/SanFranBaySenD42/supermaster.PRM
+mintpy.load.baselineDir   = $DATA_DIR/SanFranBaySenD42/baseline_table.dat
 ##---------interferogram datasets:
-mintpy.load.unwFile      = $DATA_DIR/SanFranBaySenD42/interferograms/*/unwrap_ll*.grd
-mintpy.load.corFile      = $DATA_DIR/SanFranBaySenD42/interferograms/*/corr_ll*.grd
+mintpy.load.unwFile       = $DATA_DIR/SanFranBaySenD42/interferograms/*/unwrap_ll*.grd
+mintpy.load.corFile       = $DATA_DIR/SanFranBaySenD42/interferograms/*/corr_ll*.grd
 ##---------geometry datasets:
-mintpy.load.demFile      = $DATA_DIR/SanFranBaySenD42/geometry/dem*.grd
-mintpy.load.incAngleFile = $DATA_DIR/SanFranBaySenD42/geometry/incidence_angle.grd
-mintpy.load.azAngleFile  = $DATA_DIR/SanFranBaySenD42/geometry/azimuth_angle.grd
+mintpy.load.demFile       = $DATA_DIR/SanFranBaySenD42/geometry/dem.grd
+mintpy.load.incAngleFile  = $DATA_DIR/SanFranBaySenD42/geometry/incidence_angle.grd
+mintpy.load.azAngleFile   = $DATA_DIR/SanFranBaySenD42/geometry/azimuth_angle.grd
+mintpy.load.waterMaskFile = $DATA_DIR/SanFranBaySenD42/geometry/water_mask.grd
 ```
 
 ### Gamma ###

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,16 +79,18 @@ bash Miniforge3-Linux-x86_64.sh -b -p ~/tools/miniforge
 Install dependencies into a new environment, e.g. named "insar":
 
 ```bash
-# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
-# Add "isce2"     below to install extra dependencies if you use ISCE-2
+# Add "isce2"      below to install extra dependencies if you use ISCE-2
+# Add "gdal"       below to install extra dependencies if you use ARIA, FRInGE or HyP3
+# Add "gdal'<3.9'" below to install extra dependencies if you use GMTSAR
 mamba create --name insar --file ~/tools/MintPy/requirements.txt
 ```
 
 or install dependencies into an existing environment:
 
 ```bash
-# Add "gdal'>=3'" below to install extra dependencies if you use ARIA, FRInGE, HyP3 or GMTSAR
-# Add "isce2"     below to install extra dependencies if you use ISCE-2
+# Add "isce2"      below to install extra dependencies if you use ISCE-2
+# Add "gdal"       below to install extra dependencies if you use ARIA, FRInGE or HyP3
+# Add "gdal'<3.9'" below to install extra dependencies if you use GMTSAR
 mamba update --name my-existing-env --file ~/tools/MintPy/requirements.txt
 ```
 

--- a/docs/templates/SanFranBaySenD42.txt
+++ b/docs/templates/SanFranBaySenD42.txt
@@ -1,0 +1,28 @@
+# vim: set filetype=cfg:
+## manually add the following metadata
+HEADING = -168
+ALOOKS  = 8
+RLOOKS  = 32
+
+########## computing resource configuration
+mintpy.compute.maxMemory    = 8
+mintpy.compute.cluster      = local
+mintpy.compute.numWorker    = 4
+
+########## 1. Load Data (--load to exit after this step)
+mintpy.load.processor       = gmtsar    #[isce, aria, hyp3, gmtsar, snap, gamma, roipac], auto for isce
+mintpy.load.metaFile        = ../supermaster.PRM
+mintpy.load.baselineDir     = ../baseline_table.dat
+##---------interferogram datasets:
+mintpy.load.unwFile         = ../interferograms/*/unwrap_ll*.grd
+mintpy.load.corFile         = ../interferograms/*/corr_ll*.grd
+##---------geometry datasets:
+mintpy.load.demFile         = ../geometry/dem.grd
+mintpy.load.incAngleFile    = ../geometry/incidence_angle.grd
+mintpy.load.azAngleFile     = ../geometry/azimuth_angle.grd
+mintpy.load.waterMaskFile   = ../geometry/water_mask.grd
+
+mintpy.reference.lalo           = 37.69, -122.07
+mintpy.troposphericDelay.method = pyaps
+mintpy.deramp                   = no
+mintpy.topographicResidual      = yes

--- a/src/mintpy/objects/stackDict.py
+++ b/src/mintpy/objects/stackDict.py
@@ -695,10 +695,7 @@ class geometryDict:
                                                              c=str(compression)))
 
                     # read
-                    data = np.array(self.read(family=dsName,
-                                              box=box,
-                                              xstep=xstep,
-                                              ystep=ystep)[0], dtype=dsDataType)
+                    data = self.read(family=dsName, box=box, xstep=xstep, ystep=ystep)[0]
 
                     # water body: -1/True  for water and 0/False for land
                     # water mask:  0/False for water and 1/True  for land
@@ -707,6 +704,12 @@ class geometryDict:
                         data = ~data
                         print('    input file "{}" is water body (True/False for water/land), '
                               'convert to water mask (False/True for water/land).'.format(fname))
+
+                    elif dsName == 'waterMask':
+                        # GMTSAR water/land mask: 1 for land, and nan for water / no data
+                        if np.sum(np.isnan(data)) > 0:
+                            print('    convert NaN value for waterMask to zero.')
+                            data[np.isnan(data)] = 0
 
                     elif dsName == 'height':
                         noDataValueDEM = -32768
@@ -745,6 +748,7 @@ class geometryDict:
                                 data = ut.wrap(data, wrap_range=[-180, 180])    # rewrap within -180 to 180
 
                     # write
+                    data = np.array(data, dtype=dsDataType)
                     ds = f.create_dataset(dsName,
                                           data=data,
                                           chunks=True,

--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -1811,7 +1811,7 @@ def _attribute_gmtsar2roipac(prm_dict_in):
             prm_dict['ANTENNA_SIDE'] = '1'
 
     # orbdir -> ORBIT_DIRECTION
-    key = 'obsdir'
+    key = 'orbdir'
     if key in prm_dict_in.keys():
         prm_dict['ORBIT_DIRECTION'] = {
             'A' : 'ASCENDING',

--- a/tests/configs/SanFranBaySenD42.txt
+++ b/tests/configs/SanFranBaySenD42.txt
@@ -1,0 +1,27 @@
+# vim: set filetype=cfg:
+## manually add the following metadata
+HEADING = -168
+ALOOKS  = 8
+RLOOKS  = 32
+
+########## computing resource configuration
+mintpy.compute.cluster      = local
+
+########## 1. Load Data (--load to exit after this step)
+mintpy.load.processor       = gmtsar    #[isce, aria, hyp3, gmtsar, snap, gamma, roipac], auto for isce
+mintpy.load.metaFile        = ../supermaster.PRM
+mintpy.load.baselineDir     = ../baseline_table.dat
+##---------interferogram datasets:
+mintpy.load.unwFile         = ../interferograms/*/unwrap_ll*.grd
+mintpy.load.corFile         = ../interferograms/*/corr_ll*.grd
+##---------geometry datasets:
+mintpy.load.demFile         = ../geometry/dem.grd
+mintpy.load.incAngleFile    = ../geometry/incidence_angle.grd
+mintpy.load.azAngleFile     = ../geometry/azimuth_angle.grd
+mintpy.load.waterMaskFile   = ../geometry/water_mask.grd
+
+mintpy.reference.lalo                           = 37.69, -122.07
+mintpy.networkInversion.weightFunc              = no    # fast but not the best
+mintpy.deramp                                   = no
+mintpy.topographicResidual                      = yes
+mintpy.topographicResidual.pixelwiseGeometry    = no    # fast but not the best

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-gdal>=3         # for ISCE-2/3, ARIA, FRInGE, HyP3, GMTSAR users
+gdal<3.9        # for ISCE-2/3, ARIA, FRInGE, HyP3, GMTSAR users, gdal-3.9 could not read GMT *.grd file's coordinate info properly
 isce2           # for ISCE-2 users
 pre-commit      # for developers
 pyfftw

--- a/tests/smallbaselineApp.py
+++ b/tests/smallbaselineApp.py
@@ -26,6 +26,7 @@ URL_LIST = [
     'https://zenodo.org/record/6662079/files/SanFranSenDT42.tar.xz',       # 280 MB
     'https://zenodo.org/record/3952950/files/WellsEnvD2T399.tar.xz',       # 280 MB
     'https://zenodo.org/record/11049257/files/RidgecrestSenDT71.tar.xz',   # 240 MB
+    'https://zenodo.org/record/12772940/files/SanFranBaySenD42.tar.xz',    # 290 MB
     'https://zenodo.org/record/6661536/files/WCapeSenAT29.tar.xz',         # 240 MB
     'https://zenodo.org/record/3952917/files/KujuAlosAT422F650.tar.xz',    # 230 MB
 ]
@@ -40,6 +41,7 @@ DSET_INFO = """
   SanFranSenDT42     for ARIA
   WellsEnvD2T399     for GAMMA
   RidgecrestSenDT71  for HyP3
+  SanFranBaySenD42   for GMTSAR
   WCapeSenAT29       for SNAP
   KujuAlosAT422F650  for ROI_PAC
 """


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the example GMTSAR datasets for MintPy inputs, as prepared by @Xiaohua-Eric-Xu.

+ docs: add SanFranBaySenD42 for GMTSAR
   - add docs/templates/SanFranBaySenD42.txt for GMTSAR
   - demo_dataset.md: add SanFranBaySenD42 for GMTSAR with figure (with DOI from zenodo)
   - use demo fig from github/insarlab/design-doc repo, instead of Yunjun's obsolete personal website, for better independency.

+ tests: add GMTSAR into the regular circle ci testing using example dataset from zenodo
   - add tests/configs/SanFranBaySenD42.txt
   - tests/smallbaselineApp.py: add SanFranBaySenD42 dataset with a false URL for place holder
   - add SanFranBaySenD42 to the regular Circle CI integration testing

+ load water mask for gmtsar, by adding:
   - objects.stackDict.geometryDict.write2hdf5(): convert NaN value to zero.
   - prep_gmtsar.prepare_geometry(): add all supported geometry data files, including water mask file
   - prep_gmtsar: add comments on input/output parameters for all functions.

+ utils.readfile._attribute_gmtsar2roipac: bugfix for ORBIT_DIRECTION

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Pass local test
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.