### PR TITLE
Unwrap error correction with phase_closure should use user-defined `connCompMinArea`

### DIFF
--- a/src/mintpy/unwrap_error_phase_closure.py
+++ b/src/mintpy/unwrap_error_phase_closure.py
@@ -308,7 +308,7 @@ def get_common_region_int_ambiguity(ifgram_file, cc_mask_file, water_mask_file=N
 
 def correct_unwrap_error_phase_closure(ifgram_file, common_regions, water_mask_file=None,
                                        ccName='connectComponent', dsNameIn='unwrapPhase',
-                                       dsNameOut='unwrapPhase_phaseClosure'):
+                                       dsNameOut='unwrapPhase_phaseClosure', cc_min_area=2.5e3):
     print('-'*50)
     print(f'correct unwrapping error in {ifgram_file} with phase closure ...')
     stack_obj = ifgramStack(ifgram_file)
@@ -359,7 +359,7 @@ def correct_unwrap_error_phase_closure(ifgram_file, common_regions, water_mask_f
                 if water_mask is not None:
                     cc[water_mask == 0] = 0
                 cc_obj = conncomp.connectComponent(conncomp=cc, metadata=stack_obj.metadata)
-                cc_obj.label()
+                cc_obj.label(min_area=cc_min_area)
                 local_regions = measure.regionprops(cc_obj.labelImg)
 
                 # matching regions and correct unwrap error
@@ -420,6 +420,7 @@ def run_unwrap_error_phase_closure(inps):
             water_mask_file=inps.waterMaskFile,
             dsNameIn=inps.datasetNameIn,
             dsNameOut=inps.datasetNameOut,
+            cc_min_area=inps.connCompMinArea,
         )
 
     else:


### PR DESCRIPTION
Make `correct_unwrap_error_phase_closure` use user-defined `connCompMinArea` when labeling connected components. It currently always uses the default.

**Description of proposed changes**

Fixes #1335 

- adds a `cc_min_area` arg to `correct_unwrap_error_phase_closure` so it can be passed to `cc_obj.label(min_area=cc_min_area)`.
  - If  `min_area` is not passed `label`, it uses the default of 2.5e3

**Reminders**

- [X] Fix #1335
- [X] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [X] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] ~~If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.~~
- [ ] ~~If adding new functionality, add a detailed description to the documentation and/or an example.~~
