### PR TITLE
Removes np.nan in output of spatial_filter.py

### DIFF
--- a/src/mintpy/spatial_filter.py
+++ b/src/mintpy/spatial_filter.py
@@ -195,6 +195,7 @@ def filter_file(fname, ds_names=None, filter_type='lowpass_gaussian', filter_par
             data = filter_data(data, filter_type, filter_par)
 
         # save
+        data *= ~np.isnan(data)
         dsDict[ds_name] = data
 
     # write to file


### PR DESCRIPTION
**Description of proposed changes**

Removes np.nan when using spatial_filter.py. This is useful to generate velocity using timeseries2velocity.py.

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Bug Fixes:
- Remove np.nan values from the output of spatial_filter.py to ensure compatibility with timeseries2velocity.py.