### PR TITLE
docs: switch fig links to github page - part 2

### DIFF
--- a/docs/QGIS.md
+++ b/docs/QGIS.md
@@ -10,11 +10,11 @@ ramp_color('RdBu', scale_linear(VEL, -20, 20, 0, 1))
 ```
 
 <p align="left">
-  <img width="1000" src="https://yunjunzhang.files.wordpress.com/2019/11/ps-time-series-viewer-1.png">
+  <img width="1000" src="https://insarlab.github.io/figs/docs/mintpy/QGIS-PS-TSV-map.png">
 </p>
 
 5. Click the [PS Time Series Viewer logo](https://gitlab.com/faunalia/ps-speed/blob/master/icons/logo.png) to activate the tool, and click/play on the map to display the time-series!
 
 <p align="left">
-  <img width="800" src="https://yunjunzhang.files.wordpress.com/2019/11/ps-time-series-viewer-2.png">
+  <img width="800" src="https://insarlab.github.io/figs/docs/mintpy/QGIS-PS-TSV-point.png">
 </p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/FernandinaSenDT128.txt
 ```
 
 <p align="left">
-  <img width="600" src="https://insarlab.github.io/figs/docs/FernandinaSenDT128-ISCE2.jpg">
+  <img width="600" src="https://insarlab.github.io/figs/docs/mintpy/FernandinaSenDT128-ISCE2.jpg">
 </p>
 
 Results are plotted in **./pic** folder. To explore more data information and visualization, try the following scripts:

--- a/docs/_layouts/default_tactile.html
+++ b/docs/_layouts/default_tactile.html
@@ -18,7 +18,7 @@
 
         <header>
           <p align="center">
-            <img src="https://yunjunzhang.files.wordpress.com/2017/08/logo_githubpage.pdf">
+            <img src="https://insarlab.github.io/figs/docs/mintpy/logo_pysar_obsolete.pdf">
           </p>
         </header>
         <section id="downloads" class="clearfix">

--- a/docs/api/colormaps.md
+++ b/docs/api/colormaps.md
@@ -64,7 +64,7 @@ The following colormaps is included by default:
 + More at [Scientific Color-Maps](http://www.fabiocrameri.ch/colourmaps.php) ([Crameri, 2018](https://doi.org/10.5194/gmd-11-2541-2018))
 
 <p align="left">
-  <img src="https://insarlab.github.io/figs/docs/mintpy/cmap_scientific_colour_maps_fabiocrameri.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/cmap_scientific_colour_maps_fabiocrameri.jpg">
 </p>
 
 ### Interactive [web tool](https://jdherman.github.io/colormap/) to generate custom colormaps by Jon Herman ###

--- a/docs/api/colormaps.md
+++ b/docs/api/colormaps.md
@@ -9,7 +9,7 @@ MintPy support the following colormaps:
 We recommend to use cyclic colormap `cmy` for wrapped phase/displacement measurement.
 
 <p align="left">
-  <img width="280" src="https://yunjunzhang.files.wordpress.com/2020/01/cmap_cmy-1.png">
+  <img width="280" src="https://insarlab.github.io/figs/docs/mintpy/cmap_cmy.png">
 </p>
 
 To use colormap `cmy` in view.py:
@@ -64,7 +64,7 @@ The following colormaps is included by default:
 + More at [Scientific Color-Maps](http://www.fabiocrameri.ch/colourmaps.php) ([Crameri, 2018](https://doi.org/10.5194/gmd-11-2541-2018))
 
 <p align="left">
-  <img src="https://yunjunzhang.files.wordpress.com/2021/01/scientificcolourmaps_fabiocrameri.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/cmap_scientific_colour_maps_fabiocrameri.png">
 </p>
 
 ### Interactive [web tool](https://jdherman.github.io/colormap/) to generate custom colormaps by Jon Herman ###

--- a/docs/api/coord.md
+++ b/docs/api/coord.md
@@ -11,4 +11,4 @@ Y_UNIT     degrees
 
 X/Y_FIRST are the longitude/latitude value of the first (upper left corner) pixel’s upper left corner, as shown below:
 
-<img src="https://yunjunzhang.files.wordpress.com/2019/06/coord_index.png" width="400">
+<img src="https://insarlab.github.io/figs/docs/mintpy/coord_index.png" width="400">

--- a/docs/dask.md
+++ b/docs/dask.md
@@ -54,7 +54,7 @@ A typical run time without local cluster is 30 secs and with 8 workers 11.4 secs
 
 To show the run time improvement, we test three datasets (South Isabela, Fernandina, and Kilauea) with different number of cores and same amount of allocated memory (4 GB) on a compute node in the [Stampede2 cluster's skx-normal queue](https://portal.tacc.utexas.edu/user-guides/stampede2#overview-skxcomputenodes). Results are as below:
 
-![Dask LocalCluster Performance](https://yunjunzhang.files.wordpress.com/2020/08/dask_local_cluster_performance.png)
+![Dask LocalCluster Performance](https://insarlab.github.io/figs/docs/mintpy/dask_local_cluster_performance.png)
 
 #### 1.5 Known problems ####
 

--- a/docs/demo_dataset.md
+++ b/docs/demo_dataset.md
@@ -14,7 +14,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/FernandinaSenDT128.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://insarlab.github.io/figs/docs/FernandinaSenDT128-ISCE2.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/mintpy/FernandinaSenDT128-ISCE2.jpg">
 </p>
 
 Relevant literature:
@@ -35,7 +35,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranSenDT42.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://insarlab.github.io/figs/docs/SanFranSenDT42-ARIA.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/mintpy/SanFranSenDT42-ARIA.jpg">
 </p>
 
 Relevant literature:
@@ -69,7 +69,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/SanFranBaySenD42.txt
 ```
 
 <p align="left">
-  <img width="600" src="https://insarlab.github.io/figs/docs/SanFranBaySenD42-GMTSAR.jpg">
+  <img width="600" src="https://insarlab.github.io/figs/docs/mintpy/SanFranBaySenD42-GMTSAR.jpg">
 </p>
 
 Relevant literature:
@@ -90,7 +90,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/WellsEnvD2T399.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://insarlab.github.io/figs/docs/WellsEnvD2T399-Gamma.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/mintpy/WellsEnvD2T399-Gamma.jpg">
 </p>
 
 Relevant literature:
@@ -124,7 +124,7 @@ smallbaselineApp.py ${MINTPY_HOME}/docs/templates/KujuAlosAT422F650.txt
 ```
 
 <p align="left">
-  <img width="650" src="https://insarlab.github.io/figs/docs/KujuAlosAT422F650-ROIPAC.jpg">
+  <img width="650" src="https://insarlab.github.io/figs/docs/mintpy/KujuAlosAT422F650-ROIPAC.jpg">
 </p>
 
 Relevant literature:

--- a/docs/google_earth.md
+++ b/docs/google_earth.md
@@ -5,7 +5,7 @@ MintPy use [pyKML](https://pythonhosted.org/pykml/) to generate KMZ (Keyhole Mar
 `save_kmz_timeseries.py` takes 3D displacement time-series file and outputs a KMZ file with interactive time-seires plot.
 
 <p align="center">
-  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-TS.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-TS.jpg">
 </p>
 
 [Download KMZ file](https://miami.box.com/v/FernandinaSenDT128TS)
@@ -15,7 +15,7 @@ MintPy use [pyKML](https://pythonhosted.org/pykml/) to generate KMZ (Keyhole Mar
 `save_kmz.py` takes any 2D matrix and outputs a KMZ file with a overlay image.
 
 <p align="center">
-  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-VEL.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-VEL.jpg">
 </p>
 
 [Download KMZ file](https://miami.box.com/v/FernandinaSenDT128VEL)

--- a/docs/google_earth.md
+++ b/docs/google_earth.md
@@ -5,7 +5,7 @@ MintPy use [pyKML](https://pythonhosted.org/pykml/) to generate KMZ (Keyhole Mar
 `save_kmz_timeseries.py` takes 3D displacement time-series file and outputs a KMZ file with interactive time-seires plot.
 
 <p align="center">
-  <img src="https://yunjunzhang.files.wordpress.com/2019/02/fernandinasendt128_ge-1.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-TS.png">
 </p>
 
 [Download KMZ file](https://miami.box.com/v/FernandinaSenDT128TS)
@@ -15,7 +15,7 @@ MintPy use [pyKML](https://pythonhosted.org/pykml/) to generate KMZ (Keyhole Mar
 `save_kmz.py` takes any 2D matrix and outputs a KMZ file with a overlay image.
 
 <p align="center">
-  <img src="https://yunjunzhang.files.wordpress.com/2019/02/vel_fernandinasendt128_ge.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-VEL.png">
 </p>
 
 [Download KMZ file](https://miami.box.com/v/FernandinaSenDT128VEL)
@@ -35,7 +35,7 @@ The script samples the input 3D dataset at 3 levels of details by default (`--st
 The low- and moderate-resolution LODs cover the entire region, while the high-resolution LOD covers only the actively deforming regions. These regions (red boxes below) are currently identified as boxes having >20% pixels with velocity magnitude > the global velocity median absolute deviation (`mintpy.save_kmz_timeseries.get_boxes4deforming_area`).
 
 <p align="center">
-  <img src="https://yunjunzhang.files.wordpress.com/2020/03/defo_area.png">
+  <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-defoArea.png">
 </p>
 
 2. Region-based Network Links

--- a/docs/hdfeos5.md
+++ b/docs/hdfeos5.md
@@ -90,4 +90,4 @@ HDF-EOS5 file format is used as the input of the University of Miami's web viewe
 
 <p align="center"><b>http://insarmaps.miami.edu</b><br></p>
 
-[![InSAR Web Viewer](https://yunjunzhang.files.wordpress.com/2019/06/web_viewer_kujualosat422.png)](http://insarmaps.miami.edu/)
+[![InSAR Web Viewer](https://insarlab.github.io/figs/docs/mintpy/insarmaps-KujuAlosA422.png)](http://insarmaps.miami.edu/)


### PR DESCRIPTION
**Description of proposed changes**

+ docs: switch the image src links from Yunjun's obsolete WordPress website to the GitHub page of `insarlab/figs`, for better independency. A continuation of #1229, #1234, #1237.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2749/workflows/74d5e176-1227-465d-ad2e-d50171ff53cc/jobs/2757) test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.