### PR TITLE
typo fix in `defaults/mintpy.yaml` for Slurm

### DIFF
--- a/docs/google_earth.md
+++ b/docs/google_earth.md
@@ -2,7 +2,7 @@ MintPy use [pyKML](https://pythonhosted.org/pykml/) to generate KMZ (Keyhole Mar
 
 ### 1. Displacement time-series ###
 
-`save_kmz_timeseries.py` takes 3D displacement time-series file and outputs a KMZ file with interactive time-seires plot.
+`save_kmz_timeseries.py` takes 3D displacement time-series file and outputs a KMZ file with interactive time-series plot.
 
 <p align="center">
   <img src="https://insarlab.github.io/figs/docs/mintpy/GoogleEarth-FernandinaSenD128-TS.jpg">

--- a/src/mintpy/defaults/mintpy.yaml
+++ b/src/mintpy/defaults/mintpy.yaml
@@ -67,7 +67,7 @@ jobqueue:
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
     local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
 
-    # LSF resource manager options
+    # Slurm resource manager options
     shebang: "#!/usr/bin/env bash"
     queue: null
     project: null


### PR DESCRIPTION
**Description of proposed changes**

Correct the comment for this section of the yaml file

## Summary by Sourcery

Correct the comment in the YAML configuration file to accurately reflect the use of the Slurm resource manager.

Documentation:
- Correct the comment in the YAML file to accurately refer to the Slurm resource manager instead of LSF.