### PR TITLE
support --lalo-label for UTM-geocoded products in view.py

### DIFF
--- a/src/mintpy/utils/map.py
+++ b/src/mintpy/utils/map.py
@@ -67,6 +67,57 @@ def draw_lalo_label(ax, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1], lalo_max
     return ax
 
 
+def draw_utm_lalo_label(ax, meta, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1],
+                        lalo_max_num=4, lalo_offset=None, font_size=None, print_msg=True):
+    """Draw lat/lon tick labels on a regular matplotlib axes for UTM-geocoded data.
+
+    Data/extent stay in UTM meters. Tick positions are UTM coordinates of lat/lon
+    lines through the plot center; tick labels are formatted as lat/lon.
+    """
+    from mintpy.utils import utils as ut
+
+    W, N, E, S = geo_box
+    lats, lons = ut.utm2latlon(meta, [W, E, E, W], [N, N, S, S])
+    lalo_box = (min(lons), max(lats), max(lons), min(lats))
+    if print_msg:
+        print(f'convert UTM box {geo_box} to lat/lon box {lalo_box} for --lalo-label')
+
+    lats_t, lons_t, lalo_step, digit = auto_lalo_sequence(
+        lalo_box, lalo_step=lalo_step, lalo_max_num=lalo_max_num)
+    if print_msg:
+        print(f'plot lat/lon label in step of {lalo_step} and location of {lalo_loc}')
+
+    mid_lat = 0.5 * (lalo_box[1] + lalo_box[3])
+    mid_lon = 0.5 * (lalo_box[0] + lalo_box[2])
+    # latlon2utm returns (northing, easting)
+    xticks = [ut.latlon2utm(meta, mid_lat, lon)[1] for lon in lons_t]
+    yticks = [ut.latlon2utm(meta, lat, mid_lon)[0] for lat in lats_t]
+
+    dec_digit = max(0, 0 - digit)
+    lon_fmt = f'{{:.{dec_digit}f}}'
+    lat_fmt = f'{{:.{dec_digit}f}}'
+
+    def _lon_label(lon):
+        return f'{lon_fmt.format(abs(lon))}°{"E" if lon >= 0 else "W"}'
+
+    def _lat_label(lat):
+        return f'{lat_fmt.format(abs(lat))}°{"N" if lat >= 0 else "S"}'
+
+    ax.tick_params(which='both', direction='in', labelsize=font_size,
+                   left=True, right=True, top=True, bottom=True,
+                   labelleft=bool(lalo_loc[0]), labelright=bool(lalo_loc[1]),
+                   labeltop=bool(lalo_loc[2]), labelbottom=bool(lalo_loc[3]))
+    if lalo_offset:
+        ax.tick_params(axis='x', which='major', pad=lalo_offset[1])
+        ax.tick_params(axis='y', which='major', pad=lalo_offset[0])
+
+    ax.set_xticks(xticks)
+    ax.set_xticklabels([_lon_label(lon) for lon in lons_t], fontsize=font_size)
+    ax.set_yticks(yticks)
+    ax.set_yticklabels([_lat_label(lat) for lat in lats_t], fontsize=font_size)
+    return ax
+
+
 def auto_lalo_sequence(geo_box, lalo_step=None, lalo_max_num=4, step_candidate=[1, 2, 3, 4, 5]):
     """Auto calculate lat/lon label sequence based on input geo_box
     Parameters: geo_box        : 4-tuple of float, defining UL_lon, UL_lat, LR_lon, LR_lat coordinate

--- a/src/mintpy/utils/map.py
+++ b/src/mintpy/utils/map.py
@@ -74,11 +74,11 @@ def draw_utm_lalo_label(ax, meta, geo_box, lalo_step=None, lalo_loc=[1, 0, 0, 1]
     Data/extent stay in UTM meters. Tick positions are UTM coordinates of lat/lon
     lines through the plot center; tick labels are formatted as lat/lon.
     """
-    from mintpy.utils import utils as ut
+    from mintpy.utils import utils0 as ut
 
     W, N, E, S = geo_box
     lats, lons = ut.utm2latlon(meta, [W, E, E, W], [N, N, S, S])
-    lalo_box = (min(lons), max(lats), max(lons), min(lats))
+    lalo_box = (min(lons), max(lats), max(lons), min(lats))   # W, N, E, S
     if print_msg:
         print(f'convert UTM box {geo_box} to lat/lon box {lalo_box} for --lalo-label')
 

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -23,7 +23,7 @@ from mintpy.objects import TIMESERIES_DSET_NAMES, TIMESERIES_KEY_NAMES
 from mintpy.objects.colors import ColormapExt
 from mintpy.objects.coord import coordinate
 from mintpy.utils import network as pnet, ptime, readfile, utils0 as ut0
-from mintpy.utils.map import draw_lalo_label, draw_scalebar
+from mintpy.utils.map import draw_lalo_label, draw_scalebar, draw_utm_lalo_label
 
 min_figsize_single = 6.0       # default min size in inch, for single plot
 max_figsize_single = 10.0      # default min size in inch, for single plot

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -210,12 +210,15 @@ def check_map_projection(inps, metadata, print_msg=True):
         elif inps.coord_unit.startswith('meter'):
             if 'UTM_ZONE' in metadata.keys():
                 utm_zone = metadata['UTM_ZONE']
-                inps.map_proj_obj = ccrs.UTM(utm_zone)
-                print(msg + f'UTM zone {utm_zone}')
-
-                # check --lalo-label (works for PlateCarree only)
+                # --lalo-label: keep regular axes and label ticks as lat/lon (see draw_utm_lalo_label)
                 if inps.lalo_label:
-                    raise ValueError('--lalo-label is NOT supported for projection: UTM')
+                    print(f'UTM zone {utm_zone}: draw --lalo-label on regular axes')
+                else:
+                    # --coastline only: cartopy needs zone number, not "14N"
+                    zone_num = int(str(utm_zone)[:-1])
+                    southern = str(utm_zone)[-1].upper() == 'S'
+                    inps.map_proj_obj = ccrs.UTM(zone_num, southern_hemisphere=southern)
+                    print(msg + f'UTM zone {utm_zone}')
 
             else:
                 print(f'WARNING: Un-recognized coordinate unit: {inps.coord_unit}')
@@ -604,16 +607,30 @@ def plot_slice(ax, data, metadata, inps):
 
         # Lat Lon labels
         if inps.lalo_label:
-            pp.draw_lalo_label(
-                ax=ax,
-                geo_box=inps.geo_box,
-                lalo_step=inps.lalo_step,
-                lalo_loc=inps.lalo_loc,
-                lalo_max_num=inps.lalo_max_num,
-                lalo_offset=inps.lalo_offset,
-                font_size=inps.lalo_font_size if inps.lalo_font_size else inps.font_size,
-                projection=inps.map_proj_obj,
-                print_msg=inps.print_msg)
+            if (inps.coord_unit.startswith('meter')
+                    and 'UTM_ZONE' in metadata.keys()):
+                pp.draw_utm_lalo_label(
+                    ax=ax,
+                    meta=metadata,
+                    geo_box=inps.geo_box,
+                    lalo_step=inps.lalo_step,
+                    lalo_loc=inps.lalo_loc,
+                    lalo_max_num=inps.lalo_max_num,
+                    lalo_offset=inps.lalo_offset,
+                    font_size=inps.lalo_font_size if inps.lalo_font_size else inps.font_size,
+                    print_msg=inps.print_msg,
+                )
+            else:
+                pp.draw_lalo_label(
+                    ax=ax,
+                    geo_box=inps.geo_box,
+                    lalo_step=inps.lalo_step,
+                    lalo_loc=inps.lalo_loc,
+                    lalo_max_num=inps.lalo_max_num,
+                    lalo_offset=inps.lalo_offset,
+                    font_size=inps.lalo_font_size if inps.lalo_font_size else inps.font_size,
+                    projection=inps.map_proj_obj,
+                    print_msg=inps.print_msg)
         else:
             ax.tick_params(which='both', direction='in', labelsize=inps.font_size,
                            left=True, right=True, top=True, bottom=True)

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -214,10 +214,7 @@ def check_map_projection(inps, metadata, print_msg=True):
                 if inps.lalo_label:
                     print(f'UTM zone {utm_zone}: draw --lalo-label on regular axes')
                 else:
-                    # --coastline only: cartopy needs zone number, not "14N"
-                    zone_num = int(str(utm_zone)[:-1])
-                    southern = str(utm_zone)[-1].upper() == 'S'
-                    inps.map_proj_obj = ccrs.UTM(zone_num, southern_hemisphere=southern)
+                    inps.map_proj_obj = ccrs.UTM(utm_zone)
                     print(msg + f'UTM zone {utm_zone}')
 
             else:


### PR DESCRIPTION
## Summary
- Enable `view.py --lalo-label` for UTM-geocoded files (e.g. NISAR GUNW).
- Keep the image in UTM on regular matplotlib axes; only convert tick positions/labels to lat/lon (no raster reprojection).

## Approach
Previously UTM + `--lalo-label` raised:
`ValueError: --lalo-label is NOT supported for projection: UTM`

Now:
1. Skip cartopy for UTM + `--lalo-label`
2. Plot with UTM easting/northing as before
3. Use `draw_utm_lalo_label()` to place ticks at UTM coords of lat/lon lines and label them as `101°W` / `19°N`

## Test plan
- [ ] UTM file: `view.py velocity.h5 velocity --lalo-label` → lat/lon tick labels
- [ ] Lat/lon geo file + `--lalo-label` unchanged
- [ ] UTM file without `--lalo-label` unchanged

## Summary by Sourcery

Support lat/lon tick labeling on UTM-geocoded maps without reprojecting raster data.

New Features:
- Add draw_utm_lalo_label to render latitude/longitude tick labels for UTM-geocoded products on regular matplotlib axes.

Enhancements:
- Update view.py map projection handling so --lalo-label skips Cartopy UTM projection and keeps plots in native UTM coordinates.
- Route UTM datasets with --lalo-label through the new UTM-specific labeling helper while preserving existing behavior for lat/lon and non-lalo-label cases.