### PR TITLE
`view`: convert integer to floating to enable masking with `nan`

### DIFF
--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -699,7 +699,7 @@ def read_binary_file(fname, datasetName=None, box=None, xstep=1, ystep=1):
             cpx_band = 'magnitude'
 
         elif fext in ['.mli', '.rmli']:
-            byte_order = 'little-endian'
+            byte_order = 'little-endian'   # big-endian
 
     # SNAP
     # BEAM-DIMAP data format

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -1652,9 +1652,15 @@ class viewer():
             no_data_val = readfile.get_no_data_value(self.file)
             if self.no_data_value is not None:
                 vprint(f'masking pixels with NO_DATA_VALUE of {self.no_data_value}')
+                # convert integer to floating to enable masking with nan
+                if np.issubdtype(data.dtype, np.integer):
+                    data = np.array(data, np.float32)
                 data[data == self.no_data_value] = np.nan
             elif no_data_val is not None and not np.isnan(no_data_val):
                 vprint(f'masking pixels with NO_DATA_VALUE of {no_data_val}')
+                # convert integer to floating to enable masking with nan
+                if np.issubdtype(data.dtype, np.integer):
+                    data = np.array(data, np.float32)
                 data[data == no_data_val] = np.nan
 
             # update/save mask info


### PR DESCRIPTION
**Description of proposed changes**

+ `view.viewer.plot()`: convert `integer` to `floating` to enable masking with `nan` for one subplot scenario

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2809) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

## Summary by Sourcery

Convert integer data types to floating point in the plot function to enable masking with NaN values, ensuring proper handling of no-data values.

Bug Fixes:
- Convert integer data types to floating point in the plot function to enable masking with NaN values.

Enhancements:
- Add a check to convert integer data types to floating point before applying NaN masking in the plot function.