### PR TITLE
`ts2vel`: add `--rm-timefun` option for customized TS clean up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,37 +53,37 @@ jobs:
             ${MINTPY_HOME}/tests/dem_error.py
 
       - run:
-          name: Integration Test 1 - FernandinaSenDT128 (ISCE2/topsStack)
+          name: Integration Test 1/6 - FernandinaSenDT128 (ISCE2/topsStack)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset FernandinaSenDT128
 
       - run:
-          name: Integration Test 2 - SanFranSenDT42 (ARIA)
+          name: Integration Test 2/6 - SanFranSenDT42 (ARIA)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranSenDT42
 
       - run:
-          name: Integration Test 3 - RidgecrestSenDT71 (HyP3)
+          name: Integration Test 3/6 - RidgecrestSenDT71 (HyP3)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset RidgecrestSenDT71
 
       - run:
-          name: Integration Test 4 - SanFranBaySenD42 (GMTSAR)
+          name: Integration Test 4/6 - SanFranBaySenD42 (GMTSAR)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset SanFranBaySenD42
 
       - run:
-          name: Integration Test 5 - WellsEnvD2T399 (Gamma)
+          name: Integration Test 5/6 - WellsEnvD2T399 (Gamma)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WellsEnvD2T399
 
       - run:
-          name: Integration Test 6 - WCapeSenAT29 (SNAP)
+          name: Integration Test 6/6 - WCapeSenAT29 (SNAP)
           command: |
             mkdir -p ${HOME}/data
             ${MINTPY_HOME}/tests/smallbaselineApp.py --dir ${HOME}/data --dset WCapeSenAT29

--- a/src/mintpy/cli/geocode.py
+++ b/src/mintpy/cli/geocode.py
@@ -113,7 +113,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check
     if inps.templateFile:

--- a/src/mintpy/cli/ifgram_inversion.py
+++ b/src/mintpy/cli/ifgram_inversion.py
@@ -132,7 +132,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check
     atr = readfile.read_attribute(inps.ifgramStackFile)

--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -78,7 +78,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # default: auxiliary file paths (velocity and template)
     mintpy_dir = os.path.dirname(os.path.dirname(inps.ifgram_file))

--- a/src/mintpy/cli/plot_network.py
+++ b/src/mintpy/cli/plot_network.py
@@ -114,7 +114,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check: input file type
     if inps.file.endswith(('.h5','.he5')):

--- a/src/mintpy/cli/plot_transection.py
+++ b/src/mintpy/cli/plot_transection.py
@@ -88,7 +88,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check: coupled options
     if inps.outfile or not inps.disp_fig:

--- a/src/mintpy/cli/save_gbis.py
+++ b/src/mintpy/cli/save_gbis.py
@@ -62,7 +62,7 @@ def cmd_line_parse(iargs=None):
     parser = create_parser()
     inps = parser.parse_args(args=iargs)
 
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
     print('{} {}'.format(os.path.basename(__file__), ' '.join(inps.argv)))
 
     return inps

--- a/src/mintpy/cli/smallbaselineApp.py
+++ b/src/mintpy/cli/smallbaselineApp.py
@@ -90,7 +90,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check
     template_file = os.path.join(os.path.dirname(mintpy.__file__), 'defaults/smallbaselineApp.cfg')

--- a/src/mintpy/cli/timeseries2velocity.py
+++ b/src/mintpy/cli/timeseries2velocity.py
@@ -203,7 +203,7 @@ def cmd_line_parse(iargs=None):
             print(f'output velocity file: {inps.outfile}')
 
     # default: --res-file option (for specified time function components)
-    if '--res-file' not in inps.argv and 'all' not in inps.rm_timefuns:
+    if inps.save_res and '--res-file' not in inps.argv and 'all' not in inps.rm_timefuns:
         suffix = '_'.join(inps.rm_timefuns)
         inps.res_file = f'{os.path.splitext(inps.timeseries_file)[0]}_{suffix}.h5'
         print(f'output residual time series file: {inps.res_file}')

--- a/src/mintpy/cli/timeseries2velocity.py
+++ b/src/mintpy/cli/timeseries2velocity.py
@@ -112,7 +112,7 @@ def create_parser(subparsers=None):
     resid.add_argument('--res-file', dest='res_file', default='timeseriesResidual.h5',
                        help='Output file name for the residual time-series file (default: %(default)s).')
     resid.add_argument('--rm-timefun', dest='rm_timefuns', nargs='*', default=['all'],
-                       choices={'all', 'polynomial' , 'periodic', 'step', 'polyline', 'exp', 'log'},
+                       choices=['all', 'polynomial', 'periodic', 'step', 'polyline', 'exp', 'log'],
                        help='Specify the time functions to be removed from the input (default: %(default)s).')
 
     # computing

--- a/src/mintpy/cli/timeseries2velocity.py
+++ b/src/mintpy/cli/timeseries2velocity.py
@@ -133,7 +133,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check
     atr = readfile.read_attribute(inps.timeseries_file)

--- a/src/mintpy/cli/timeseries_rms.py
+++ b/src/mintpy/cli/timeseries_rms.py
@@ -64,7 +64,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     return inps
 

--- a/src/mintpy/cli/tsview.py
+++ b/src/mintpy/cli/tsview.py
@@ -122,7 +122,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check: --gnss-comp option (not implemented for tsview yet)
     if inps.gnss_component:

--- a/src/mintpy/cli/view.py
+++ b/src/mintpy/cli/view.py
@@ -108,7 +108,7 @@ def cmd_line_parse(iargs=None):
     # save argv (to check the manually specified arguments)
     # use iargs        for python call
     # use sys.argv[1:] for command line call
-    inps.argv = iargs if iargs else sys.argv[1:]
+    inps.argv = iargs or sys.argv[1:]
 
     # check: invalid file inputs
     for key in ['file','dem_file','mask_file','pts_file']:

--- a/src/mintpy/timeseries2velocity.py
+++ b/src/mintpy/timeseries2velocity.py
@@ -439,7 +439,7 @@ def run_timeseries2time_func(inps):
             if 'all' in inps.rm_timefuns:
                 ts_res[:, mask] = ts_data - np.dot(G, m)[:, mask]
             else:
-                rm_ds_names, rm_ds_inds = timefun_names2ds_names(inps.rm_timefuns, ds_dict.keys())
+                rm_ds_inds = timefun_names2ds_names(inps.rm_timefuns, ds_dict.keys())[1]
                 ts_res[:, mask] = ts_data - np.dot(G[:, rm_ds_inds], m[rm_ds_inds, :])[:, mask]
 
             # write to HDF5 file


### PR DESCRIPTION
**Description of proposed changes**

+ add `timeseries2velocity.py --rm-timfun / --remove-time-functions` option to specify the time function components to be removed from the residual file, for customized TS clean up, like GNSS time series.

+ add timefun_names2ds_names() to translate the spcified time function names to the corresponding dataset names/index in the design matrix, to facilitate the customized TS clean up.

+ set default output vel/res filenames for --rm-timefun options

+ `.circleci/config.yml`: show total num of integration tests for more informative status

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2895) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.