### PR TITLE
`tropo_pyaps3`: add `--debug-mode` option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ joblib
 lxml
 matplotlib
 numpy
-pyaps3>=0.3
+pyaps3>=0.3.6
 pykml>=0.2
 pyproj
 pyresample

--- a/src/mintpy/cli/tropo_pyaps3.py
+++ b/src/mintpy/cli/tropo_pyaps3.py
@@ -90,6 +90,9 @@ def create_parser(subparsers=None):
     parser.add_argument('--hour', type=str, help='time of data in HH, e.g. 12, 06')
     parser.add_argument('-o','--output', dest='cor_dis_file',
                         help='Output file name for trospheric corrected timeseries.')
+    parser.add_argument('--debug', '--debug-mode', dest='debug_mode', action='store_true',
+                        help='Enable debug mode, i.e. run pyaps3 without try/except to show the full message '
+                             'and potential stopping points.')
 
     # delay calculation
     delay = parser.add_argument_group('delay calculation')

--- a/src/mintpy/cli/tropo_pyaps3.py
+++ b/src/mintpy/cli/tropo_pyaps3.py
@@ -38,6 +38,9 @@ EXAMPLE = """example:
   tropo_pyaps3.py -d SAFE_files.txt
   # download datasets (covering the area of interest)
   tropo_pyaps3.py -d SAFE_files.txt -g inputs/geometryRadar.h5
+
+  # debug mode (to facilitate potential pyaps3 debugging)
+  tropo_pyaps3.py -f timeseries.h5 -g inputs/geometryRadar.h5 --debug
 """
 
 SAFE_FILE = """SAFE_files.txt:


### PR DESCRIPTION
**Description of proposed changes**

+ `tropo_pyaps3.py`: add `--debug(--mode)` option to enable the debug mode to show the full error message of `pyaps3` while downloading, to better diagnose #1321

+ `requirements.txt`: set min version of `pyaps3` to 0.3.6 for the new CDS website

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2856) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Add a `--debug-mode` option to show the full error message of `pyaps3` while downloading, and set the minimum version of `pyaps3` to 0.3.6.

New Features:
- Added a `--debug-mode` option to `tropo_pyaps3.py` to facilitate debugging of pyaps3 downloads.

Tests:
- Updated the help message to include the new `--debug` option.