### PR TITLE
`circleci`: update `miniforge` setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,10 @@ jobs:
             # install miniforge
             mkdir -p ${HOME}/tools
             cd ${HOME}/tools
-            wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-            bash Miniforge3-Linux-x86_64.sh -b -p ${HOME}/tools/miniforge
-            ${HOME}/tools/miniforge/bin/mamba init bash
+            wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+            bash Miniforge3.sh -b -p ${HOME}/tools/miniforge
+            source "${HOME}/tools/miniforge/etc/profile.d/conda.sh"
+            source "${HOME}/tools/miniforge/etc/profile.d/mamba.sh"
             # modify/export env var PATH to BASH_ENV to be shared across run steps
             echo 'export PATH=${CONDA_PREFIX}/bin:${PATH}' >> ${BASH_ENV}
 


### PR DESCRIPTION
**Description of proposed changes**

+ `.circleci/config.yml`: replace `mamba init bash` with `source conda/mamba.sh`, as suggested by its GitHub repo readme at https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline, to fix the current circle CI environment setup error.

**Reminders**

- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.