### PR TITLE
sensor: add Fucheng-1 parameters

### DIFF
--- a/src/mintpy/objects/sensor.py
+++ b/src/mintpy/objects/sensor.py
@@ -480,7 +480,7 @@ SEN = {
 }
 
 # Fucheng-1
-# launch date: 2023-06
+# launch date: 2023-06-07
 # end    date: operational
 # Table 1 in Cai et al. (2025), https://doi.org/10.16356/j.1005‑1120.2025.04.005
 # Table 1-2 in Han et al. (2025), https://doi.org/10.1016/j.measurement.2025.116876


### PR DESCRIPTION
**Description of proposed changes**

Update support of Fucheng-1 data. Tested in GAMMA+Mintpy.
Despite the difficulty in obtaining data from this satellite, I believe it will be widely used in the future.

**Reminders**

- [x] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.

## Summary by Sourcery

Add initial support for the Fucheng-1 (FC1) SAR satellite in MintPy’s sensor definitions.

New Features:
- Recognize Fucheng-1/FC1 data via new sensor name aliases.
- Provide mission and instrument parameters for the Fucheng-1 satellite and register it in the mission configuration mapping.