### PR TITLE
fix matplotlib `Figure already exist` error while running view in parallel via smallbaselineApp

### DIFF
--- a/src/mintpy/smallbaselineApp.py
+++ b/src/mintpy/smallbaselineApp.py
@@ -1106,7 +1106,10 @@ class TimeSeriesAnalysis:
         import mintpy.cli.view
         if run_parallel and num_cores > 1:
             print(f"parallel processing using {num_cores} cores ...")
-            Parallel(n_jobs=num_cores)(delayed(mintpy.cli.view.main)(iargs) for iargs in iargs_list)
+            Parallel(n_jobs=num_cores, backend='multiprocessing')(
+                delayed(mintpy.cli.view.main)(iargs)
+                for iargs in iargs_list
+            )
         else:
             for iargs in iargs_list:
                 mintpy.cli.view.main(iargs)

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -10,13 +10,13 @@
 import datetime as dt
 import os
 import re
-import warnings  # suppress UserWarning from matplotlib
+import warnings
 
 warnings.filterwarnings("ignore", category=UserWarning, module="matplotlib")
-
-import cartopy.crs as ccrs
-import matplotlib.pyplot as plt
+import matplotlib;  matplotlib.use('Agg')
 import numpy as np
+from cartopy import crs as ccrs
+from matplotlib import pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from mintpy import subset, version
@@ -1365,7 +1365,7 @@ def plot_figure(j, inps, metadata):
 
     # Open a new figure object
     fig, axs = plt.subplots(
-        num=j, figsize=inps.fig_size,
+        figsize=inps.fig_size,
         nrows=inps.fig_row_num,
         ncols=inps.fig_col_num,
         sharex=True, sharey=True,
@@ -1461,8 +1461,8 @@ def plot_figure(j, inps, metadata):
     if inps.save_fig:
         vprint(f'save figure to {os.path.abspath(inps.outfile[j-1])} with dpi={inps.fig_dpi}')
         fig.savefig(inps.outfile[j-1], bbox_inches='tight', transparent=True, dpi=inps.fig_dpi)
-        if not inps.disp_fig:
-            fig.clf()
+    if not inps.disp_fig:
+        plt.close(fig)
     return
 
 
@@ -1580,8 +1580,8 @@ class viewer():
         vprint = print if inps.print_msg else lambda *args, **kwargs: None
 
         # matplotlib backend setting
-        if not inps.disp_fig:
-            plt.switch_backend('Agg')
+        if inps.disp_fig:
+            plt.switch_backend('TkAgg')
 
         inps, self.atr = read_input_file_info(inps)
         inps = update_inps_with_file_metadata(inps, self.atr)
@@ -1690,8 +1690,8 @@ class viewer():
                     fig.savefig(self.outfile[0], transparent=True, dpi=self.fig_dpi, pad_inches=0.0)
                 else:
                     fig.savefig(self.outfile[0], transparent=True, dpi=self.fig_dpi, bbox_inches='tight')
-                if not self.disp_fig:
-                    fig.clf()
+            if not self.disp_fig:
+                plt.close(fig)
 
         # Multiple Subplots
         else:


### PR DESCRIPTION
**Description of proposed changes**

Fix the following error while calling view.py in paralle at the end of smallbaselineApp.py, as shown in https://app.circleci.com/pipelines/github/insarlab/MintPy/2546/workflows/b8a6111c-4972-4297-ae62-257f6ea45822/jobs/2621

```bash
view.py --dpi 150 --noverbose --nodisplay --update --memory 2.0 inputs/ifgramStack.h5 unwrapPhase- --zero-mask
joblib.externals.loky.process_executor._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/root/tools/miniforge/lib/python3.13/site-packages/joblib/externals/loky/process_executor.py", line 490, in _process_worker
    r = call_item()
  File "/root/tools/miniforge/lib/python3.13/site-packages/joblib/externals/loky/process_executor.py", line 291, in __call__
    return self.fn(*self.args, **self.kwargs)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/tools/miniforge/lib/python3.13/site-packages/joblib/parallel.py", line 607, in __call__
    return [func(*args, **kwargs) for func, args, kwargs in self.items]
            ~~~~^^^^^^^^^^^^^^^^^
  File "/root/tools/miniforge/lib/python3.13/site-packages/mintpy/cli/view.py", line 186, in main
    obj.plot()
    ~~~~~~~~^^
  File "/root/tools/miniforge/lib/python3.13/site-packages/mintpy/view.py", line 1711, in plot
    plot_figure(j, self, metadata=self.atr)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/tools/miniforge/lib/python3.13/site-packages/mintpy/view.py", line 1367, in plot_figure
    fig, axs = plt.subplots(
               ~~~~~~~~~~~~^
        num=j, figsize=inps.fig_size,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        sharex=True, sharey=True,
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/root/tools/miniforge/lib/python3.13/site-packages/matplotlib/pyplot.py", line 1884, in subplots
    _raise_if_figure_exists(fig_kw.get('num'), "subplots", fig_kw.get('clear'))
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/tools/miniforge/lib/python3.13/site-packages/matplotlib/pyplot.py", line 1199, in _raise_if_figure_exists
    raise ValueError(
    ...<2 lines>...
        f"Alternatively, pass 'clear=True' to {func_name}().")
ValueError: Figure 1 already exists. Use plt.figure(1) to get it or plt.close(1) to close it. Alternatively, pass 'clear=True' to subplots().
"""
```

+ view.py:
   - set matplotlib.use('Agg') BEFORE importing pyplot, and switch backend in `viewer.configure()`.
   - properly close fig object
   - do NOT specify the `num` while calling subplots(), to avoid potential conflicts between parallel processes of view.py calls

+ smallbaselineApp.plot_results(): use `multiprocessing` backend while calling joblib.Parallel()

**Reminders**

- [ ] Fix #xxxx
- [x] Pass Pre-commit check (green)
- [x] Pass Codacy code review (green)
- [x] Pass [Circle CI](https://app.circleci.com/jobs/github/yunjunz/MintPy/3131) test (green)
- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

## Summary by Sourcery

Resolve parallel plotting errors in smallbaselineApp by adjusting view backend usage, figure handling, and joblib configuration.

Bug Fixes:
- Prevent matplotlib 'Figure already exists' errors when running view.py in parallel via smallbaselineApp.

Enhancements:
- Set a non-interactive matplotlib backend by default in view.py and switch to an interactive backend only when displaying figures.
- Ensure figures are properly closed after saving to avoid resource leaks and cross-process conflicts.
- Use the multiprocessing backend for joblib.Parallel in smallbaselineApp plot_result to improve parallel robustness.