### PR TITLE
bugfix in subset.subset_input_dict2box()

### DIFF
--- a/src/mintpy/info.py
+++ b/src/mintpy/info.py
@@ -174,6 +174,11 @@ def print_aux_info(fname):
         print('file type: '+atr['FILE_TYPE'])
         if 'Y_FIRST' in atr.keys():
             print('coordinates : GEO')
+            n = float(atr['Y_FIRST'])
+            w = float(atr['X_FIRST'])
+            s = n + float(atr['Y_STEP']) * int(atr['LENGTH'])
+            e = w + float(atr['X_STEP']) * int(atr['WIDTH'])
+            print(f'SNWE: {s}, {n}, {w}, {e}.')
         else:
             print('coordinates : RADAR')
         if k in ['timeseries']:

--- a/src/mintpy/subset.py
+++ b/src/mintpy/subset.py
@@ -208,7 +208,7 @@ def subset_input_dict2box(subset_dict, meta_dict):
                 raise TypeError('Both --lat/lon are required for WGS84-UTM coordinates conversion.')
         else:
             # lat/lon --> y/x conversion
-            sub_x = coord.lalo2yx(None, subset_dict['subset_lon'])[0]
+            sub_x = coord.lalo2yx(None, subset_dict['subset_lon'])[1]
     elif subset_dict['subset_x']:
         sub_x = subset_dict['subset_x']
     else:


### PR DESCRIPTION
**Description of proposed changes**

Fix a bug introduced in #1464, while subsetting a file in WGS84 coordinate using `--lon` option.

**Reminders**

- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI test](https://app.circleci.com/jobs/github/yunjunz/MintPy/3114) (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.

## Summary by Sourcery

Fix longitude-based subsetting for WGS84 inputs and improve GEO file metadata reporting.

Bug Fixes:
- Correct longitude-to-x index conversion in WGS84 subsetting when using the --lon option.

Enhancements:
- Print derived SNWE geographic bounds for GEO-coordinate files in the auxiliary info output.