### PR TITLE
fix progress bar reset giving ZeroDivisionError

### DIFF
--- a/src/mintpy/objects/progress.py
+++ b/src/mintpy/objects/progress.py
@@ -106,8 +106,12 @@ class progressBar:
 
         # Figure out the new percent done (round to an integer)
         diffFromMin = float(self.amount - self.min)
-        percentDone = (diffFromMin / float(self.span)) * 100.0
+        if self.span == 0:
+            percentDone = 100
+        else:
+            percentDone = (diffFromMin / float(self.span)) * 100.0
         percentDone = int(np.round(percentDone))
+        percentDone = max(0, min(100, percentDone))
 
         # Figure out how many hash bars the percentage should be
         allFull = self.width - 2 - 18


### PR DESCRIPTION
**Description of proposed changes**

Prevent `ZeroDivisionError` in `progressBar` when span is zero and clamp
percent values to the [0,100] range. This makes the progress bar more
robust and avoids showing negative or >100% values.

**Reminders**

- [ ] Fix #xxxx
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
