### PR TITLE
wrap-up for version 1.6.2

### DIFF
--- a/src/mintpy/cli/geocode.py
+++ b/src/mintpy/cli/geocode.py
@@ -22,7 +22,8 @@ EXAMPLE = """example:
   geocode.py velocity.h5 timeseries.h5 -t smallbaselineApp.cfg --outdir ./geo --update
 
   # geocode file using ISCE-2 lat/lon.rdr file
-  geocode.py filt_fine.int --lat-file ../../geom_reference/lat.rdr --lon-file ../../geom_reference/lon.rdr
+  multilook.py lat.rdr.full.vrt lon.rdr.full.vrt -x 9 -y 3
+  geocode.py filt_fine.int --lat-file lat.rdr --lon-file lon.rdr
 
   # radar-code file in geo coordinates
   geocode.py swbdLat_S02_N01_Lon_W092_W090.wbd -l geometryRadar.h5 -o waterMask.rdr --geo2radar

--- a/src/mintpy/save_kmz.py
+++ b/src/mintpy/save_kmz.py
@@ -480,7 +480,7 @@ def save_kmz(inps):
     inps.norm = colors.Normalize(vmin=inps.vlim[0], vmax=inps.vlim[1])
 
     # output filename
-    inps.fig_title = pp.auto_figure_title(inps.file, inps.dset, vars(inps))
+    inps.fig_title = pp.auto_figure_title(inps.file, inps.dset, vars(inps)).replace(' ', '')
     inps.outfile = inps.outfile if inps.outfile else f'{inps.fig_title}.kmz'
     inps.outfile = os.path.abspath(inps.outfile)
 

--- a/src/mintpy/unwrap_error_phase_closure.py
+++ b/src/mintpy/unwrap_error_phase_closure.py
@@ -165,15 +165,13 @@ def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None,
     if mask_file is not None:
         mask = readfile.read(mask_file)[0]
         num_nonzero_closure[mask == 0] = np.nan
-        num_nonzero_closure[np.isnan(mask)] = np.nan
-        print('mask out pixels with zero/nan in file:', mask_file)
+        print('mask out pixels with zero in file:', mask_file)
 
     coh_file = os.path.join(out_dir, 'avgSpatialCoh.h5')
     if os.path.isfile(coh_file):
         coh = readfile.read(coh_file)[0]
         num_nonzero_closure[coh == 0] = np.nan
-        num_nonzero_closure[np.isnan(coh)] = np.nan
-        print('mask out pixels with zero/nan in file:', coh_file)
+        print('mask out pixels with zero in file:', coh_file)
 
     num_nonzero_closure[num_nonzero_closure == C.shape[0]] = np.nan
     print('mask out invalid pixels (values == num of triplets)')

--- a/src/mintpy/unwrap_error_phase_closure.py
+++ b/src/mintpy/unwrap_error_phase_closure.py
@@ -165,13 +165,18 @@ def calc_num_triplet_with_nonzero_integer_ambiguity(ifgram_file, mask_file=None,
     if mask_file is not None:
         mask = readfile.read(mask_file)[0]
         num_nonzero_closure[mask == 0] = np.nan
-        print('mask out pixels with zero in file:', mask_file)
+        num_nonzero_closure[np.isnan(mask)] = np.nan
+        print('mask out pixels with zero/nan in file:', mask_file)
 
     coh_file = os.path.join(out_dir, 'avgSpatialCoh.h5')
     if os.path.isfile(coh_file):
         coh = readfile.read(coh_file)[0]
         num_nonzero_closure[coh == 0] = np.nan
-        print('mask out pixels with zero in file:', coh_file)
+        num_nonzero_closure[np.isnan(coh)] = np.nan
+        print('mask out pixels with zero/nan in file:', coh_file)
+
+    num_nonzero_closure[num_nonzero_closure == C.shape[0]] = np.nan
+    print('mask out invalid pixels (values == num of triplets)')
 
     # write to disk
     print('write to file', out_file)

--- a/src/mintpy/utils/isce_utils.py
+++ b/src/mintpy/utils/isce_utils.py
@@ -1275,6 +1275,8 @@ def unwrap_snaphu(int_file, cor_file, unw_file, max_defo=2.0, max_comp=32,
     atr['INTERLEAVE'] = 'BIL'
     atr['BANDS'] = '2'
     writefile.write_isce_xml(atr, unw_file)
+    if os.path.isfile(int_file+'.rsc'):
+        writefile.write_roipac_rsc(atr, unw_file+'.rsc', print_msg=True)
 
     if snp.dumpConnectedComponents:
         print(f'write metadata file: {unw_file}.conncomp.xml')
@@ -1283,6 +1285,8 @@ def unwrap_snaphu(int_file, cor_file, unw_file, max_defo=2.0, max_comp=32,
         atr['INTERLEAVE'] = 'BIP'
         atr['BANDS'] = '1'
         writefile.write_isce_xml(atr, f'{unw_file}.conncomp')
+        if os.path.isfile(int_file+'.rsc'):
+            writefile.write_roipac_rsc(atr, unw_file+'.conncomp.rsc', print_msg=True)
 
     # time usage
     m, s = divmod(time.time() - start_time, 60)

--- a/src/mintpy/version.py
+++ b/src/mintpy/version.py
@@ -14,6 +14,7 @@ from importlib.metadata import PackageNotFoundError, metadata
 ###########################################################################
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('1.6.2', '2025-07-07'),
     Tag('1.6.1', '2024-07-31'),
     Tag('1.6.0', '2024-05-09'),
     Tag('1.5.3', '2023-11-23'),


### PR DESCRIPTION
**Description of proposed changes**

+ `version`: add version tag for v1.6.2

+ `utils.isce_utils.unwrap_snaphu()`: create RSC file if input has one as well

+ `cli.geocode`: more usage example for isce2 files

+ `save_kmz`: remove whitespace while showing the figure title

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2959) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

## Summary by Sourcery

Prepare for v1.6.2 release by bumping version, preserving .rsc metadata in SNAPHU unwrapping, enhancing KMZ output formatting, and enriching geocode CLI examples.

Enhancements:
- Make unwrap_snaphu generate ROI-PAC .rsc files when the input .rsc exists
- Strip whitespace from autogenerated figure titles in save_kmz outputs

Build:
- Update project version tag to v1.6.2 in release history

Documentation:
- Add ISCE-2 .rdr usage examples to the geocode CLI help