### PR TITLE
utils0: use more hardwired `EARTH_RADIUS` if needed

### DIFF
--- a/src/mintpy/objects/sensor.py
+++ b/src/mintpy/objects/sensor.py
@@ -368,6 +368,7 @@ RCM = {
 # Table 2 & 6 in https://directory.eoportal.org/web/eoportal/satellite-missions/g/gaofen-3
 # https://www.eoportal.org/satellite-missions/gaofen-3
 # Li et al. (2018, RS) at https://doi.org/10.3390/rs10121929
+# Table I in Yang et al. (2023, IEEE-TGRS) at https://doi.org/10.1109/TGRS.2023.3238707
 GF3 = {
     # orbit
     'altitude'                   : 755e3,     # m
@@ -377,7 +378,11 @@ GF3 = {
     'carrier_frequency'          : 5.4e9,     # Hz
     'antenna_length'             : 15,        # m
     'antenna_width'              : 1.5,       # m
+    'pulse_repetition_frequency' : 1412.18,   # Hz
+    'chirp_bandwidth'            : 60.00e6,   # Hz
     'sampling_frequency'         : 533.33e6,  # Hz
+    'azimuth_pixel_size'         : 4.77,      # m, FSII mode
+    'range_pixel_size'           : 2.25,      # m, FSII mode
 }
 
 # Sentinel-1 Interferometric Wide (IW / TOPS) swath mode

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -194,7 +194,7 @@ def incidence_angle2slant_range_distance(atr, inc_angle):
     if isinstance(inc_angle, str):
         inc_angle = float(inc_angle)
     inc_angle = np.array(inc_angle, dtype=np.float32) / 180 * np.pi
-    r = float(atr['EARTH_RADIUS'])
+    r = float(atr.get('EARTH_RADIUS', EARTH_RADIUS))
     H = float(atr['HEIGHT'])
 
     # calculate 2R based on the law of sines
@@ -229,7 +229,7 @@ def azimuth_ground_resolution(atr):
 
     proc = atr.get('PROCESSOR', 'isce')
     if proc in ['roipac', 'isce']:
-        Re = float(atr['EARTH_RADIUS'])
+        Re = float(atr.get('EARTH_RADIUS', EARTH_RADIUS))
         height = float(atr['HEIGHT'])
         az_step = float(atr['AZIMUTH_PIXEL_SIZE']) * Re / (Re + height)
     elif proc == 'gamma':

--- a/tests/objects/ionex.py
+++ b/tests/objects/ionex.py
@@ -102,6 +102,19 @@ def test_get_ionex_value():
         print(f'Interpolation method ({method:8s}) with rotation ({str(rotate):5s}): Pass.')
 
 
+def test_plot_ionex():
+    """Test mintpy.objects.ionex.plot_ionex()"""
+    # get IONEX file path
+    tec_file = ionex.get_ionex_filename(
+        date_str,
+        tec_dir=tec_dir,
+        sol_code=sol_code,
+    )
+
+    # plot IONEX file
+    ionex.plot_ionex(tec_file, save_fig=True)
+
+
 if __name__ == '__main__':
 
     print('-'*50)
@@ -112,3 +125,5 @@ if __name__ == '__main__':
     test_read_ionex()
 
     test_get_ionex_value()
+
+    #test_plot_ionex()


### PR DESCRIPTION
**Description of proposed changes**

+ `utils.utils0`: use more hardwired `EARTH_RADIUS` if needed, to be more tolerant of potential missing metadata

+ `tests.objects.ionex.py`: add `test_plot_ionex()` to plot an IONEX file easily in the command line, but did not call/test this function in the routine unit test.

+ `objects.sensor`: add more `Gaofen3` parameters

**Reminders**

- [x] Fix #1256
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [ ] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/2788) test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.