### PR TITLE
`version`: add `get_version_info_v2()`

### DIFF
--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -74,7 +74,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranBaySenD42.txt
 
 Relevant literature:
 
-+ Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct connection between the Hayward and Calaveras Faults, _Geophysical Research Letters,_ 42(8), 2734-2741, doi:10.1002/2015GL063575.
++ Xu, X., Sandwell, D. T., Klein, E., & Bock, Y. (2021). Integrated Sentinel-1 InSAR and GNSS Time-Series Along the San Andreas Fault System. _Journal of Geophysical Research: Solid Earth, 126_(11), e2021JB022579, doi:10.1029/2021JB022579
 
 ### Envisat of the 2008 Wells, Nevada earthquake with Gamma ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0", "setuptools_scm[toml]"]
+requires = ["setuptools>=64.0", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/mintpy/version.py
+++ b/src/mintpy/version.py
@@ -1,9 +1,15 @@
-# grab version / date of the latest commit
-
+############################################################
+# Program is part of MintPy                                #
+# Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
+# Author: Zhang Yunjun, Mar 2018                           #
+############################################################
+# Recommend import:
+#   from mintpy.version import version, version_description, logo
 
 import collections
 import os
 import subprocess
+from importlib.metadata import PackageNotFoundError, metadata
 
 ###########################################################################
 Tag = collections.namedtuple('Tag', 'version date')
@@ -35,11 +41,9 @@ release_history = (
     Tag('0.2.0', '2016-07-14'),
     Tag('0.1.0', '2015-11-23'),
 )
-release_version = release_history[0].version
-release_date = release_history[0].date
 
 def get_version_info():
-    """Grab version and date of the latest commit from a git repository"""
+    """Grab version and its date from a git repository."""
     # go to the repository directory
     dir_orig = os.getcwd()
     os.chdir(os.path.dirname(os.path.dirname(__file__)))
@@ -49,28 +53,42 @@ def get_version_info():
         cmd = "git describe --tags"
         version = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
         version = version.decode('utf-8').strip()[1:]
-
         # if there are new commits after the latest release
         if '-' in version:
             version, num_commit = version.split('-')[:2]
             version += f'.post{num_commit}'
-
         cmd = "git log -1 --date=short --format=%cd"
-        date = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
-        date = date.decode('utf-8').strip()
-
+        version_date = subprocess.check_output(cmd.split(), stderr=subprocess.DEVNULL)
+        version_date = version_date.decode('utf-8').strip()
     except:
         # use the latest release version/date
-        version = release_version
-        date = release_date
+        version = release_history[0].version
+        version_date = release_history[0].date
 
     # go back to the original directory
     os.chdir(dir_orig)
-    return version, date
+    return version, version_date
+
+
+def get_version_info_v2():
+    """Grab the version and its date from a git repository.
+    Note by Yunjun on 5 Dec 2023: could not grab release/commit date info
+        using importlib, thus, return None always.
+    """
+    try:
+        package_name = os.path.basename(os.path.dirname(__file__))
+        package = metadata(package_name)
+        version = package['Version']
+    except PackageNotFoundError:
+        print('package is not installed!\n'
+          'Please follow the installation instructions in the README.md.\n'
+          'Or, to just get the version number, use:\n'
+          '   python -m setuptools_scm')
+        version = None
+    return version, None
 
 
 ###########################################################################
-
 version, version_date = get_version_info()
 version_description = """MintPy version {v}, date {d}""".format(
     v=version,


### PR DESCRIPTION
**Description of proposed changes**

+ version: add `get_version_info_v2()` using `importlib.metadata` module, but it's not working yet, as described below, thus, not used yet.

   - 1st, the returned version is not correct: 1.5.1.post55, which should be 1.5.3.post2
   - 2nd, the returned date is not correct: None, which should be 2023-12-05

+ version: remove the unused `website` and `description` vars

+ docs/demo*: update relevant literature for San Francisco Bay dataset using GMTSAR to Xu et al. (2021, JGR)

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Pass local test
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
