### PR TITLE
Load ARIA-tools generated ionosphere stack from the template file

### DIFF
--- a/src/mintpy/load_data.py
+++ b/src/mintpy/load_data.py
@@ -740,6 +740,7 @@ def prepare_metadata(iDict):
             '--incidence-angle'     : 'mintpy.load.incAngleFile',
             '--azimuth-angle'       : 'mintpy.load.azAngleFile',
             '--water-mask'          : 'mintpy.load.waterMaskFile',
+            '--iono'                : 'mintpy.load.ionUnwFile',
         }
 
         for arg_name, opt_name in ARG2OPT_DICT.items():

--- a/src/mintpy/prep_aria.py
+++ b/src/mintpy/prep_aria.py
@@ -654,8 +654,8 @@ def load_aria(inps):
 
         layer_name, _ = get_correction_layer(inps.ionoFile)
 
-        if run_or_skip(inps, ds_name_dict, out_file=inps.outfile[0]) == 'run':
-            outname = f'{out_dir}/ionStack.h5'
+        outname = f'{out_dir}/ionStack.h5'
+        if run_or_skip(inps, ds_name_dict, out_file=outname) == 'run':
 
             writefile.layout_hdf5(
                 outname,


### PR DESCRIPTION
- Add the `--iono` option to `load_data.py` arguments so when ionosphere file is given in the template, the `load_data` step will read the `ionoStack.vrt`.
- Fix a bug in `prep_aria.py` which was causing the script to skip loading to `ionStack.h5`

