### PR TITLE
bugfixes in `cood` & `tropo_pyaps3`

### DIFF
--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -194,14 +194,23 @@ class coordinate:
         To support point outside of value pool/matrix, could use np.polyfit to fit a line
         for y and x value buffer and return the intersection point row/col
         """
-        ymin = y - y_factor;  ymax = y + y_factor
-        xmin = x - x_factor;  xmax = x + x_factor
-        if not geo_coord:
-            ymin = max(ymin, 0.5)
-            xmin = max(xmin, 0.5)
-        mask_y = np.multiply(self.lut_y >= ymin, self.lut_y <= ymax)
-        mask_x = np.multiply(self.lut_x >= xmin, self.lut_x <= xmax)
-        mask_yx = np.multiply(mask_y, mask_x)
+        # iterate multiple times if the given y/x_factor is too small, resulting in no overlap
+        num_iter = 1
+        mask_yx = np.zeros(self.lut_y.shape, dtype=np.bool_)
+        while np.sum(mask_yx) <= 0 and num_iter<=3:
+            # search overlap
+            ymin = y - y_factor;  ymax = y + y_factor
+            xmin = x - x_factor;  xmax = x + x_factor
+            if not geo_coord:
+                ymin = max(ymin, 0.5)
+                xmin = max(xmin, 0.5)
+            mask_y = np.multiply(self.lut_y >= ymin, self.lut_y <= ymax)
+            mask_x = np.multiply(self.lut_x >= xmin, self.lut_x <= xmax)
+            mask_yx = np.multiply(mask_y, mask_x)
+            # prepare for the next iteration
+            y_factor *= 2
+            x_factor *= 2
+            num_iter += 1
 
         # for debugging only
         if debug_mode:

--- a/src/mintpy/prep_aria.py
+++ b/src/mintpy/prep_aria.py
@@ -370,7 +370,6 @@ def write_ifgram_stack(outfile, stackFiles, box=None, xstep=1, ystep=1, mli_meth
             f["dropIfgram"][ii] = True
 
             # loop through stacks
-            print(stackFiles.keys())
             for dsName in stackFiles.keys():
                 dsStack = gdal.Open(stackFiles[dsName], gdal.GA_ReadOnly)
                 bnd = dsStack.GetRasterBand(bndIdx)
@@ -378,8 +377,6 @@ def write_ifgram_stack(outfile, stackFiles, box=None, xstep=1, ystep=1, mli_meth
                 if xstep * ystep > 1:
                     mli_method_spec = mli_method if dsName not in \
                         ['connCompStack'] else 'nearest'
-                    print(f'apply {xstep} x {ystep} multilooking/downsampling via '
-                          f'{mli_method_spec} to: {dsName}')
                     data = multilook_data(data, ystep, xstep, method=mli_method_spec)
                 data[data == noDataValues[dsName]] = 0  #assign pixel with no-data to 0
 

--- a/src/mintpy/tropo_pyaps3.py
+++ b/src/mintpy/tropo_pyaps3.py
@@ -421,7 +421,7 @@ def check_pyaps_account_config(tropo_model):
 
     # for ERA5: ~/.cdsapirc
     if tropo_model == 'ERA5' and os.path.isfile(rc_file):
-        fc = np.loadtxt('.cdsapirc', dtype=str)
+        fc = np.loadtxt(rc_file, dtype=str)
         if not (fc[0,0] == 'url:' and fc[0,1] == 'https://cds.climate.copernicus.eu/api'):
             raise ValueError('CDS account is NOT setup to the latest format! Check https://github.com/insarlab/PyAPS/.')
 


### PR DESCRIPTION
**Description of proposed changes**

+ `objects.coord.coordinate._get_lookup_row_col()`: if the given `y/x_factor` is too small, resulting in no overlap area, then iterate with larger `y/x_factor` values. This fixes the bug (#1369) introduced in #1238, which reduced the default y/x_factor from 10 to 4.

+ `tropo_pyaps3`: fix a bug introduced by #1364, which did not specify the full path to the `~/.netrc` file.

+ `prep_aria`: remove the redundant print out msg for a nicer print out msg.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/pipelines/github/yunjunz/MintPy/2922/workflows/e17c0a37-4256-4b27-b8f2-45ade93b6873/jobs/2929) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.