### PR TITLE
`iono_split_spectrum`: hardwire dset while inverting for iono TS

### DIFF
--- a/src/mintpy/defaults/smallbaselineApp.cfg
+++ b/src/mintpy/defaults/smallbaselineApp.cfg
@@ -206,7 +206,10 @@ mintpy.solidEarthTides = auto #[yes / no], auto for no
 
 ########## 7. correct_ionosphere (optional but recommended)
 ## correct ionospheric delay [need split spectrum results from ISCE-2 stack processors]
-## reference: Fattahi et al. (2017, IEEE-TGRS); Liang et al. (2017 IEEE-TGRS; 2018 IEEE-TGRS)
+## reference:
+##   ISCE-2 topsApp/topsStack: Liang et al. (2019, IEEE-TGRS)
+##   ISCE-2 stripmapApp/stripmapStack: Fattahi et al. (2017, IEEE-TGRS)
+##   ISCE-2 alos2App/alosStack: Liang et al. (2018, IEEE-TGRS)
 mintpy.ionosphericDelay.method        = auto  #[split_spectrum / no], auto for no
 mintpy.ionosphericDelay.excludeDate   = auto  #[20080520,20090817 / no], auto for no
 mintpy.ionosphericDelay.excludeDate12 = auto  #[20080520_20090817 / no], auto for no

--- a/src/mintpy/iono_split_spectrum.py
+++ b/src/mintpy/iono_split_spectrum.py
@@ -37,7 +37,7 @@ def run_iono_split_spectrum(inps):
     # 3. estimate iono time-series
     print('\n'+'-'*80)
     print('Estimate ionospheric delay time-series via ifgram_inversion.py ...')
-    cmd = f'ifgram_inversion.py {inps.iono_stack_file} -t {inps.template_file} -w no --update'
+    cmd = f'ifgram_inversion.py {inps.iono_stack_file} --dset unwrapPhase --weight-func no --update'
     print(cmd)
     ifgram_inversion.main(cmd.split()[1:])
 

--- a/src/mintpy/iono_split_spectrum.py
+++ b/src/mintpy/iono_split_spectrum.py
@@ -35,6 +35,7 @@ def run_iono_split_spectrum(inps):
     reference_point.main(cmd.split()[1:])
 
     # 3. estimate iono time-series
+    # hardwire "--dset unwrapPhase" to ignore dataset name change from unwrapping error correction options
     print('\n'+'-'*80)
     print('Estimate ionospheric delay time-series via ifgram_inversion.py ...')
     cmd = f'ifgram_inversion.py {inps.iono_stack_file} --dset unwrapPhase --weight-func no --update'


### PR DESCRIPTION
**Description of proposed changes**

+ `iono_split_spectrum`:
   - hardwire dataset name to `unwrapPhase` while inverting for iono TS
   - remove the template file input, so it can ignore the template inputs, such as the `unwrapPhase_bridging` if one turns on the PU error correction.

+ `defaults.smallbaselineApp.cfg`: update `correct_ionosphere` reference, to be consistent with `iono_split_spectrum.py` help message.

**Reminders**

- [x] Fix https://github.com/insarlab/MintPy/discussions/1189#discussioncomment-10135331
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2750) test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.