### PR TITLE
docs: switch fig links to github page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/FernandinaSenDT128.txt
 ```
 
 <p align="left">
-  <img width="600" src="https://github.com/insarlab/figs/blob/main/docs/FernandinaSenDT128-ISCE2.jpg">
+  <img width="600" src="https://insarlab.github.io/figs/docs/FernandinaSenDT128-ISCE2.jpg">
 </p>
 
 Results are plotted in **./pic** folder. To explore more data information and visualization, try the following scripts:

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -14,7 +14,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/FernandinaSenDT128.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://github.com/insarlab/figs/blob/main/docs/FernandinaSenDT128-ISCE2.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/FernandinaSenDT128-ISCE2.jpg">
 </p>
 
 Relevant literature:
@@ -35,7 +35,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranSenDT42.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://github.com/insarlab/figs/blob/main/docs/SanFranSenDT42-ARIA.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/SanFranSenDT42-ARIA.jpg">
 </p>
 
 Relevant literature:
@@ -69,7 +69,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranBaySenD42.txt
 ```
 
 <p align="left">
-  <img width="600" src="https://github.com/insarlab/figs/blob/main/docs/SanFranBaySenD42-GMTSAR.jpg">
+  <img width="600" src="https://insarlab.github.io/figs/docs/SanFranBaySenD42-GMTSAR.jpg">
 </p>
 
 Relevant literature:
@@ -90,7 +90,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/WellsEnvD2T399.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://github.com/insarlab/figs/blob/main/docs/WellsEnvD2T399-Gamma.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/WellsEnvD2T399-Gamma.jpg">
 </p>
 
 Relevant literature:
@@ -124,7 +124,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/KujuAlosAT422F650.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://github.com/insarlab/figs/blob/main/docs/KujuAlosAT422F650-ROIPAC.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/KujuAlosAT422F650-ROIPAC.jpg">
 </p>
 
 Relevant literature:


### PR DESCRIPTION
**Description of proposed changes**

+ docs: switch fig links in README and demo_dataset from github repo to github page, as an attempt to fix the not-showing issue of github image file on readthedocs website, which was introduced in https://github.com/insarlab/MintPy/pull/1229 and https://github.com/insarlab/MintPy/pull/1234.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2739) test (green)