### PR TITLE
gnss.GNSS_SIDESHOW.get_site_lat_lon: dload site list file if not exist

### DIFF
--- a/src/mintpy/objects/gnss.py
+++ b/src/mintpy/objects/gnss.py
@@ -1082,6 +1082,8 @@ class GNSS_SIDESHOW(GNSS):
         """
         # need to refer to the site list
         site_list_file = os.path.basename(GNSS_SITE_LIST_URLS['SIDESHOW'])
+        if not os.path.exists(site_list_file):
+            dload_site_list(out_file=site_list_file, source=self.source, print_msg=True)
 
         # find site in site list file
         with open(site_list_file) as site_list:


### PR DESCRIPTION
**Description of proposed changes**

+ bugfix while running `view.py --gnss-source SIDESHOW --ref-gnss P225` on the first time, where the reference GNSS needs the site list file to extract its lat/lon location, but the site list file has not been downloaded yet, thus, causing the following error:

```bash
(insar) yunjunz:~/data/test/SanFranSenDT42/mintpy>$ view.py velocity.h5 velocity --show-gnss --gnss-src SIDESHOW  --ref-gnss P225 --gnss-comp enu2los --gnss-label
run view.py in MintPy version 1.6.1.post1, date 2024-08-09
input file is velocity file: /Users/yunjunz/data/test/SanFranSenDT42/mintpy/velocity.h5 in float32 format
file size in y/x: (510, 510)
input dataset: "['velocity']"
turning glob search OFF for velocity file
num of datasets in file velocity.h5: 5
datasets to exclude (0):
[]
datasets to display (1):
['velocity']
data   coverage in y/x: (0, 0, 510, 510)
subset coverage in y/x: (0, 0, 510, 510)
data   coverage in lat/lon: (-122.600833333, 38.1, -121.750833673, 37.25000034000001)
subset coverage in lat/lon: (-122.600833333, 38.1, -121.750833673, 37.25000034000001)
------------------------------------------------------------------------
colormap: jet
figure title: velocity
figure size : [7.5, 6.0]
read mask from file: maskTempCoh.h5
reading data ...
masking data
data    range: [-1.3753852, 1.003038] cm/year
display range: [-1.3753852, 1.003038] cm/year
display data in transparency: 1.0
plot in geo-coordinate
create directory: /Users/yunjunz/data/test/SanFranSenDT42/mintpy/GNSS-SIDESHOW
Traceback (most recent call last):
  File "/Users/yunjunz/tools/mambaforge/envs/insar/bin/view.py", line 8, in <module>
    sys.exit(main())
  File "/Users/yunjunz/tools/MintPy/src/mintpy/cli/view.py", line 184, in main
    obj.plot()
  File "/Users/yunjunz/tools/MintPy/src/mintpy/view.py", line 1677, in plot
    self = plot_slice(ax, data, self.atr, self)[1]
  File "/Users/yunjunz/tools/MintPy/src/mintpy/view.py", line 549, in plot_slice
    ref_site_lalo = gnss_obj.get_site_lat_lon()
  File "/Users/yunjunz/tools/MintPy/src/mintpy/objects/gnss.py", line 1087, in get_site_lat_lon
    with open(site_list_file) as site_list:
FileNotFoundError: [Errno 2] No such file or directory: 'table2.html'
```

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2782) test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.