### PR TITLE
`tropo_pyaps3`: check `~/.cdsapirc` file content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             apt update
             apt-get update --yes && apt-get upgrade --yes
             apt-get install --yes git wget
-            # install miniforge
+            # install miniforge (https://github.com/conda-forge/miniforge?tab=readme-ov-file#as-part-of-a-ci-pipeline)
             mkdir -p ${HOME}/tools
             cd ${HOME}/tools
             wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"

--- a/src/mintpy/objects/stack.py
+++ b/src/mintpy/objects/stack.py
@@ -1195,7 +1195,7 @@ class ifgramStack:
         # to avoid the abnormal result as shown in https://github.com/insarlab/MintPy/pull/1063
         # This may be caused by the phase stitching during product preparation via ARIA-tools,
         # which could have broken the temporal consistency of the native unwrapped phase.
-        processor = self.metadata.get('mintpy.load.processor', 'isce')
+        processor = self.metadata.get('mintpy.load.processor', self.metadata.get('PROCESSOR', 'isce'))
         if ds_name == 'unwrapPhase' and processor in ['aria']:
             print(f'apply spatial referencing to {processor} products')
             ref_phase = self.get_reference_phase(dropIfgram=False)

--- a/src/mintpy/subset.py
+++ b/src/mintpy/subset.py
@@ -475,7 +475,6 @@ def read_aux_subset2inps(inps):
             and (inps.subset_y is None and inps.subset_x is None)
             and inps.lookup_file is not None):
         print('convert bounding box in lat/lon to y/x')
-        print(f'input bounding box in lat/lon: {geo_box}')
         if not os.path.isfile(inps.lookup_file):
             raise FileNotFoundError(f'lookup file {inps.lookup_file} NOT found!')
 
@@ -485,6 +484,7 @@ def read_aux_subset2inps(inps):
                    inps.subset_lon[1], inps.subset_lat[0])    # (W, N, E, S)
         pix_box = coord.bbox_geo2radar(geo_box, buf=0)
         pix_box = coord.check_box_within_data_coverage(pix_box)
+        print(f'input bounding box in lat/lon: {geo_box}')
         print(f'box to read for datasets in y/x: {pix_box}')
 
         # update inps

--- a/src/mintpy/tropo_pyaps3.py
+++ b/src/mintpy/tropo_pyaps3.py
@@ -415,39 +415,40 @@ def check_pyaps_account_config(tropo_model):
     Parameters: tropo_model - str, tropo model being used to calculate tropospheric delay
     Returns:    None
     """
-    # Convert MintPy tropo model name to data archive center name
-    # NARR model included for completeness but no key required
-    MODEL2ARCHIVE_NAME = {
-        'ERA5' : 'CDS',
-        'ERAI' : 'ECMWF',
-        'MERRA': 'MERRA',
-        'NARR' : 'NARR',
-    }
-    SECTION_OPTS = {
-        'CDS'  : ['key'],
-        'ECMWF': ['email', 'key'],
-        'MERRA': ['user', 'password'],
-    }
-
-    # Default values in cfg file
-    default_values = [
-        'the-email-address-used-as-login@ecmwf-website.org',
-        'the-user-name-used-as-login@earthdata.nasa.gov',
-        'the-password-used-as-login@earthdata.nasa.gov',
-        'the-email-adress-used-as-login@ucar-website.org',
-        'your-uid:your-api-key',
-    ]
-
-    # account file for pyaps3 < and >= 0.3.0
-    cfg_file = os.path.join(os.path.dirname(pa.__file__), 'model.cfg')
+    # account file
     rc_file = os.path.expanduser('~/.cdsapirc')
+    cfg_file = os.path.join(os.path.dirname(pa.__file__), 'model.cfg')
 
     # for ERA5: ~/.cdsapirc
     if tropo_model == 'ERA5' and os.path.isfile(rc_file):
-        pass
+        fc = np.loadtxt('.cdsapirc', dtype=str)
+        if not (fc[0,0] == 'url:' and fc[0,1] == 'https://cds.climate.copernicus.eu/api'):
+            raise ValueError('CDS account is NOT setup to the latest format! Check https://github.com/insarlab/PyAPS/.')
 
     # check account info for the following models
     elif tropo_model in ['ERA5', 'ERAI', 'MERRA']:
+        # Convert MintPy tropo model name to data archive center name
+        # NARR model included for completeness but no key required
+        MODEL2ARCHIVE_NAME = {
+            'ERA5' : 'CDS',
+            'ERAI' : 'ECMWF',
+            'MERRA': 'MERRA',
+            'NARR' : 'NARR',
+        }
+        SECTION_OPTS = {
+            'CDS'  : ['key'],
+            'ECMWF': ['email', 'key'],
+            'MERRA': ['user', 'password'],
+        }
+        # Default values in cfg file
+        default_values = [
+            'the-email-address-used-as-login@ecmwf-website.org',
+            'the-user-name-used-as-login@earthdata.nasa.gov',
+            'the-password-used-as-login@earthdata.nasa.gov',
+            'the-email-adress-used-as-login@ucar-website.org',
+            'your-uid:your-api-key',
+        ]
+
         section = MODEL2ARCHIVE_NAME[tropo_model]
 
         # Read model.cfg file
@@ -476,7 +477,7 @@ def dload_grib_files(grib_files, tropo_model='ERA5', snwe=None, debug_mode=False
     Returns:    grib_files  - list of string of grib files after downloading
     """
     print('-'*50)
-    print('downloading weather model data using PyAPS ...')
+    print(f'downloading weather model data using PyAPS (version {pa.__version__}) ...')
 
     # Get date list to download (skip already downloaded files)
     grib_files_exist = check_exist_grib_file(grib_files, print_msg=True)

--- a/tests/smallbaselineApp.py
+++ b/tests/smallbaselineApp.py
@@ -30,7 +30,7 @@ DSET_INFO = {
         'url':'https://zenodo.org/record/6662079/files/SanFranSenDT42.tar.xz',      # 280 MB
     },
     'RidgecrestSenDT71':{
-        'processor':'ASF HyP3',
+        'processor':'HyP3',
         'url':'https://zenodo.org/record/11049257/files/RidgecrestSenDT71.tar.xz',  # 240 MB
     },
     'SanFranBaySenD42':{


### PR DESCRIPTION
**Description of proposed changes**

+ `tropo_pyaps3`: check ~/.cdsapirc file content for account setup
   - `check_pyaps_account_config()`: check the url address for CDS to ensure it's consistent with the latest CDS format
   - `dload_grib_files()`: printout the pyaps3 version, to facilitate the debugging.

+ other minor bug fixes and comment update
   - `subset`: bugfix for the print out msg of `geo_box`
   - `objects.stack.ifgramStack.get_sequential_closure_phase()`: grab processor info from PROCESSOR, if mintpy.load.processor does not exist
   - `tests.smallbaselineApp`: use HyP3 instead of ASF HyP3.
   - `.circleci/config.yml`: add link in the comment for miniforge

**Reminders**

- [x] Fix #1232 
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2913) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

## Summary by Sourcery

Add content validation for ~/.cdsapirc in tropo_pyaps3, enhance download logging and fix minor bugs across subset, stack, tests, and CI configuration.

New Features:
- Validate ~/.cdsapirc URL format for ERA5 model setup in tropo_pyaps3

Bug Fixes:
- Correct processor name in smallbaselineApp tests from 'ASF HyP3' to 'HyP3'

Enhancements:
- Print PyAPS version in dload_grib_files download logs
- Fallback to PROCESSOR metadata in get_sequential_closure_phase when mintpy.load.processor is missing
- Move and correct geo_box print position in subset.py
- Add link to Miniforge repository in CircleCI config comment