### PR TITLE
pyproject.toml: use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=77.0", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,12 +12,11 @@ authors = [
 requires-python = ">=3.8"
 
 keywords = ["InSAR", "deformation", "time-series", "volcano", "tectonics", "geodesy", "geophysics", "remote-sensing"]
-license = {text = "GPL-3.0-or-later"}
+license = "GPL-3.0-or-later"
 classifiers=[
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
**Description of proposed changes**

+ use a simple string containing a `SPDX` expression for `project.license`, which is available on setuptools>=77.0

+ removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/2995) (green)