### PR TITLE
tests: pin gdal"<=3.8" for circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,10 @@ jobs:
           command: |
             export PYTHONUNBUFFERED=1
             # install dependencies and source code
-            # pin gdal version because gdal-3.9 could not read the GMT-6 *.grd file properly
-            mamba install --verbose --yes --file ${MINTPY_HOME}/requirements.txt gdal"<3.9"
+            # pin gdal version as "<=3.8" because:
+            # 1) gdal-3.9 could not read the GMT-6 *.grd file properly
+            # 2) gdal-3.9 could not be imported in circle CI (https://github.com/insarlab/MintPy/issues/1220)
+            mamba install --verbose --yes --file ${MINTPY_HOME}/requirements.txt gdal"<=3.8"
             python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -h
@@ -62,7 +64,7 @@ jobs:
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
 
       - run:
-          name: Integration Test 3 - RidgecrestSenDT71 (ASF HyP3)
+          name: Integration Test 3 - RidgecrestSenDT71 (HyP3)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset RidgecrestSenDT71

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -42,7 +42,7 @@ Relevant literature:
 
 + Chaussard, E., R. Bürgmann, H. Fattahi, R. M. Nadeau, T. Taira, C. W. Johnson, and I. Johanson (2015), Potential for larger earthquakes in the East San Francisco Bay Area due to the direct connection between the Hayward and Calaveras Faults, _Geophysical Research Letters,_ 42(8), 2734-2741, doi:10.1002/2015GL063575.
 
-### Sentinel-1 of the 2019 Ridgecrest, California earthquake sequence with ASF HyP3 ###
+### Sentinel-1 of the 2019 Ridgecrest, California earthquake sequence with HyP3 ###
 
 + Area: Owens Valley, California, USA ([USGS event page](https://earthquake.usgs.gov/earthquakes/eventpage/ci38457511/executive))
 + Data: Sentinel-1 descending track 71 during June - August 2019 (7 acquisitions; [Zenodo](https://zenodo.org/record/11049257))

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -378,7 +378,7 @@ mintpy.load.azAngleFile      = $DATA_DIR/SanFranSenDT42/azimuthAngle/*.vrt
 mintpy.load.waterMaskFile    = $DATA_DIR/SanFranSenDT42/mask/watermask.msk
 ```
 
-### [ASF HyP3](https://hyp3-docs.asf.alaska.edu/)
+### [HyP3](https://hyp3-docs.asf.alaska.edu/)
 
 1. Search, request and download interferograms using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb) or the [ASF Vertex website](https://search.asf.alaska.edu/) following the [story map](https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3).
     + For at least one interferogram, download the accompanying DEM.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,7 +91,8 @@ or install dependencies into an existing environment:
 # Add "isce2"      below to install extra dependencies if you use ISCE-2
 # Add "gdal"       below to install extra dependencies if you use ARIA, FRInGE or HyP3
 # Add "gdal'<3.9'" below to install extra dependencies if you use GMTSAR
-mamba update --name my-existing-env --file ~/tools/MintPy/requirements.txt
+mamba activate my-existing-env
+mamba install --file ~/tools/MintPy/requirements.txt
 ```
 
 <h4>c. Install MintPy</h4>

--- a/tests/configs/SanFranBaySenD42.txt
+++ b/tests/configs/SanFranBaySenD42.txt
@@ -22,6 +22,7 @@ mintpy.load.waterMaskFile   = ../geometry/water_mask.grd
 
 mintpy.reference.lalo                           = 37.69, -122.07
 mintpy.networkInversion.weightFunc              = no    # fast but not the best
+mintpy.troposphericDelay.method                 = no
 mintpy.deramp                                   = no
 mintpy.topographicResidual                      = yes
 mintpy.topographicResidual.pixelwiseGeometry    = no    # fast but not the best

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-gdal<3.9        # for ISCE-2/3, ARIA, FRInGE, HyP3, GMTSAR users, gdal-3.9 could not read GMT *.grd file's coordinate info properly
+gdal<=3.8       # for ISCE-2/3, ARIA, FRInGE, HyP3, GMTSAR users; gdal-3.9 could not read GMT *.grd file's coordinate info properly [for GMTSAR]
 isce2           # for ISCE-2 users
 pre-commit      # for developers
 pyfftw


### PR DESCRIPTION
**Description of proposed changes**

+ circle ci: pin gdal"<=3.8" to fix the import error, which only occurrs in circle CI

+ tests/configs/SanFranBaySenD42: turn off tropo correction from pyaps

+ docs: use "HyP3" instead of "ASF HyP3"

**Reminders**

- [x] Fix #1220 
- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2735) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.