### PR TITLE
`plot_coherence_matrix`: split image and matrix windows

### DIFF
--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -9,7 +9,6 @@
 import os
 import sys
 
-from mintpy.utils import readfile
 from mintpy.utils.arg_utils import create_argument_parser
 
 ###########################  Sub Function  #############################
@@ -83,16 +82,10 @@ def cmd_line_parse(iargs=None):
 
     # default: auxiliary file paths (velocity and template)
     mintpy_dir = os.path.dirname(os.path.dirname(inps.ifgram_file))
-    atr = readfile.read_attribute(inps.ifgram_file)
-    is_geo = 'Y_FIRST' in atr
     if not inps.img_file:
         inps.img_file = os.path.join(mintpy_dir, 'velocity.h5')
-        if is_geo:
-            inps.img_file = os.path.join(mintpy_dir, 'geo', 'geo_velocity.h5')
     if not inps.tcoh_file:
         inps.tcoh_file = os.path.join(mintpy_dir, 'temporalCoherence.h5')
-        if is_geo:
-            inps.tcoh_file = os.path.join(mintpy_dir, 'geo', 'geo_temporalCoherence.h5')
     if not inps.template_file:
         inps.template_file = os.path.join(mintpy_dir, 'smallbaselineApp.cfg')
 

--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -9,8 +9,8 @@
 import os
 import sys
 
-from mintpy.utils.arg_utils import create_argument_parser
 from mintpy.utils import readfile
+from mintpy.utils.arg_utils import create_argument_parser
 
 ###########################  Sub Function  #############################
 EXAMPLE = """example:

--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mintpy.utils.arg_utils import create_argument_parser
+from mintpy.utils import readfile
 
 ###########################  Sub Function  #############################
 EXAMPLE = """example:
@@ -56,7 +57,7 @@ def create_parser(subparsers=None):
                              'Default: view.py img_file --wrap --noverbose')
 
     # aux files
-    parser.add_argument('--tcoh', dest='tcoh_file', default='temporalCoherence.h5',
+    parser.add_argument('--tcoh', dest='tcoh_file',
                         help='temporal coherence file.')
     parser.add_argument('-t','--template', dest='template_file',
                         help='temporal file.')
@@ -82,8 +83,16 @@ def cmd_line_parse(iargs=None):
 
     # default: auxiliary file paths (velocity and template)
     mintpy_dir = os.path.dirname(os.path.dirname(inps.ifgram_file))
+    atr = readfile.read_attribute(inps.ifgram_file)
+    is_geo = 'Y_FIRST' in atr
     if not inps.img_file:
         inps.img_file = os.path.join(mintpy_dir, 'velocity.h5')
+        if is_geo:
+            inps.img_file = os.path.join(mintpy_dir, 'geo', 'geo_velocity.h5')
+    if not inps.tcoh_file:
+        inps.tcoh_file = os.path.join(mintpy_dir, 'temporalCoherence.h5')
+        if is_geo:
+            inps.tcoh_file = os.path.join(mintpy_dir, 'geo', 'geo_temporalCoherence.h5')
     if not inps.template_file:
         inps.template_file = os.path.join(mintpy_dir, 'smallbaselineApp.cfg')
 
@@ -114,7 +123,7 @@ def main(iargs=None):
     obj = coherenceMatrixViewer(inps)
     obj.open()
     obj.plot()
-    #obj.fig.canvas.mpl_disconnect(obj.cid)
+    obj.fig_img.canvas.mpl_disconnect(obj.cid_img)
 
 
 ############################################################

--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -116,7 +116,7 @@ def main(iargs=None):
     obj = coherenceMatrixViewer(inps)
     obj.open()
     obj.plot()
-    obj.fig_img.canvas.mpl_disconnect(obj.cid_img)
+    #obj.fig_img.canvas.mpl_disconnect(obj.cid_img)
 
 
 ############################################################

--- a/src/mintpy/cli/plot_coherence_matrix.py
+++ b/src/mintpy/cli/plot_coherence_matrix.py
@@ -114,7 +114,7 @@ def main(iargs=None):
     obj = coherenceMatrixViewer(inps)
     obj.open()
     obj.plot()
-    obj.fig.canvas.mpl_disconnect(obj.cid)
+    #obj.fig.canvas.mpl_disconnect(obj.cid)
 
 
 ############################################################

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -62,10 +62,14 @@ class coherenceMatrixViewer():
 
     def __init__(self, inps):
         # figure variables
-        self.figname = 'Coherence matrix'
-        self.fig_size = None
-        self.fig = None
+        self.figname_img = 'Image'
+        self.figsize_img = None
+        self.fig_img = None
         self.ax_img = None
+
+        self.figname_mat = 'Coherence Matrix'
+        self.figsize_mat = None
+        self.fig_mat = None
         self.ax_mat = None
 
         # copy inps to self object
@@ -89,11 +93,20 @@ class coherenceMatrixViewer():
         self = read_network_info(self)
 
         # auto figure size
-        if not self.fig_size:
+        if not self.figsize_img:
             ds_shape = readfile.read(self.img_file)[0].shape
-            fig_size = pp.auto_figure_size(ds_shape, disp_cbar=True, scale=0.7)
-            self.fig_size = [fig_size[0]+fig_size[1], fig_size[1]]
-            vprint(f'create figure in size of {self.fig_size} inches')
+            self.figsize_img = pp.auto_figure_size(ds_shape, disp_cbar=True, scale=0.7)
+            vprint(f'create image figure in size of {self.figsize_img} inches')
+
+        if not self.figsize_mat:
+            num_ifg = len(self.date12_list)
+            if num_ifg <= 50:
+                self.figsize_mat = [6, 5]
+            elif num_ifg <= 100:
+                self.figsize_mat = [8, 6]
+            else:
+                self.figsize_mat = [10, 8]
+            vprint(f'create matrix figure in size of {self.figsize_mat} inches')
 
         # read aux data
         # 1. temporal coherence value
@@ -111,11 +124,26 @@ class coherenceMatrixViewer():
 
 
     def plot(self):
-        # Figure 1
-        self.fig = plt.figure(self.figname, figsize=self.fig_size)
+        # Figure 1 - Image
+        self.fig_img, self.ax_img = plt.subplots(num=self.figname_img, figsize=self.figsize_img)
+        self.plot_init_image()
 
-        # Axes 1 - Image
-        self.ax_img = self.fig.add_axes([0.05, 0.1, 0.4, 0.8])
+        # Figure 2 - Coherence Matrix
+        self.fig_mat, self.ax_mat = plt.subplots(num=self.figname_mat, figsize=self.figsize_mat)
+        self.colormap = pp.ColormapExt(self.cmap_name, vlist=self.cmap_vlist).colormap
+        if all(i is not None for i in self.yx):
+            self.plot_coherence_matrix4pixel(self.yx)
+
+        # Link the canvas to the plots.
+        self.cid_img = self.fig_img.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
+        self.cid_mat = self.fig_mat.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
+
+        if self.disp_fig:
+            plt.show()
+        return
+
+    def plot_init_image(self):
+        """Plot the initial image."""
         view_cmd = self.view_cmd.format(self.img_file)
         d_img, atr, view_inps = view.prep_slice(view_cmd)
         self.coord = ut.coordinate(atr)
@@ -137,16 +165,8 @@ class coherenceMatrixViewer():
         self.ax_img = view.plot_slice(self.ax_img, d_img, atr, view_inps)[0]
         self.fig_coord = view_inps.fig_coord
 
-        # Axes 2 - coherence matrix
-        self.ax_mat = self.fig.add_axes([0.55, 0.125, 0.40, 0.75])
-        self.colormap = pp.ColormapExt(self.cmap_name, vlist=self.cmap_vlist).colormap
-        if all(i is not None for i in self.yx):
-            self.plot_coherence_matrix4pixel(self.yx)
-
-        # Link the canvas to the plots.
-        self.cid = self.fig.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
-        if self.disp_fig:
-            plt.show()
+        self.fig_img.canvas.manager.set_window_title(self.figname_img)
+        self.fig_img.tight_layout()
         return
 
     def plot_coherence_matrix4pixel(self, yx):
@@ -203,12 +223,16 @@ class coherenceMatrixViewer():
             msg += f'temporal coherence: {tcoh:.2f}'
         vprint(msg)
 
+        self.fig_mat.canvas.manager.set_window_title(self.figname_mat)
+        self.fig_mat.tight_layout()
+
         # update figure
-        self.fig.canvas.draw_idle()
-        self.fig.canvas.flush_events()
+        self.fig_mat.canvas.draw_idle()
+        self.fig_mat.canvas.flush_events()
         return
 
     def update_coherence_matrix(self, event):
+        """Update coherence matrix when clicking on either window."""
         if event.inaxes == self.ax_img:
             if self.fig_coord == 'geo':
                 yx = self.coord.lalo2yx(event.ydata, event.xdata)
@@ -216,3 +240,16 @@ class coherenceMatrixViewer():
                 yx = [int(event.ydata+0.5),
                       int(event.xdata+0.5)]
             self.plot_coherence_matrix4pixel(yx)
+            self.update_image_marker(yx)
+
+        elif event.inaxes == self.ax_mat:
+            pass
+
+    def update_image_marker(self, yx):
+        """Update the marker point in the image window."""
+        for artist in self.ax_img.get_children():
+            if hasattr(artist, 'get_marker') and artist.get_marker() == '^':
+                artist.remove()
+
+        self.ax_img.plot(yx[1], yx[0], 'r^', markersize=10, markeredgecolor='black')
+        self.fig_img.canvas.draw_idle()

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -108,14 +108,8 @@ class coherenceMatrixViewer():
         # read aux data
         # 1. temporal coherence value
         self.tcoh = None
-        tcoh_file = getattr(self, 'tcoh_file', None)
-        if tcoh_file:
-            self.tcoh = readfile.read(tcoh_file)[0]
-            if self.tcoh.shape != self.ifgram_shape:
-                msg = f'WARNING: {tcoh_file} has shape {self.tcoh.shape}, '
-                msg += f'not matching ifgramStack shape {self.ifgram_shape}; ignore it.'
-                print(msg)
-                self.tcoh = None
+        if self.tcoh_file:
+            self.tcoh = readfile.read(self.tcoh_file)[0]
         # 2. minimum used coherence from template file
         self.min_coh_used = 0.0
         if self.template_file:
@@ -208,8 +202,8 @@ class coherenceMatrixViewer():
         # info
         msg = f'pixel in yx = {tuple(yx)}, '
         if self.fig_coord == 'geo':
-            lat, lon = self.coord.radar2geo(yx[0], yx[1])[0:2]
-            msg += f'lat/lon = ({lat}, {lon}), '
+            lat, lon = self.coord.yx2lalo(yx[0], yx[1])
+            msg += f'lat/lon = ({lat:.8f}, {lon:.8f}), '
         msg += f'min/max spatial coherence: {np.min(coh):.2f} / {np.max(coh):.2f}, '
         if self.tcoh is not None:
             msg += f'temporal coherence: {tcoh:.2f}'
@@ -227,21 +221,14 @@ class coherenceMatrixViewer():
         self.fig_mat.canvas.flush_events()
 
         # plot/update marker on the image window
-        xlim = self.ax_img.get_xlim()
-        ylim = self.ax_img.get_ylim()
-        if self.fig_coord == 'geo':
-            lat, lon = self.coord.radar2geo(yx[0], yx[1], print_msg=False)[0:2]
-            marker_x, marker_y = lon, lat
-        else:
-            marker_x, marker_y = yx[1], yx[0]
+        mx = lon if self.fig_coord == 'geo' else yx[1]
+        my = lat if self.fig_coord == 'geo' else yx[0]
         if self._marker_artist is None:
-            (self._marker_artist,) = self.ax_img.plot(
-                marker_x, marker_y, 'r^', markersize=6, markeredgecolor='black'
-            )
+            self._marker_artist = self.ax_img.plot(
+                mx, my, 'r^', markersize=6, markeredgecolor='black'
+            )[0]
         else:
-            self._marker_artist.set_data([marker_x], [marker_y])
-        self.ax_img.set_xlim(xlim)
-        self.ax_img.set_ylim(ylim)
+            self._marker_artist.set_data([mx], [my])
 
         self.fig_img.canvas.draw_idle()
 
@@ -255,8 +242,4 @@ class coherenceMatrixViewer():
             else:
                 yx = [int(event.ydata+0.5),
                       int(event.xdata+0.5)]
-            y, x = yx
-            if not (0 <= y < self.ifgram_shape[0] and 0 <= x < self.ifgram_shape[1]):
-                vprint(f'ignore point outside ifgramStack coverage: {yx}')
-                return
             self.plot_coherence_matrix4pixel(yx)

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -223,7 +223,11 @@ class coherenceMatrixViewer():
         vprint(msg)
 
         self.fig_mat.canvas.manager.set_window_title(self.figname_mat)
-        self.fig_mat.tight_layout()
+
+        # call tight_layout only once to avoid jitter and repeated work
+        if not hasattr(self, "_mat_tight_layout_done"):
+            self.fig_mat.tight_layout()
+            self._mat_tight_layout_done = True
 
         # update figure
         self.fig_mat.canvas.draw_idle()

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -28,6 +28,7 @@ def read_network_info(inps):
     date12_kept = obj.get_date12_list(dropIfgram=True)
     inps.ex_date12_list = sorted(list(set(inps.date12_list) - set(date12_kept)))
     inps.date_list = obj.get_date_list(dropIfgram=False)
+    inps.ifgram_shape = (int(obj.metadata['LENGTH']), int(obj.metadata['WIDTH']))
     vprint(f'number of all     interferograms: {len(inps.date12_list)}')
     vprint(f'number of dropped interferograms: {len(inps.ex_date12_list)}')
     vprint(f'number of kept    interferograms: {len(inps.date12_list) - len(inps.ex_date12_list)}')
@@ -109,6 +110,12 @@ class coherenceMatrixViewer():
         self.tcoh = None
         if self.tcoh_file:
             self.tcoh = readfile.read(self.tcoh_file)[0]
+            if self.tcoh.shape != self.ifgram_shape:
+                msg = f'WARNING: {self.tcoh_file} has shape {self.tcoh.shape}, '
+                msg += f'not matching ifgramStack shape {self.ifgram_shape}; ignore it.'
+                print(msg)
+                self.tcoh = None
+                self.tcoh_file = None
         # 2. minimum used coherence from template file
         self.min_coh_used = 0.0
         if self.template_file:
@@ -131,7 +138,7 @@ class coherenceMatrixViewer():
             self.plot_coherence_matrix4pixel(self.yx)
 
         # Link the canvas to the plots.
-        self.fig_img.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
+        self.cid_img = self.fig_img.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
 
         if self.disp_fig:
             plt.show()
@@ -171,7 +178,7 @@ class coherenceMatrixViewer():
         plotDict = {}
         plotDict['fig_title'] = f'Y = {yx[0]}, X = {yx[1]}'
         # display temporal coherence value of the pixel
-        if self.tcoh_file:
+        if self.tcoh is not None:
             tcoh = self.tcoh[yx[0], yx[1]]
             plotDict['fig_title'] += f', tcoh = {tcoh:.2f}'
         plotDict['colormap'] = self.colormap
@@ -204,7 +211,7 @@ class coherenceMatrixViewer():
             lat, lon = self.coord.radar2geo(yx[0], yx[1])[0:2]
             msg += f'lat/lon = ({lat}, {lon}), '
         msg += f'min/max spatial coherence: {np.min(coh):.2f} / {np.max(coh):.2f}, '
-        if self.tcoh_file:
+        if self.tcoh is not None:
             msg += f'temporal coherence: {tcoh:.2f}'
         vprint(msg)
 
@@ -220,12 +227,21 @@ class coherenceMatrixViewer():
         self.fig_mat.canvas.flush_events()
 
         # plot/update marker on the image window
+        xlim = self.ax_img.get_xlim()
+        ylim = self.ax_img.get_ylim()
+        if self.fig_coord == 'geo':
+            lat, lon = self.coord.radar2geo(yx[0], yx[1], print_msg=False)[0:2]
+            marker_x, marker_y = lon, lat
+        else:
+            marker_x, marker_y = yx[1], yx[0]
         if self._marker_artist is None:
             (self._marker_artist,) = self.ax_img.plot(
-                yx[1], yx[0], 'r^', markersize=6, markeredgecolor='black'
+                marker_x, marker_y, 'r^', markersize=6, markeredgecolor='black'
             )
         else:
-            self._marker_artist.set_data([yx[1]], [yx[0]])
+            self._marker_artist.set_data([marker_x], [marker_y])
+        self.ax_img.set_xlim(xlim)
+        self.ax_img.set_ylim(ylim)
 
         self.fig_img.canvas.draw_idle()
 
@@ -239,4 +255,8 @@ class coherenceMatrixViewer():
             else:
                 yx = [int(event.ydata+0.5),
                       int(event.xdata+0.5)]
+            y, x = yx
+            if not (0 <= y < self.ifgram_shape[0] and 0 <= x < self.ifgram_shape[1]):
+                vprint(f'ignore point outside ifgramStack coverage: {yx}')
+                return
             self.plot_coherence_matrix4pixel(yx)

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -135,8 +135,7 @@ class coherenceMatrixViewer():
             self.plot_coherence_matrix4pixel(self.yx)
 
         # Link the canvas to the plots.
-        self.cid_img = self.fig_img.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
-        self.cid_mat = self.fig_mat.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
+        self.fig_img.canvas.mpl_connect('button_press_event', self.update_coherence_matrix)
 
         if self.disp_fig:
             plt.show()
@@ -242,14 +241,13 @@ class coherenceMatrixViewer():
             self.plot_coherence_matrix4pixel(yx)
             self.update_image_marker(yx)
 
-        elif event.inaxes == self.ax_mat:
-            pass
 
     def update_image_marker(self, yx):
         """Update the marker point in the image window."""
+        # remove any existing marker
         for artist in self.ax_img.get_children():
             if hasattr(artist, 'get_marker') and artist.get_marker() == '^':
                 artist.remove()
-
+        # draw the new marker
         self.ax_img.plot(yx[1], yx[0], 'r^', markersize=10, markeredgecolor='black')
         self.fig_img.canvas.draw_idle()

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -108,14 +108,14 @@ class coherenceMatrixViewer():
         # read aux data
         # 1. temporal coherence value
         self.tcoh = None
-        if self.tcoh_file:
-            self.tcoh = readfile.read(self.tcoh_file)[0]
+        tcoh_file = getattr(self, 'tcoh_file', None)
+        if tcoh_file:
+            self.tcoh = readfile.read(tcoh_file)[0]
             if self.tcoh.shape != self.ifgram_shape:
-                msg = f'WARNING: {self.tcoh_file} has shape {self.tcoh.shape}, '
+                msg = f'WARNING: {tcoh_file} has shape {self.tcoh.shape}, '
                 msg += f'not matching ifgramStack shape {self.ifgram_shape}; ignore it.'
                 print(msg)
                 self.tcoh = None
-                self.tcoh_file = None
         # 2. minimum used coherence from template file
         self.min_coh_used = 0.0
         if self.template_file:

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -101,7 +101,6 @@ class coherenceMatrixViewer():
             vprint(f'create image figure in size of {self.figsize_img} inches')
 
         if not self.figsize_mat:
-            num_ifg = len(self.date12_list)
             self.figsize_mat = [8, 6]
             vprint(f'create matrix figure in size of {self.figsize_mat} inches')
 

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -1,7 +1,7 @@
 ############################################################
 # Program is part of MintPy                                #
 # Copyright (c) 2013, Zhang Yunjun, Heresh Fattahi         #
-# Author: Zhang Yunjun, Nov 2018                           #
+# Author: Zhang Yunjun, Changyang Hu, Nov 2018             #
 ############################################################
 
 
@@ -102,10 +102,7 @@ class coherenceMatrixViewer():
 
         if not self.figsize_mat:
             num_ifg = len(self.date12_list)
-            if num_ifg <= 50:
-                self.figsize_mat = [6, 5]
-            else:
-                self.figsize_mat = [8, 6]
+            self.figsize_mat = [8, 6]
             vprint(f'create matrix figure in size of {self.figsize_mat} inches')
 
         # read aux data
@@ -146,19 +143,6 @@ class coherenceMatrixViewer():
         view_cmd = self.view_cmd.format(self.img_file)
         d_img, atr, view_inps = view.prep_slice(view_cmd)
         self.coord = ut.coordinate(atr)
-
-        if all(i is not None for i in self.yx):
-            view_inps.pts_marker = 'r^'
-            view_inps.pts_yx = np.array(self.yx).reshape(-1, 2)
-
-            # point yx --> lalo for geocoded product
-            if 'Y_FIRST' in atr.keys():
-                view_inps.pts_lalo = np.array(
-                    self.coord.radar2geo(
-                        self.yx[0],
-                        self.yx[1],
-                    )[0:2],
-                ).reshape(-1,2)
 
         view_inps.print_msg = self.print_msg
         self.ax_img = view.plot_slice(self.ax_img, d_img, atr, view_inps)[0]
@@ -217,6 +201,9 @@ class coherenceMatrixViewer():
 
         # info
         msg = f'pixel in yx = {tuple(yx)}, '
+        if self.fig_coord == 'geo':
+            lat, lon = self.coord.radar2geo(yx[0], yx[1])[0:2]
+            msg += f'lat/lon = ({lat}, {lon}), '
         msg += f'min/max spatial coherence: {np.min(coh):.2f} / {np.max(coh):.2f}, '
         if self.tcoh_file:
             msg += f'temporal coherence: {tcoh:.2f}'
@@ -232,6 +219,17 @@ class coherenceMatrixViewer():
         # update figure
         self.fig_mat.canvas.draw_idle()
         self.fig_mat.canvas.flush_events()
+
+        # plot/update marker on the image window
+        if self._marker_artist is None:
+            (self._marker_artist,) = self.ax_img.plot(
+                yx[1], yx[0], 'r^', markersize=6, markeredgecolor='black'
+            )
+        else:
+            self._marker_artist.set_data([yx[1]], [yx[0]])
+
+        self.fig_img.canvas.draw_idle()
+
         return
 
     def update_coherence_matrix(self, event):
@@ -243,16 +241,3 @@ class coherenceMatrixViewer():
                 yx = [int(event.ydata+0.5),
                       int(event.xdata+0.5)]
             self.plot_coherence_matrix4pixel(yx)
-            self.update_image_marker(yx)
-
-
-    def update_image_marker(self, yx):
-        """Update the marker point in the image window."""
-        if self._marker_artist is None:
-            (self._marker_artist,) = self.ax_img.plot(
-                yx[1], yx[0], 'r^', markersize=10, markeredgecolor='black'
-            )
-        else:
-            self._marker_artist.set_data([yx[1]], [yx[0]])
-
-        self.fig_img.canvas.draw_idle()

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -28,7 +28,6 @@ def read_network_info(inps):
     date12_kept = obj.get_date12_list(dropIfgram=True)
     inps.ex_date12_list = sorted(list(set(inps.date12_list) - set(date12_kept)))
     inps.date_list = obj.get_date_list(dropIfgram=False)
-    inps.ifgram_shape = (int(obj.metadata['LENGTH']), int(obj.metadata['WIDTH']))
     vprint(f'number of all     interferograms: {len(inps.date12_list)}')
     vprint(f'number of dropped interferograms: {len(inps.ex_date12_list)}')
     vprint(f'number of kept    interferograms: {len(inps.date12_list) - len(inps.ex_date12_list)}')

--- a/src/mintpy/plot_coherence_matrix.py
+++ b/src/mintpy/plot_coherence_matrix.py
@@ -76,6 +76,8 @@ class coherenceMatrixViewer():
         for key, value in inps.__dict__.items():
             setattr(self, key, value)
 
+        self._marker_artist = None
+
 
     def open(self):
         global vprint
@@ -102,10 +104,8 @@ class coherenceMatrixViewer():
             num_ifg = len(self.date12_list)
             if num_ifg <= 50:
                 self.figsize_mat = [6, 5]
-            elif num_ifg <= 100:
-                self.figsize_mat = [8, 6]
             else:
-                self.figsize_mat = [10, 8]
+                self.figsize_mat = [8, 6]
             vprint(f'create matrix figure in size of {self.figsize_mat} inches')
 
         # read aux data
@@ -248,10 +248,11 @@ class coherenceMatrixViewer():
 
     def update_image_marker(self, yx):
         """Update the marker point in the image window."""
-        # remove any existing marker
-        for artist in self.ax_img.get_children():
-            if hasattr(artist, 'get_marker') and artist.get_marker() == '^':
-                artist.remove()
-        # draw the new marker
-        self.ax_img.plot(yx[1], yx[0], 'r^', markersize=10, markeredgecolor='black')
+        if self._marker_artist is None:
+            (self._marker_artist,) = self.ax_img.plot(
+                yx[1], yx[0], 'r^', markersize=10, markeredgecolor='black'
+            )
+        else:
+            self._marker_artist.set_data([yx[1]], [yx[0]])
+
         self.fig_img.canvas.draw_idle()

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -947,7 +947,7 @@ def plot_coherence_matrix(ax, date12List, cohList, date12List_drop=[], p_dict={}
     if p_dict['disp_cbar']:
         divider = make_axes_locatable(ax)
         cax = divider.append_axes("right", "3%", pad="3%")
-        cbar = plt.colorbar(im, cax=cax)
+        cbar = ax.figure.colorbar(im, cax=cax)
         cbar.set_label(p_dict['cbar_label'], fontsize=p_dict['fontsize'])
 
     # Legend


### PR DESCRIPTION
**Description of proposed changes**

This PR separates the interactive coherence matrix viewer into two matplotlib windows: one for the reference image/map and one for the coherence matrix.

<img width="1474" height="1010" alt="image" src="https://github.com/user-attachments/assets/50a2862c-3afa-4125-bda5-56c8c814604a" />

The previous layout placed both views in a single figure, which made the coherence matrix small for large interferogram networks. With this change, clicking a pixel in the image window still updates the coherence matrix, while the selected pixel marker is refreshed in the image window.

This PR does not change the coherence matrix calculation or add new plotting modes. It only reorganizes the interactive viewer layout to make the matrix easier to inspect.

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Split the coherence matrix viewer into separate image and matrix windows to improve matrix visibility while preserving interactive pixel selection.

New Features:
- Display the reference image and coherence matrix in two independent matplotlib windows linked by interactive pixel selection.

Enhancements:
- Adjust figure sizing logic to choose appropriate dimensions for the coherence matrix window based on network size.
- Ensure the selected pixel marker in the image view is refreshed when coherence matrix updates, improving visual feedback during interaction.