### PR TITLE
`gnss`: support UNR solutions in IGS20 reference frame

### DIFF
--- a/src/mintpy/objects/gnss.py
+++ b/src/mintpy/objects/gnss.py
@@ -278,9 +278,6 @@ def get_los_obs(meta, obs_type, site_names, start_date, end_date, source='UNR', 
 
         # get url_prefix [to speed up downloading for ESESES]
         url_prefix = get_ESESES_url_prefix() if source == 'ESESES' else None
-        gnss_obj = get_gnss_class(source)(site_names[0], url_prefix=url_prefix)
-        vprint(f'GNSS source: {gnss_obj.source}')
-        vprint(f'GNSS reference frame: {gnss_obj.version}')
 
         # loop for calculation
         prog_bar = ptime.progressBar(maxValue=num_site, print_msg=print_msg)
@@ -826,7 +823,7 @@ class GNSS_UNR(GNSS):
             if version in ['IGS08', 'IGS14']:
                 self.url_prefix = f'https://geodesy.unr.edu/gps_timeseries/tenv3/{self.version}'
             if version == 'IGS20':
-                self.url_prefix = f'https://geodesy.unr.edu/gps_timeseries/IGS20/tenv3/IGS20'
+                self.url_prefix = 'https://geodesy.unr.edu/gps_timeseries/IGS20/tenv3/IGS20'
 
         self.url = os.path.join(self.url_prefix, os.path.basename(self.file))
 

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1160,10 +1160,11 @@ def plot_gnss(ax, SNWE, inps, metadata=dict(), print_msg=True):
         start_date=start_date,
         end_date=end_date,
         source=inps.gnss_source,
+        print_msg=print_msg,
     )
     if site_names.size == 0:
         warnings.warn(f'No GNSS found within {SNWE} during {start_date} - {end_date}!')
-        print('  continue without GNSS plots.')
+        vprint('  continue without GNSS plots.')
         return ax
 
     # print the nearest GNSS to the current reference point
@@ -1178,7 +1179,12 @@ def plot_gnss(ax, SNWE, inps, metadata=dict(), print_msg=True):
         n_ind = np.argmin(site_dist)
         msg = 'nearest GNSS site (potential --ref-gnss choice): '
         msg += f'{site_names[n_ind]} at [{site_lats[n_ind]}, {site_lons[n_ind]}]'
-        print(msg)
+        vprint(msg)
+
+    # print the GNSS solution reference frame
+    gnss_obj = gnss.get_gnss_class(inps.gnss_source)(site_names[0])
+    vprint(f'GNSS source: {gnss_obj.source}')
+    vprint(f'GNSS reference frame: {gnss_obj.version}')
 
     # post-query: convert lat/lon to UTM for plotting
     if 'UTM_ZONE' in metadata.keys():


### PR DESCRIPTION
Forward stream GNSS data from the UNR archive are now processed/uploaded as IGS20 version products.

Thus, this change must be reflected by changes to expected paths.

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [x] Fix #1432 
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Update GNSS UNR handling to use IGS20 as the default version and support IGS20-specific file and URL paths.

New Features:
- Support IGS20-format UNR GNSS products, including correct local filenames and remote URL patterns for data and plots.

Bug Fixes:
- Fix typo in the error message for unsupported GNSS versions.

Enhancements:
- Change default GNSS version from IGS14 to IGS20 for GNSS and GNSS_UNR classes.