### PR TITLE
readfile: support `float16` data type via gdal

### DIFF
--- a/src/mintpy/utils/readfile.py
+++ b/src/mintpy/utils/readfile.py
@@ -138,6 +138,7 @@ DATA_TYPE_GDAL2NUMPY = {
     12: 'uint64',
     13: 'int64',
     14: 'int8',         # GDAL >= 3.7
+    15: 'float16',      # GDAL >= 3.11
 }
 
 DATA_TYPE_NUMPY2GDAL = {
@@ -155,6 +156,7 @@ DATA_TYPE_NUMPY2GDAL = {
     "uint64"    : 12,   # GDT_UInt64 (GDAL >= 3.5)
     "int64"     : 13,   # GDT_Int64  (GDAL >= 3.5)
     "int8"      : 14,   # GDT_Int8   (GDAL >= 3.7)
+    "float16"   : 15,   # GDT_Float16 (GDAL >= 3.11)
 }
 
 # 3 - ISCE

--- a/src/mintpy/utils/writefile.py
+++ b/src/mintpy/utils/writefile.py
@@ -209,7 +209,8 @@ def write(datasetDict, out_file, metadata=None, ref_file=None, compression=None,
         elif fext == '.msk':
             meta['DATA_TYPE'] = 'int8'
 
-        data_types = ['bool', 'int8', 'uint8', 'int16', 'float32', 'float64', 'complex32', 'complex64', 'complex128']
+        data_types = ['bool', 'int8', 'uint8', 'int16', 'float16', 'float32',
+                      'float64', 'complex32', 'complex64', 'complex128']
         if meta['DATA_TYPE'] not in data_types:
             msg = 'Un-supported file type "{}" with data type "{}"!'.format(fext, meta['DATA_TYPE'])
             msg += f'\nSupported data type list: {data_types}'


### PR DESCRIPTION
For GDAL >= 3.11 you will run into `Key 15` error when trying to read float16 format files

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [X] Fix #1482
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Add support for GDAL float16 (GDT_Float16) datasets in readfile data type mappings.

New Features:
- Recognize GDAL data type key 15 as float16 in GDAL-to-NumPy data type mapping.
- Map NumPy float16 data type to GDAL key 15 in NumPy-to-GDAL data type mapping.