### PR TITLE
Add `save_gdal.py --mask/--zero-mask` options

### DIFF
--- a/src/mintpy/cli/save_gdal.py
+++ b/src/mintpy/cli/save_gdal.py
@@ -15,6 +15,8 @@ EXAMPLE = """example:
   save_gdal.py geo/geo_ifgramStack.h5 -d unwrapPhase-20101120_20110220 --of ISCE
   save_gdal.py geo/geo_ifgramStack.h5 -d   coherence-20101120_20110220 --of ISCE
   save_gdal.py geo_20230225.slc
+  save_gdal.py geo/timeseries.h5 -d 20230217 -m maskTempCoh.h5
+  save_gdal.py geo/timeseries.h5 -d 20230217 --zero-mask
 """
 
 

--- a/src/mintpy/cli/save_gdal.py
+++ b/src/mintpy/cli/save_gdal.py
@@ -9,6 +9,7 @@
 import sys
 
 from mintpy.utils.arg_utils import create_argument_parser
+
 EXAMPLE = """example:
   save_gdal.py geo/geo_velocity.h5
   save_gdal.py geo/geo_timeseries_ERA5_demErr.h5  -d 20200505_20200517 --of ENVI
@@ -33,11 +34,11 @@ def create_parser(subparsers=None):
     parser.add_argument('-o', '--output', dest='outfile',
                         help='output file base name. Extension is fixed by GDAL driver')
     parser.add_argument('-m','--mask', dest='mask_file', metavar='FILE',
-                        help='mask file for display')
-    parser.add_argument('--zero-mask', dest='zero_mask', action='store_true',
-                        help='Mask pixels with zero value.')
+                        help='mask file (default: %(default)s).')
+    parser.add_argument('--zm','--zero-mask', dest='zero_mask', action='store_true',
+                        help='Mask pixels with zero value (default: %(default)s)..')
     parser.add_argument('--of', '--out-format', '--output-format', dest='out_format', default='GTiff',
-                        help='file format as defined by GDAL driver name, e.g. GTiff, ENVI, default: %(default)s\n'
+                        help='file format as defined by GDAL driver name, e.g. GTiff, ENVI (default: %(default)s).\n'
                              'GDAL driver names can be found at https://gdal.org/drivers/raster/index.html')
     return parser
 

--- a/src/mintpy/cli/save_gdal.py
+++ b/src/mintpy/cli/save_gdal.py
@@ -9,7 +9,6 @@
 import sys
 
 from mintpy.utils.arg_utils import create_argument_parser
-
 EXAMPLE = """example:
   save_gdal.py geo/geo_velocity.h5
   save_gdal.py geo/geo_timeseries_ERA5_demErr.h5  -d 20200505_20200517 --of ENVI
@@ -31,6 +30,10 @@ def create_parser(subparsers=None):
                         help='date of timeseries, or date12 of interferograms to be converted')
     parser.add_argument('-o', '--output', dest='outfile',
                         help='output file base name. Extension is fixed by GDAL driver')
+    parser.add_argument('-m','--mask', dest='mask_file', metavar='FILE',
+                        help='mask file for display')
+    parser.add_argument('--zero-mask', dest='zero_mask', action='store_true',
+                        help='Mask pixels with zero value.')
     parser.add_argument('--of', '--out-format', '--output-format', dest='out_format', default='GTiff',
                         help='file format as defined by GDAL driver name, e.g. GTiff, ENVI, default: %(default)s\n'
                              'GDAL driver names can be found at https://gdal.org/drivers/raster/index.html')

--- a/src/mintpy/save_gdal.py
+++ b/src/mintpy/save_gdal.py
@@ -116,17 +116,19 @@ def save_gdal(inps):
         data -= readfile.read(inps.file, datasetName=inps.ref_date)[0]
 
     # mask
-    mask = pp.read_mask(
-        inps.file,
-        mask_file=inps.mask_file,
-        datasetName=inps.dset)[0]
-    if mask is not None:
-        print(f'masking out pixels with zero value in file: {inps.mask_file}')
-        data[mask == 0] = np.nan
+    if inps.mask_file:
+        mask = pp.read_mask(
+            inps.file,
+            mask_file=inps.mask_file,
+            datasetName=inps.dset)[0]
+        if mask is not None:
+            print(f'masking out pixels with zero value in file: {inps.mask_file}')
+            data[mask == 0] = np.nan
+        del mask
     if inps.zero_mask:
         print('masking out pixels with zero value')
         data[data == 0] = np.nan
-    del mask
+
 
     ## write file
     # output file name

--- a/src/mintpy/save_gdal.py
+++ b/src/mintpy/save_gdal.py
@@ -115,6 +115,19 @@ def save_gdal(inps):
         print(f'read {inps.ref_date} from file: {inps.file}')
         data -= readfile.read(inps.file, datasetName=inps.ref_date)[0]
 
+    # mask
+    mask = pp.read_mask(
+        inps.file,
+        mask_file=inps.mask_file,
+        datasetName=inps.dset)[0]
+    if mask is not None:
+        print(f'masking out pixels with zero value in file: {inps.mask_file}')
+        data[mask == 0] = np.nan
+    if inps.zero_mask:
+        print('masking out pixels with zero value')
+        data[data == 0] = np.nan
+    del mask
+
     ## write file
     # output file name
     if not inps.outfile:

--- a/src/mintpy/save_gdal.py
+++ b/src/mintpy/save_gdal.py
@@ -129,8 +129,7 @@ def save_gdal(inps):
         print('masking out pixels with zero value')
         data[data == 0] = np.nan
 
-
-    ## write file
+    ## write data to file
     # output file name
     if not inps.outfile:
         fbase = pp.auto_figure_title(inps.file, inps.dset, vars(inps))


### PR DESCRIPTION
This PR adds support for the `-m` and `--zero-mask` command-line arguments to the `save_gdal.py` CLI, allowing users to:

- `-m /path/to/mask`: Apply a custom mask file (e.g. maskTempCoh.h5) to exclude invalid pixels.
- `--zero-mask`: Automatically mask all zero-valued pixels in the data array.

### Changes
- Updated `save_gdal.py` to accept and handle `inps.mask_file` and `inps.zero_mask`.
- Applied masking logic before writing output using `data[mask == 0] = np.nan` and `data[data == 0] = np.nan`.

**Reminders**

- [X] Fix #1254 
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [X] Make sure that your code follows our style. Use the other functions/files as a basis.
- [X] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [X] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Add support for custom and zero-value masking to the save_gdal.py command-line interface and apply the masking logic prior to output generation

New Features:
- Add `-m/--mask` argument to save_gdal.py CLI for specifying a custom mask file
- Add `--zero-mask` flag to automatically mask zero-valued pixels before writing output

Enhancements:
- Apply masking logic in save_gdal.py using the provided mask file and zero-mask option before file export