### PR TITLE
add `mintpy.load.compression = default` option & allow custom compression for geometry HDF5 file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         exclude: tests/data/
 
   - repo: https://github.com/PyCQA/isort
-    rev: "6.0.0"
+    rev: "6.0.1"
     hooks:
       - id: isort
         name: sort imports

--- a/src/mintpy/cli/load_data.py
+++ b/src/mintpy/cli/load_data.py
@@ -75,8 +75,6 @@ def create_parser(subparsers=None):
                         help='project name of dataset for INSARMAPS Web Viewer')
     parser.add_argument('--enforce', '-f', dest='updateMode', action='store_false',
                         help='Disable the update mode, or skip checking dataset already loaded.')
-    parser.add_argument('--compression', choices={'gzip', 'lzf', None}, default=None,
-                        help='compress loaded geometry while writing HDF5 file, default: None.')
 
     return parser
 

--- a/src/mintpy/cli/prep_aria.py
+++ b/src/mintpy/cli/prep_aria.py
@@ -73,8 +73,9 @@ def create_parser(subparsers=None):
                         help='output HDF5 file')
     parser.add_argument('--update', dest='updateMode', action='store_true',
                         help='Enable the update mode: checking dataset already loaded.')
-    parser.add_argument('--compression', choices={'gzip', 'lzf', None}, default=None,
-                        help='HDF5 file compression, default: %(default)s')
+    parser.add_argument('--compression', choices={'gzip', 'lzf', None, 'default'}, default='default',
+                        help='HDF5 file compression, default: %(default)s'+
+                             '  default: None for stack, lzf for geometry.')
 
     # ifgramStack
     stack = parser.add_argument_group('interferogram stack')

--- a/src/mintpy/defaults/smallbaselineApp.cfg
+++ b/src/mintpy/defaults/smallbaselineApp.cfg
@@ -29,7 +29,7 @@ mintpy.compute.config    = auto #[none / slurm / pbs / lsf ], auto for none (sam
 mintpy.load.processor       = auto  #[isce, aria, hyp3, gmtsar, snap, gamma, roipac, nisar], auto for isce
 mintpy.load.autoPath        = auto  #[yes / no], auto for no, use pre-defined auto path
 mintpy.load.updateMode      = auto  #[yes / no], auto for yes, skip re-loading if HDF5 files are complete
-mintpy.load.compression     = auto  #[gzip / lzf / no], auto for no.
+mintpy.load.compression     = auto  #[gzip / lzf / none / default], auto for default (none/lzf for stack/geometry).
 ##---------for ISCE only:
 mintpy.load.metaFile        = auto  #[path of common metadata file for the stack], i.e.: ./reference/IW1.xml, ./referenceShelve/data.dat
 mintpy.load.baselineDir     = auto  #[path of the baseline dir], i.e.: ./baselines

--- a/src/mintpy/defaults/smallbaselineApp_auto.cfg
+++ b/src/mintpy/defaults/smallbaselineApp_auto.cfg
@@ -10,7 +10,7 @@ mintpy.compute.config    = none
 mintpy.load.processor    = isce
 mintpy.load.autoPath     = no
 mintpy.load.updateMode   = yes
-mintpy.load.compression  = no
+mintpy.load.compression  = default
 ##-------subset (optional)
 mintpy.subset.yx         = no
 mintpy.subset.lalo       = no

--- a/src/mintpy/load_data.py
+++ b/src/mintpy/load_data.py
@@ -103,9 +103,6 @@ def read_inps2dict(inps):
             iDict[prefix+key] = template[prefix+key]
     print('processor : {}'.format(iDict['processor']))
 
-    if iDict['compression'] is False:
-        iDict['compression'] = None
-
     # group - multilook
     prefix = 'mintpy.multilook.'
     key_list = [i.split(prefix)[1] for i in template.keys() if i.startswith(prefix)]
@@ -199,7 +196,7 @@ def read_subset_box(iDict):
     if geo_box is not None:
         pix_box = coord.bbox_geo2radar(geo_box)
         pix_box = coord.check_box_within_data_coverage(pix_box)
-        print(f'input bounding box of interest in lalo: {geo_box}')
+        print(f'input bounding box of interest in lat/lon: {geo_box}')
     print(f'box to read for datasets in y/x: {pix_box}')
 
     # Get box for geocoded lookup table (for gamma/roipac)
@@ -837,6 +834,9 @@ def load_data(inps):
     geom_geo_file = os.path.abspath('./inputs/geometryGeo.h5')
     geom_radar_file = os.path.abspath('./inputs/geometryRadar.h5')
 
+    # use 'lzf' HDF compression for a significantly smaller geometry file size, w/o much impact on the performance
+    compression = 'lzf' if iDict['compression'] == 'default' else iDict['compression']
+
     if run_or_skip(geom_geo_file, geom_geo_obj, iDict['box4geo'], **kwargs) == 'run':
         geom_geo_obj.write2hdf5(
             outputFile=geom_geo_file,
@@ -844,7 +844,7 @@ def load_data(inps):
             box=iDict['box4geo'],
             xstep=iDict['xstep'],
             ystep=iDict['ystep'],
-            compression=iDict['compression'])
+            compression=compression)
 
     if run_or_skip(geom_radar_file, geom_radar_obj, iDict['box'], **kwargs) == 'run':
         geom_radar_obj.write2hdf5(
@@ -853,7 +853,7 @@ def load_data(inps):
             box=iDict['box'],
             xstep=iDict['xstep'],
             ystep=iDict['ystep'],
-            compression=iDict['compression'],
+            compression=compression,
             extra_metadata=extraDict)
 
     # observations: ifgram, ion or offset
@@ -865,8 +865,9 @@ def load_data(inps):
     ]
     stack_files = ['ifgramStack.h5', 'ionStack.h5', 'offsetStack.h5']
     stack_files = [os.path.abspath(os.path.join('./inputs', x)) for x in stack_files]
-    for ds_name2tmpl_opt, stack_file in zip(stack_ds_name2tmpl_key_list, stack_files):
+    compression = None if iDict['compression'] == 'default' else iDict['compression']
 
+    for ds_name2tmpl_opt, stack_file in zip(stack_ds_name2tmpl_key_list, stack_files):
         # initiate dict objects
         stack_obj = read_inps_dict2ifgram_stack_dict_object(iDict, ds_name2tmpl_opt)
 
@@ -884,7 +885,7 @@ def load_data(inps):
                 xstep=iDict['xstep'],
                 ystep=iDict['ystep'],
                 mli_method=iDict['method'],
-                compression=iDict['compression'],
+                compression=compression,
                 extra_metadata=extraDict,
                 geom_obj=geom_obj)
 

--- a/src/mintpy/prep_aria.py
+++ b/src/mintpy/prep_aria.py
@@ -589,7 +589,7 @@ def load_aria(inps):
             inps.outfile[0],
             ds_name_dict,
             metadata=meta,
-            compression=inps.compression,
+            compression=None if inps.compression == 'default' else inps.compression,
         )
 
         write_ifgram_stack(
@@ -623,7 +623,7 @@ def load_aria(inps):
             inps.outfile[1],
             ds_name_dict,
             metadata=meta,
-            compression=inps.compression,
+            compression='lzf' if inps.compression == 'default' else inps.compression,
         )
 
         # write data to disk
@@ -661,7 +661,7 @@ def load_aria(inps):
                 outname,
                 ds_name_dict,
                 metadata=meta,
-                compression=inps.compression,
+                compression=None if inps.compression == 'default' else inps.compression,
                 )
 
             # write data to disk
@@ -706,7 +706,7 @@ def load_aria(inps):
                     f'{out_dir}/{layer_name}_ARIA.h5',
                     ds_name_dict,
                     metadata=meta,
-                    compression=inps.compression,
+                    compression=None if inps.compression == 'default' else inps.compression,
                     )
 
                 # write data to disk


### PR DESCRIPTION
**Description of proposed changes**

changed 'lzf' to iDict['compression']

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->
loading of geometry radar.h5 was choosing 'lzf' as the compression method despite specifying something else in the config file. 

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Bug Fixes:
- Fixed hardcoded compression method when saving geometry radar data to .h5 files, now using the compression method specified in the configuration dictionary