### PR TITLE
`ut.update_template_file()`: fix IndexError due to special character `+`

### DIFF
--- a/src/mintpy/smallbaselineApp.py
+++ b/src/mintpy/smallbaselineApp.py
@@ -332,8 +332,7 @@ class TimeSeriesAnalysis:
 
     def run_unwrap_error_correction(self, step_name):
         """Correct phase-unwrapping errors"""
-        # ignore whitespace
-        method = self.template['mintpy.unwrapError.method'].replace(' ', '')
+        method = self.template['mintpy.unwrapError.method']
         if not method:
             print('phase-unwrapping error correction is OFF.')
             return

--- a/src/mintpy/smallbaselineApp.py
+++ b/src/mintpy/smallbaselineApp.py
@@ -332,7 +332,8 @@ class TimeSeriesAnalysis:
 
     def run_unwrap_error_correction(self, step_name):
         """Correct phase-unwrapping errors"""
-        method = self.template['mintpy.unwrapError.method']
+        # ignore whitespace
+        method = self.template['mintpy.unwrapError.method'].replace(' ', '')
         if not method:
             print('phase-unwrapping error correction is OFF.')
             return

--- a/src/mintpy/utils/utils1.py
+++ b/src/mintpy/utils/utils1.py
@@ -558,7 +558,7 @@ def update_template_file(template_file, extra_dict, delimiter='='):
                 # link: https://docs.python.org/3/library/re.html
                 value2search = value
                 # 1. interpret special symbols as characters
-                for symbol in ['*', '[', ']', '(', ')']:
+                for symbol in ['*', '[', ']', '(', ')', '+']:
                     value2search = value2search.replace(symbol, fr"\{symbol}")
                 # 2. use "= {OLD_VALUE}" for search/replace to be more robust
                 # against the scenario when key name contains {OLD_VALUE}


### PR DESCRIPTION
**Description of proposed changes**

Fix IndexError in update_template_file when trying to set the value 'briging+phase_closure' on 'mintpy.unwrapError.method'.

```bash
Traceback (most recent call last):
  File "/opt/conda/bin/smallbaselineApp.py", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/mintpy/cli/smallbaselineApp.py", line 209, in main
    run_smallbaselineApp(inps)
  File "/opt/conda/lib/python3.10/site-packages/mintpy/smallbaselineApp.py", line 1154, in run_smallbaselineApp
    app.open()
  File "/opt/conda/lib/python3.10/site-packages/mintpy/smallbaselineApp.py", line 79, in open
    self._read_template()
  File "/opt/conda/lib/python3.10/site-packages/mintpy/smallbaselineApp.py", line 118, in _read_template
    self.templateFile = ut.update_template_file(self.templateFile, self.customTemplate)
  File "/opt/conda/lib/python3.10/site-packages/mintpy/utils/utils1.py", line 570, in update_template_file
    old_value_str = re.findall(value2search, line)[0]
    IndexError: list index out of range
```

With my debug messages:
DEBUG value2search: [\\s]*bridging+phase_closure 
DEBUG line: mintpy.unwrapError.method          = bridging+phase_closure  \n'

**Reminders**

- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

## Summary by Sourcery

Bug Fixes:
- Fixes an `IndexError` in the `update_template_file` function that occurred when processing special characters like '+' in template values. The fix ensures that these characters are properly escaped when constructing regular expressions for searching and replacing values in template files.