### PR TITLE
`gnss`: change `http` to `https` for UNR URLs

### DIFF
--- a/src/mintpy/objects/gnss.py
+++ b/src/mintpy/objects/gnss.py
@@ -21,7 +21,7 @@ from mintpy.objects.coord import coordinate
 from mintpy.utils import ptime, readfile, time_func, utils1 as ut
 
 GNSS_SITE_LIST_URLS = {
-    'UNR'      : 'http://geodesy.unr.edu/NGLStationPages/DataHoldings.txt',
+    'UNR'      : 'https://geodesy.unr.edu/NGLStationPages/DataHoldings.txt',
     'ESESES'   : 'http://garner.ucsd.edu/pub/measuresESESES_products/Velocities/ESESES_Velocities.txt',
     'SIDESHOW' : 'https://sideshow.jpl.nasa.gov/post/tables/table2.html',
     'GENERIC'  : None,
@@ -819,7 +819,8 @@ class GNSS_UNR(GNSS):
         # examples: http://geodesy.unr.edu/gps_timeseries/tenv3/IGS08/1LSU.IGS08.tenv3
         #           http://geodesy.unr.edu/gps_timeseries/tenv3/IGS14/CASU.tenv3
         if not self.url_prefix:
-            self.url_prefix = f'http://geodesy.unr.edu/gps_timeseries/tenv3/{self.version}'
+            self.url_prefix = f'https://geodesy.unr.edu/gps_timeseries/tenv3/{self.version}'
+        print(self.url_prefix)
         self.url = os.path.join(self.url_prefix, os.path.basename(self.file))
 
 
@@ -845,8 +846,8 @@ class GNSS_UNR(GNSS):
 
         # get plot file url
         url_prefix = {
-            'IGS08' : 'http://geodesy.unr.edu/tsplots/IGS08/TimeSeries',
-            'IGS14' : 'http://geodesy.unr.edu/tsplots/IGS14/IGS14/TimeSeries',
+            'IGS08' : 'https://geodesy.unr.edu/tsplots/IGS08/TimeSeries',
+            'IGS14' : 'https://geodesy.unr.edu/tsplots/IGS14/IGS14/TimeSeries',
         }[self.version]
         plot_file_url = os.path.join(url_prefix, f'{self.site}.png')
 

--- a/src/mintpy/objects/gnss.py
+++ b/src/mintpy/objects/gnss.py
@@ -820,7 +820,6 @@ class GNSS_UNR(GNSS):
         #           http://geodesy.unr.edu/gps_timeseries/tenv3/IGS14/CASU.tenv3
         if not self.url_prefix:
             self.url_prefix = f'https://geodesy.unr.edu/gps_timeseries/tenv3/{self.version}'
-        print(self.url_prefix)
         self.url = os.path.join(self.url_prefix, os.path.basename(self.file))
 
 


### PR DESCRIPTION
**Update web address for UNR GPS data**

University of Nevada Reno National Geodetic Laboratory has updated their web addresses to http secure protocol. This PR updates the appropriate links in the mintpy.objects.gnss module.

Tested with:
```
gnss_source = 'UNR'

from mintpy.objects import gnss

# Get analysis metadata from InSAR velocity file
(S,N,W,E) = (34.65836106, 35.60002848, -116.620093296, -114.38925817799999)
start_date = '20180105'
end_date = '20181231'

# Search for collocated GNSS stations
site_names, _, _ = gnss.search_gnss(SNWE=(S,N,W,E),
                                    start_date=start_date,
                                    end_date=end_date,
                                    source=gnss_source)
site_names = [str(site_name) for site_name in site_names]
n_sites = len(site_names)
print(f"{n_sites:d} found")

for site_name in site_names:
    print(f"Downloading {site_name:s}")
    gnss_stn = gnss.get_gnss_class(gnss_source)(site = site_name)
    gnss_stn.open(print_msg=False)
```

The download is currently slow on my home machine (8 minutes for 27 stations). I do not know if it is faster on different networks or at different times of day.

## Summary by Sourcery

Updates UNR URLs from HTTP to HTTPS to use a secure protocol.