### PR TITLE
`plot.scale_data2disp_unit`: fix time-unit scaling in month/day

### DIFF
--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1852,8 +1852,8 @@ def scale_data2disp_unit(data=None, metadata=dict(), disp_unit=None):
     if len(data_unit) == 2:
         try:
             if   disp_unit[1] in ['y','yr','year'  ]: disp_unit[1] = 'year'
-            elif disp_unit[1] in ['m','mon','month']: disp_unit[1] = 'mon'; scale *= 12.0
-            elif disp_unit[1] in ['d','day'        ]: disp_unit[1] = 'day'; scale *= 365.25
+            elif disp_unit[1] in ['m','mon','month']: disp_unit[1] = 'mon'; scale /= 12.0
+            elif disp_unit[1] in ['d','day'        ]: disp_unit[1] = 'day'; scale /= 365.25
             else: print('Unrecognized time unit for display:', disp_unit[1])
         except:
             disp_unit.append('year')


### PR DESCRIPTION
## Summary
- Fix inverted time-unit conversion in `scale_data2disp_unit()` (`src/mintpy/utils/plot.py`): rates stored as `m/year` should be **divided** (not multiplied) when displaying as `/month` or `/day`.
- `view.py ... --unit cm/month` previously inflated values by an extra ×12 after the cm conversion (×144 overall vs correct `cm/month`). The same bug applied to `/day` with ×365.25.

## Example
For a velocity file with data range about `[-1232, 1000] cm/year`:
- before: `--unit cm/month` → about `[-14785, 12002] cm/mon` (×12)
- after: `--unit cm/month` → about `[-103, 83] cm/mon` (/12)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect scaling of year-based rates when converting display units to per-month and per-day in scale_data2disp_unit(), preventing inflated values in view outputs.