### PR TITLE
utils/plot: handle empty data in `auto_adjust_colormap_lut_and_disp_limit()`

### DIFF
--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -397,11 +397,10 @@ def auto_adjust_colormap_lut_and_disp_limit(data, num_multilook=1, max_discrete_
                 vlim                  - list(float), min/max value for display
                 unique_values         - np.ndarray, unique values of the given data
     """
-
+    # prevent empty input data
     finite_values = np.ma.masked_invalid(data).compressed()
     if finite_values.size == 0:
-        if print_msg:
-            print('WARNING: no finite pixels found; using neutral display limits.')
+        warnings.warn('NO pixel with finite value found!')
         return 256, [0.0, 0.0], None
 
     # max step size / min step number for a uniform colormap


### PR DESCRIPTION
**Description of proposed changes**

Fix `ValueError: zero-size array to reduction operation minimum` in
`auto_adjust_colormap_lut_and_disp_limit`.

- Handle the case where input data has no finite values.
- Return neutral display limits `[0.0, 0.0]` and `None` LUT when no valid pixels are found.
- Prevents crashes in `view.py` plotting when datasets are fully NaN/invalid.

**Reminders**

- [ ] Fix #xxxx
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Handle empty or fully invalid data in auto_adjust_colormap_lut_and_disp_limit by returning default neutral display limits and None LUT instead of crashing

Bug Fixes:
- Avoid ValueError from zero-size array reduction when no finite values are present

Enhancements:
- Warn when no valid pixels are found and return display limits [0.0, 0.0] with a None LUT