### PR TITLE
update for GDAL version 3.9+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,7 @@ jobs:
           command: |
             export PYTHONUNBUFFERED=1
             # install dependencies and source code
-            # pin gdal version as "<=3.8" because:
-            # 1) gdal-3.9 could not read the GMT-6 *.grd file properly
-            # 2) gdal-3.9 could not be imported in circle CI (https://github.com/insarlab/MintPy/issues/1220)
-            mamba install --verbose --yes --file ${MINTPY_HOME}/requirements.txt gdal"<=3.8"
+            mamba install --verbose --yes --file ${MINTPY_HOME}/requirements.txt gdal libgdal-netcdf
             python -m pip install ${MINTPY_HOME}
             # test installation
             smallbaselineApp.py -h

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ Install dependencies into a new environment, e.g. named "insar":
 # Add "isce2"               below to install extra dependencies if you use ISCE-2
 # Add "gdal"                below to install extra dependencies if you use ARIA, FRInGE, HyP3
 # Add "gdal libgdal-netcdf" below to install extra dependencies if you use GMTSAR
-mamba create --name insar --file ~/tools/MintPy/requirements.txt isce2
+mamba create --name insar --file ~/tools/MintPy/requirements.txt
 ```
 
 or install dependencies into an existing environment:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,18 +79,18 @@ bash Miniforge3-Linux-x86_64.sh -b -p ~/tools/miniforge
 Install dependencies into a new environment, e.g. named "insar":
 
 ```bash
-# Add "isce2"      below to install extra dependencies if you use ISCE-2
-# Add "gdal"       below to install extra dependencies if you use ARIA, FRInGE or HyP3
-# Add "gdal'<3.9'" below to install extra dependencies if you use GMTSAR
-mamba create --name insar --file ~/tools/MintPy/requirements.txt
+# Add "isce2"               below to install extra dependencies if you use ISCE-2
+# Add "gdal"                below to install extra dependencies if you use ARIA, FRInGE, HyP3
+# Add "gdal libgdal-netcdf" below to install extra dependencies if you use GMTSAR
+mamba create --name insar --file ~/tools/MintPy/requirements.txt isce2
 ```
 
 or install dependencies into an existing environment:
 
 ```bash
-# Add "isce2"      below to install extra dependencies if you use ISCE-2
-# Add "gdal"       below to install extra dependencies if you use ARIA, FRInGE or HyP3
-# Add "gdal'<3.9'" below to install extra dependencies if you use GMTSAR
+# Add "isce2"               below to install extra dependencies if you use ISCE-2
+# Add "gdal"                below to install extra dependencies if you use ARIA, FRInGE, HyP3
+# Add "gdal libgdal-netcdf" below to install extra dependencies if you use GMTSAR
 mamba activate my-existing-env
 mamba install --file ~/tools/MintPy/requirements.txt
 ```

--- a/src/mintpy/objects/ionex.py
+++ b/src/mintpy/objects/ionex.py
@@ -459,6 +459,7 @@ def plot_ionex(tec_file, save_fig=False):
     from cartopy import crs as ccrs
     from matplotlib import pyplot as plt
     from matplotlib.animation import FuncAnimation
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
 
     from mintpy.utils.map import draw_lalo_label, round_to_1
 
@@ -478,14 +479,14 @@ def plot_ionex(tec_file, save_fig=False):
 
     # init figure
     proj_obj = ccrs.PlateCarree()
-    fig, ax = plt.subplots(figsize=[9, 4], subplot_kw=dict(projection=proj_obj))
+    fig, ax = plt.subplots(figsize=[8, 4], subplot_kw=dict(projection=proj_obj))
     im = ax.imshow(
         tec_maps[0,:,:], vmin=0, vmax=vmax,
         extent=(W, E, S, N), origin='upper',
         animated=True, interpolation='nearest',
     )
 
-    ax.coastlines()
+    cl = ax.coastlines()
     draw_lalo_label(
         ax,
         geo_box=(W, N, E, S),
@@ -494,7 +495,9 @@ def plot_ionex(tec_file, save_fig=False):
     )
 
     # colorbar
-    cbar = fig.colorbar(im, shrink=0.5)
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size="1.5%", pad=0.05, axes_class=plt.Axes)
+    cbar = fig.colorbar(im, cax=cax)
     cbar.set_label('TECU')
     fig.tight_layout()
 
@@ -510,12 +513,13 @@ def plot_ionex(tec_file, save_fig=False):
 
         # update image & title
         im.set_array(tec_maps[ind,:,:])
+        cl.set_visible(True)
         dt_obj = date_obj + dt.timedelta(minutes=mins[ind])
         ax.set_title(f'{dt_obj.isoformat()} - {sol_name}')
-        return im,
+        return im, cl
 
     # play animation
-    ani = FuncAnimation(fig, animate, interval=200, blit=True, save_count=num_map)
+    ani = FuncAnimation(fig, animate, interval=200, blit=False, save_count=num_map)
 
     # output
     out_fig = f'{os.path.abspath(tec_file)}.gif'

--- a/src/mintpy/utils/map.py
+++ b/src/mintpy/utils/map.py
@@ -18,7 +18,7 @@ from matplotlib import pyplot as plt
 ##########################################  Lat/Lon Labels  ##########################################
 
 def draw_lalo_label(ax, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1], lalo_max_num=4, lalo_offset=None,
-                    direction='in', projection=ccrs.PlateCarree(), font_size=None, print_msg=True):
+                    *, direction='in', projection=ccrs.PlateCarree(), font_size=None, print_msg=True):
     """Auto draw lat/lon label/tick based on coverage from geo_box
     Parameters: ax           : cartopy axes.
                 geo_box      : 4-tuple of float, (W, N, E, S) in degree

--- a/src/mintpy/utils/map.py
+++ b/src/mintpy/utils/map.py
@@ -18,7 +18,7 @@ from matplotlib import pyplot as plt
 ##########################################  Lat/Lon Labels  ##########################################
 
 def draw_lalo_label(ax, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1], lalo_max_num=4, lalo_offset=None,
-                    projection=ccrs.PlateCarree(), font_size=None, print_msg=True):
+                    direction='in', projection=ccrs.PlateCarree(), font_size=None, print_msg=True):
     """Auto draw lat/lon label/tick based on coverage from geo_box
     Parameters: ax           : cartopy axes.
                 geo_box      : 4-tuple of float, (W, N, E, S) in degree
@@ -28,6 +28,7 @@ def draw_lalo_label(ax, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1], lalo_max
                 lalo_max_num : int, maximum number of major ticks for X/Y axes
                 lalo_offset  : float, distance in points between tick and label.
                                Set to negative value to move the ticklabel inside the plot.
+                direction    : str, tick direction, in or out.
                 projection   : cartopy.crs object
                 ...
     Example:    geo_box = (128.0, 37.0, 138.0, 30.0)
@@ -42,7 +43,7 @@ def draw_lalo_label(ax, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1], lalo_max
         print(f'plot lat/lon label in step of {lalo_step} and location of {lalo_loc}')
 
     # ticklabel/tick style
-    ax.tick_params(which='both', direction='in', labelsize=font_size,
+    ax.tick_params(which='both', direction=direction, labelsize=font_size,
                    left=True, right=True, top=True, bottom=True,
                    labelleft=lalo_loc[0], labelright=lalo_loc[1],
                    labeltop=lalo_loc[2], labelbottom=lalo_loc[3])

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
-gdal<=3.8       # for ISCE-2/3, ARIA, FRInGE, HyP3, GMTSAR users; gdal-3.9 could not read GMT *.grd file's coordinate info properly [for GMTSAR]
-isce2           # for ISCE-2 users
+gdal            # for users of ISCE-2/3, ARIA, FRInGE, HyP3, GMTSAR users
+libgdal-netcdf  # for users of GMTSAR users
+isce2           # for users of ISCE-2 users
 pre-commit      # for developers
 pyfftw
 setuptools_scm


### PR DESCRIPTION
**Description of proposed changes**

+ `.circleci/config.yml`: unpin `gdal<=3.8` constraint (https://github.com/insarlab/MintPy/pull/1235) as the issue seems to have been fixed by the latest version 3.11 (it occurred on gdal-3.9.0, I have not tested on other gdal-3.9.x versions)

+ GDAL-3.9 did a huge split. As a result, the `netCDF` driver (packaged as `libgdal-netcdf`), as required by GMTSAR, needs to be explicitly specified in the environment. This PR address this dependency change and update the related documentation.

+ minor updated related to IONEX plotting via `ionex.plot_ionex()`: show coastline in the animation
   - add `cl.set_visible(True)`
   - set `FuncAnimation(blit=False)`
   - use `mpl_toolkits.axes_grid1.make_axes_locatable()` for a more compact whitespace around the axes

+ `utils.map.draw_lalo_label()`: add `direction` option to change the tick direction

**Reminders**

- [x] Fix #1236 
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2922) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

## Summary by Sourcery

Support GDAL 3.9+ by unpinning the GDAL version constraint and explicitly requiring libgdal-netcdf across docs, CI, and tests. Add configurable tick direction to map utilities and refine IONEX plotting to show coastlines, improve colorbar placement, and disable blitting for animations.

Enhancements:
- Unpin GDAL version constraint and add libgdal-netcdf requirement to support GDAL 3.9+.
- Add `direction` parameter to `draw_lalo_label` for configurable tick orientation.
- Enhance `plot_ionex` to display coastline, optimize colorbar layout, adjust figure size, and disable blitting for animations.

CI:
- Update CircleCI config to unpin GDAL and install `libgdal-netcdf`.

Documentation:
- Update installation guide to include `libgdal-netcdf` for GMTSAR dependencies.

Tests:
- Modify test requirements to remove GDAL version pin and add `libgdal-netcdf`.